### PR TITLE
Documentation; Pretty output

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,41 +25,47 @@ pip install -e git+https://github.com/tqdm/tqdm.git#egg=master
 ## Documentation
 
 ```python
-def tqdm(iterable, desc='', total=None,
-         leave=False, file=sys.stderr,
-         mininterval=0.5, miniters=1):
-    """Get an iterable object, and return an iterator which acts exactly like
-    the iterable, but prints a progress meter and updates it every time a
-    value is requested.
-
+def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
+         ncols=None, mininterval=0.1, miniters=1):
+    """
+    Decorate an iterable object, returning an iterator which acts exactly
+    like the orignal iterable, but prints a dynamically updating
+    progressbar.
+    
     Parameters
     ----------
-    iterable: iterable
-        Iterable to show progress for.
-    desc: str, optional
-        A short string, describing the progress, that is added in the beginning
-        of the line.
-    total : int, optional
-        The number of expected iterations. If not given, len(iterable) is used
-        if it is defined.
-    file : `io.TextIOWrapper` or `io.StringIO`, optional
-        A file-like object to output the progress message to. By default,
-        sys.stderr is used.
-    leave : bool, optional
-        If it is False (default), tqdm deletes its traces from screen after
-        it has finished iterating over all elements.
-    mininterval : float, optional
-        If less than mininterval seconds have passed since the last progress
-        meter update, it is not updated again (default: 0.5).
-    miniters : float, optional
-        If less than miniters iterations have passed since the last progress
-        meter update, it is not updated again (default: 1).
-
+    iterable  : iterable
+        Iterable to decorate with a progressbar.
+    desc  : str, optional
+        Prefix for the progressbar.
+    total  : int, optional
+        The number of expected iterations. If not given, len(iterable) is
+        used if possible. As a last resort, only basic progress statistics
+        are displayed.
+    file  : `io.TextIOWrapper` or `io.StringIO`, optional
+        Specifies where to output the progress messages.
+    leave  : bool, optional
+        if unset, removes all traces of the progressbar upon termination of
+        iteration [default: False].
+    ncols  : int, optional
+        The width of the entire output message. If sepcified, dynamically
+        resizes the progress meter [default: None]. The fallback meter
+        width is 10.
+    mininterval  : float, optional
+        Minimum progress update interval, in seconds [default: 0.5].
+    miniters  : int, optional
+        Minimum progress update interval, in iterations [default: 1].
+    
+    Returns
+    -------
+    out  : decorated iterator.
     """
 
 def trange(*args, **kwargs):
-    """A shortcut for writing tqdm(xrange)"""
-    return tqdm(xrange(*args), **kwargs)
+    """
+    A shortcut for tqdm(xrange(*args), **kwargs).
+    On Python3+ range is used instead of xrange.
+    """
 ```
 
 ## Contributions
@@ -83,3 +89,10 @@ $ make coverage
 ## Authors
 
 - noamraph (original author)
+- JackMc
+- arkottke
+- obiwanus
+- fordhurley
+- kmike
+- hadim
+- casperdcl

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -39,17 +39,21 @@ def format_meter(n, total, elapsed):
     if total:
         frac = float(n) / total
 
-        N_BARS = 10
-        bar_length = int(frac*N_BARS)
-        bar = '#'*bar_length + '-'*(N_BARS-bar_length)
+        N_BARS = 32
+        bar_length = int(frac * N_BARS)
+        frac_bar_length = int((frac * N_BARS * 8) % 8)
+        
+        bar = u'\u2588'*bar_length + \
+                (unichr(0x2590-frac_bar_length) if frac_bar_length else ' ')\
+                + ' '*max(N_BARS-bar_length-1,0)
 
         left_str = format_interval(elapsed * (total-n) / n) if n else '?'
 
-        return '|{0}| {1}/{2} {3:3.0f}% [elapsed: {4} left: {5}, {6} iters/sec]'.format(
+        return u'{3:3.0f}%|{0}| {1}/{2} [{4}<{5}, {6} it/s]'.format(
             bar, n, total, frac * 100, elapsed_str, left_str, rate)
 
     else:
-        return '{0:d} [elapsed: {1}, {2} iters/sec]'.format(n, elapsed_str, rate)
+        return '{0:d} [{1}, {2} it/s]'.format(n, elapsed_str, rate)
 
 
 class StatusPrinter(object):

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1,9 +1,19 @@
-from __future__ import division, absolute_import
+"""
+Customisable progressbar decorator for iterators.
+Includes a default (x)range iterator printing to stderr.
 
+Usage:
+  from tqdm import trange[, tqdm]
+  for i in trange(10):
+    ...
+"""
+from __future__ import division, absolute_import
 import sys
 import time
 
 
+__author__ = {"github.com/" : ["noamraph", "JackMc", "arkottke", "obiwanus",
+        "fordhurley", "kmike", "hadim", "casperdcl"]}
 __all__ = ['tqdm', 'trange', 'format_interval', 'format_meter']
 
 
@@ -11,9 +21,9 @@ def format_interval(t):
     mins, s = divmod(int(t), 60)
     h, m = divmod(mins, 60)
     if h:
-        return '%d:%02d:%02d' % (h, m, s)
+        return '{0:d}:{1:02d}:{2:02d}'.format(h, m, s)
     else:
-        return '%02d:%02d' % (m, s)
+        return '{0:02d}:{1:02d}'.format(m, s)
 
 
 def format_meter(n, total, elapsed):
@@ -24,7 +34,7 @@ def format_meter(n, total, elapsed):
         total = None
 
     elapsed_str = format_interval(elapsed)
-    rate = '%5.2f' % (n / elapsed) if elapsed else '?'
+    rate = '{0:5.2f}'.format(n / elapsed) if elapsed else '?'
 
     if total:
         frac = float(n) / total
@@ -33,15 +43,13 @@ def format_meter(n, total, elapsed):
         bar_length = int(frac*N_BARS)
         bar = '#'*bar_length + '-'*(N_BARS-bar_length)
 
-        percentage = '%3d%%' % (frac * 100)
+        left_str = format_interval(elapsed * (total-n) / n) if n else '?'
 
-        left_str = format_interval(elapsed / n * (total-n)) if n else '?'
-
-        return '|%s| %d/%d %s [elapsed: %s left: %s, %s iters/sec]' % (
-            bar, n, total, percentage, elapsed_str, left_str, rate)
+        return '|{0}| {1}/{2} {3:3.0f}% [elapsed: {4} left: {5}, {6} iters/sec]'.format(
+            bar, n, total, frac * 100, elapsed_str, left_str, rate)
 
     else:
-        return '%d [elapsed: %s, %s iters/sec]' % (n, elapsed_str, rate)
+        return '{0:d} [elapsed: {1}, {2} iters/sec]'.format(n, elapsed_str, rate)
 
 
 class StatusPrinter(object):
@@ -55,36 +63,36 @@ class StatusPrinter(object):
         self.last_printed_len = len(s)
 
 
-def tqdm(iterable, desc='', total=None,
-         leave=False, file=sys.stderr,
+def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
          mininterval=0.5, miniters=1):
-    """Get an iterable object, and return an iterator which acts exactly like
-    the iterable, but prints a progress meter and updates it every time a
-    value is requested.
-
+    """
+    Decorate an iterable object, returning an iterator which acts exactly
+    like the orignal iterable, but prints a dynamically updating
+    progressbar.
+    
     Parameters
     ----------
-    iterable: iterable
-        Iterable to show progress for.
-    desc: str, optional
-        A short string, describing the progress, that is added in the beginning
-        of the line.
-    total : int, optional
-        The number of expected iterations. If not given, len(iterable) is used
-        if it is defined.
-    file : `io.TextIOWrapper` or `io.StringIO`, optional
-        A file-like object to output the progress message to. By default,
-        sys.stderr is used.
-    leave : bool, optional
-        If it is False (default), tqdm deletes its traces from screen after
-        it has finished iterating over all elements.
-    mininterval : float, optional
-        If less than mininterval seconds have passed since the last progress
-        meter update, it is not updated again (default: 0.5).
-    miniters : float, optional
-        If less than miniters iterations have passed since the last progress
-        meter update, it is not updated again (default: 1).
-
+    iterable  : iterable
+        Iterable to decorate with a progressbar.
+    desc  : str, optional
+        Prefix for the progressbar.
+    total  : int, optional
+        The number of expected iterations. If not given, len(iterable) is
+        used if possible. As a last resort, only basic progress statistics
+        are displayed.
+    file  : `io.TextIOWrapper` or `io.StringIO`, optional
+        Specifies where to output the progress messages.
+    leave  : bool, optional
+        if unset, removes all traces of the progressbar upon termination of
+        iteration [default: False].
+    mininterval  : float, optional
+        Minimum progress update interval, in seconds [default: 0.5].
+    miniters  : int, optional
+        Minimum progress update interval, in iterations [default: 1].
+    
+    Returns
+    -------
+    out  : decorated iterator.
     """
     if total is None:
         try:
@@ -123,7 +131,10 @@ def tqdm(iterable, desc='', total=None,
 
 
 def trange(*args, **kwargs):
-    """A shortcut for writing tqdm(range()) on py3 or tqdm(xrange()) on py2"""
+    """
+    A shortcut for tqdm(xrange(*args), **kwargs).
+    On Python3+ range is used instead of xrange.
+    """
     try:
         f = xrange
     except NameError:

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -43,9 +43,11 @@ def format_meter(n, total, elapsed):
         bar_length = int(frac * N_BARS)
         frac_bar_length = int((frac * N_BARS * 8) % 8)
         
-        bar = u'\u2588'*bar_length + \
-                (unichr(0x2590-frac_bar_length) if frac_bar_length else ' ')\
-                + ' '*max(N_BARS-bar_length-1,0)
+        bar = u'\u2588'*bar_length
+        if bar_length < N_BARS:
+            bar = bar \
+                  +(unichr(0x2590-frac_bar_length) if frac_bar_length else ' ')\
+                  + ' '*max(N_BARS - bar_length - 1, 0)
 
         left_str = format_interval(elapsed * (total-n) / n) if n else '?'
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -12,8 +12,8 @@ import sys
 import time
 
 
-__author__ = {"github.com/" : ["noamraph", "JackMc", "arkottke", "obiwanus",
-        "fordhurley", "kmike", "hadim", "casperdcl"]}
+__author__ = {"github.com/": ["noamraph", "JackMc", "arkottke", "obiwanus",
+                              "fordhurley", "kmike", "hadim", "casperdcl"]}
 __all__ = ['tqdm', 'trange', 'format_interval', 'format_meter']
 
 
@@ -53,8 +53,10 @@ def format_meter(n, total, elapsed, ncols=None, prefix=''):
         bar_length = int(frac * N_BARS)
         frac_bar_length = int((frac * N_BARS * 8) % 8)
 
-        try: unich = unichr
-        except: unich = chr
+        try:
+            unich = unichr
+        except:
+            unich = chr
 
         bar = unich(0x2588)*bar_length
         frac_bar = unich(0x2590 - frac_bar_length) if frac_bar_length else ' '
@@ -85,7 +87,7 @@ def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
     Decorate an iterable object, returning an iterator which acts exactly
     like the orignal iterable, but prints a dynamically updating
     progressbar.
-    
+
     Parameters
     ----------
     iterable  : iterable
@@ -109,7 +111,7 @@ def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
         Minimum progress update interval, in seconds [default: 0.5].
     miniters  : int, optional
         Minimum progress update interval, in iterations [default: 1].
-    
+
     Returns
     -------
     out  : decorated iterator.
@@ -137,7 +139,7 @@ def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
             cur_t = time.time()
             if cur_t - last_print_t >= mininterval:
                 sp.print_status(format_meter(
-                        n, total, cur_t-start_t, ncols, prefix))
+                    n, total, cur_t-start_t, ncols, prefix))
                 last_print_n = n
                 last_print_t = cur_t
 
@@ -147,7 +149,8 @@ def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
     else:
         if last_print_n < n:
             cur_t = time.time()
-            sp.print_status(format_meter(n, total, cur_t-start_t, ncols, prefix))
+            sp.print_status(format_meter(
+                n, total, cur_t-start_t, ncols, prefix))
         file.write('\n')
 
 

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -20,13 +20,15 @@ def test_format_interval():
 
 
 def test_format_meter():
-    try: unich = unichr
-    except: unich = chr
+    try:
+        unich = unichr
+    except:
+        unich = chr
 
     assert format_meter(0, 1000, 13) == \
         "  0%|          | 0/1000 [00:13<?,  0.00 it/s]"
-    assert format_meter(0, 1000, 13, ncols=70, prefix='desc: ') == \
-        "desc: 0%|                               | 0/1000 [00:13<?,  0.00 it/s]"
+    assert format_meter(0, 1000, 13, ncols=68, prefix='desc: ') == \
+        "desc: 0%|                             | 0/1000 [00:13<?,  0.00 it/s]"
     assert format_meter(231, 1000, 392) == \
         " 23%|" + unich(0x2588)*2 + unich(0x258e) + \
         "       | 231/1000 [06:32<21:44,  0.59 it/s]"

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -21,13 +21,12 @@ def test_format_interval():
 
 def test_format_meter():
     assert format_meter(0, 1000, 13) == \
-        "|----------| 0/1000   0% [elapsed: " \
-        "00:13 left: ?,  0.00 iters/sec]"
+        "  0%|                                | 0/1000 [00:13<?,  0.00 it/s]"
     assert format_meter(231, 1000, 392) == \
-        "|##--------| 231/1000  23% [elapsed: " \
-        "06:32 left: 21:44,  0.59 iters/sec]"
+        u" 23%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d" \
+        "                        | 231/1000 [06:32<21:44,  0.59 it/s]"
     assert format_meter(10000, 1000, 13) == \
-        "10000 [elapsed: 00:13, 769.23 iters/sec]"
+        "10000 [00:13, 769.23 it/s]"
 
 
 def test_nothing_fails():
@@ -68,14 +67,14 @@ def test_leave_option():
     for i in tqdm(range(3), file=our_file, leave=True):
         pass
     our_file.seek(0)
-    assert '3/3 100%' in our_file.read()
+    assert '| 3/3 ' in our_file.read()
     our_file.close()
 
     our_file2 = StringIO()
     for i in tqdm(range(3), file=our_file2, leave=False):
         pass
     our_file2.seek(0)
-    assert '3/3 100%' not in our_file2.read()
+    assert '| 3/3 ' not in our_file2.read()
     our_file2.close()
 
 
@@ -84,14 +83,14 @@ def test_trange():
     for i in trange(3, file=our_file, leave=True):
         pass
     our_file.seek(0)
-    assert '3/3 100%' in our_file.read()
+    assert '| 3/3 ' in our_file.read()
     our_file.close()
 
     our_file2 = StringIO()
     for i in trange(3, file=our_file2, leave=False):
         pass
     our_file2.seek(0)
-    assert '3/3 100%' not in our_file2.read()
+    assert '| 3/3 ' not in our_file2.read()
     our_file2.close()
 
 
@@ -100,4 +99,4 @@ def test_min_interval():
     for i in tqdm(range(3), file=our_file, mininterval=1e-10):
         pass
     our_file.seek(0)
-    assert "|----------| 0/3   0% [elapsed: 00:00 left" in our_file.read()
+    assert "  0%|                                | 0/3 [00:00<" in our_file.read()

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -20,13 +20,21 @@ def test_format_interval():
 
 
 def test_format_meter():
+    try: unich = unichr
+    except: unich = chr
+
     assert format_meter(0, 1000, 13) == \
-        "  0%|                                | 0/1000 [00:13<?,  0.00 it/s]"
+        "  0%|          | 0/1000 [00:13<?,  0.00 it/s]"
+    assert format_meter(0, 1000, 13, ncols=70, prefix='desc: ') == \
+        "desc: 0%|                               | 0/1000 [00:13<?,  0.00 it/s]"
     assert format_meter(231, 1000, 392) == \
-        u" 23%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d" \
-        "                        | 231/1000 [06:32<21:44,  0.59 it/s]"
+        " 23%|" + unich(0x2588)*2 + unich(0x258e) + \
+        "       | 231/1000 [06:32<21:44,  0.59 it/s]"
     assert format_meter(10000, 1000, 13) == \
         "10000 [00:13, 769.23 it/s]"
+    assert format_meter(231, 1000, 392, ncols=56) == \
+        " 23%|" + unich(0x2588)*3 + unich(0x258d) + \
+        "           | 231/1000 [06:32<21:44,  0.59 it/s]"
 
 
 def test_nothing_fails():
@@ -99,4 +107,4 @@ def test_min_interval():
     for i in tqdm(range(3), file=our_file, mininterval=1e-10):
         pass
     our_file.seek(0)
-    assert "  0%|                                | 0/3 [00:00<" in our_file.read()
+    assert "  0%|          | 0/3 [00:00<" in our_file.read()


### PR DESCRIPTION
- new-style string formatting (makes tweaking positions of details easier)
- bigger bar to fill 78-column wide terminals
- unicode chars (most terminals support these)
    - fractional full blocks for sub-character progress
- docstrings <75 chars so `import tqdm; help(tqdm)` formats with proper linebreaks
- updated tests to reflect changes