### PR TITLE
Add unit and unit_scale arguments + tqdm is now a class to allow manual update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ pip install -e git+https://github.com/tqdm/tqdm.git#egg=master
 ## Documentation
 
 ```python
-def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
-         ncols=None, mininterval=0.1, miniters=None, ascii=None, disable=False):
+class tqdm:
+
+    def __init__(self, iterable=None, desc=None, total=None, leave=False, file=sys.stderr,
+         ncols=None, mininterval=0.1, miniters=None, unit=None, unit_scale=False,
+         ascii=None, disable=False):
     """
     Decorate an iterable object, returning an iterator which acts exactly
     like the orignal iterable, but prints a dynamically updating
@@ -42,7 +45,8 @@ def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
     Parameters
     ----------
     iterable  : iterable
-        Iterable to decorate with a progressbar.
+        Iterable to decorate with a progressbar. You can leave
+        it to None if you want to manually manage the updates.
     desc  : str, optional
         Prefix for the progressbar.
     total  : int, optional
@@ -56,13 +60,21 @@ def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
         if unset, removes all traces of the progressbar upon termination of
         iteration [default: False].
     ncols  : int, optional
-        The width of the entire output message. If sepcified, dynamically
-        resizes the progress meter [default: None]. The fallback meter
-        width is 10.
+        The width of the entire output message. If specified, dynamically
+        resizes the progress meter to stay within this bound [default: None].
+        The fallback meter width is 10 for the progress bar + no limit for
+        the iterations counter and statistics.
     mininterval  : float, optional
         Minimum progress update interval, in seconds [default: 0.1].
     miniters  : int, optional
         Minimum progress update interval, in iterations [default: None].
+    unit  : str, optional
+        String that will be used to define the unit of each iteration.
+        [default: "it"]
+    unit_scale  : str, optional
+        If set, the number of iterations will be reduced/scaled automatically
+        and a metric prefix following the International System of Units standard
+        will be added (kilo, mega, etc.).
     ascii  : bool, optional
         If not set, use unicode (▏▎▋█ █) to fill the meter
         [default: False]. The fallback is to use ASCII characters (1-9 #).
@@ -71,8 +83,23 @@ def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
 
     Returns
     -------
-    out  : decorated iterator.
+    out  : decorated iterator or just a progressbar manager.
     """
+
+    def update(self, n=1):
+        """
+        Manually update the progress bar, useful for streams such as reading files (set init(total=filesize) and then in the reading loop, use update(len(current_buffer)) )
+
+        Parameters
+        ----------
+        n  : int
+            Increment to add to the internal counter of iterations.
+        """
+
+    def close(self):
+        """
+        Call this method to force print the last progress bar update based on the latest n value
+        """
 
 def trange(*args, **kwargs):
     """

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ class tqdm:
     unit  : str, optional
         String that will be used to define the unit of each iteration.
         [default: "it"]
-    unit_scale  : str, optional
+    unit_scale  : bool, optional
         If set, the number of iterations will be reduced/scaled automatically
         and a metric prefix following the International System of Units standard
-        will be added (kilo, mega, etc.).
+        will be added (kilo, mega, etc.). [default: False]
     ascii  : bool, optional
         If not set, use unicode (▏▎▋█ █) to fill the meter
         [default: False]. The fallback is to use ASCII characters (1-9 #).

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -7,7 +7,10 @@ Usage:
   for i in trange(10):
     ...
 """
-from __future__ import division, absolute_import # future division is important to divide integers and get as a result precise floating numbers (instead of truncated int)
+# future division is important to divide integers and get as
+# a result precise floating numbers (instead of truncated int)
+from __future__ import division, absolute_import
+# import compatibility functions and utilities
 from ._utils import _supports_unicode, _environ_cols, _range, _unich
 import sys
 import time
@@ -16,6 +19,7 @@ import time
 __author__ = {"github.com/": ["noamraph", "JackMc", "arkottke", "obiwanus",
                               "fordhurley", "kmike", "hadim", "casperdcl"]}
 __all__ = ['tqdm', 'trange', 'format_interval', 'format_meter']
+
 
 def format_sizeof(num, suffix='bytes'):
     """
@@ -37,8 +41,8 @@ def format_interval(t):
         return '{0:02d}:{1:02d}'.format(m, s)
 
 
-def format_meter(n, total, elapsed, ncols=None, prefix='', \
-     unit=None, unit_scale=False, ascii=False):
+def format_meter(n, total, elapsed, ncols=None, prefix='',
+                          unit=None, unit_scale=False, ascii=False):
     """
     Return a string-based progress bar given some parameters
 
@@ -74,8 +78,9 @@ def format_meter(n, total, elapsed, ncols=None, prefix='', \
     out  : Formatted meter and stats, ready to display.
     """
 
-    # in case the total is wrong (n is above the total), then we switch to the mode without showing
-    # the total prediction (since ETA would be wrong anyway)
+    # in case the total is wrong (n is above the total), then
+    # we switch to the mode without showing the total prediction
+    # (since ETA would be wrong anyway)
     if total and n > total:
         total = None
 
@@ -89,35 +94,40 @@ def format_meter(n, total, elapsed, ncols=None, prefix='', \
         rate = '?'
 
     rate_unit = unit if unit else 'it'
-    if not unit: unit = ''
+    if not unit:
+        unit = ''
 
     n_fmt = str(n)
     total_fmt = str(total)
     if unit_scale:
         n_fmt = format_sizeof(n, suffix='')
-        if total: total_fmt = format_sizeof(total, suffix='')
+        if total:
+            total_fmt = format_sizeof(total, suffix='')
 
     if total:
         frac = n / total
         percentage = frac * 100
-        
+
         remaining_str = format_interval(elapsed * (total-n) / n) if n else '?'
 
         l_bar = '{1}{0:.0f}%|'.format(percentage, prefix) if prefix else \
                 '{0:3.0f}%|'.format(percentage)
-        r_bar = '| {0}/{1}{2} [{3}<{4}, {5} {6}/s]'.format(
-                n_fmt, total_fmt, unit, elapsed_str, remaining_str, rate, rate_unit)
+        r_bar = '| {0}/{1}{2} [{3}<{4}, {5} {6}/s]'.format( \
+                n_fmt, total_fmt, unit, elapsed_str, remaining_str, \
+                rate, rate_unit)
 
         if ncols == 0:
             bar = ''
         else:
-            N_BARS = max(1, ncols - len(l_bar) - len(r_bar)) if ncols else 10
+            N_BARS = max(1, ncols - len(l_bar) - len(r_bar)) if ncols \
+                             else 10
 
             if ascii:
                 bar_length, frac_bar_length = divmod(int(frac * N_BARS * 10), 10)
 
                 bar = '#'*bar_length
-                frac_bar = chr(48 + frac_bar_length) if frac_bar_length else ' '
+                frac_bar = chr(48 + frac_bar_length) if frac_bar_length \
+                                else ' '
 
             else:
                 bar_length, frac_bar_length = divmod(int(frac * N_BARS * 8), 8)
@@ -128,21 +138,23 @@ def format_meter(n, total, elapsed, ncols=None, prefix='', \
 
         if bar_length < N_BARS:
             full_bar = bar + frac_bar + \
-                ' ' * max(N_BARS - bar_length - 1, 0) # spacing
+                ' ' * max(N_BARS - bar_length - 1, 0)  # spacing
         else:
             full_bar = bar + \
-            ' ' * max(N_BARS - bar_length, 0) # spacing
+                ' ' * max(N_BARS - bar_length, 0)  # spacing
 
         return l_bar + full_bar + r_bar
 
-    else: # no progressbar nor ETA, just progress statistics (number of iterations spent, time spent)
-        return '{0}{1} [{2}, {3} {4}/s]'.format(n_fmt, unit, elapsed_str, rate, rate_unit)
+    else: # no progressbar nor ETA, just progress statistics
+        return '{0}{1} [{2}, {3} {4}/s]'.format( \
+            n_fmt, unit, elapsed_str, rate, rate_unit)
 
 
 class StatusPrinter(object):
     """
     Manage the printing and in-place updating of a line of characters.
-    Note that if the string is longer than a line, then in-place updating may not work (it will print a new line at each refresh).
+    Note that if the string is longer than a line, then in-place updating
+    may not work (it will print a new line at each refresh).
     """
     def __init__(self, file):
         self.file = file
@@ -206,9 +218,9 @@ class tqdm(object):
     out  : decorated iterator.
     """
 
-    def __init__(self, iterable=None, desc=None, total=None, leave=False, file=sys.stderr,
-         ncols=None, mininterval=0.1, miniters=None, unit=None, unit_scale=False,
-         ascii=None, disable=False):
+    def __init__(self, iterable=None, desc=None, total=None, leave=False,
+                      file=sys.stderr, ncols=None, mininterval=0.1, miniters=None,
+                      unit=None, unit_scale=False, ascii=None, disable=False):
 
         # Preprocess the arguments
         if total is None and iterable is not None:
@@ -246,7 +258,9 @@ class tqdm(object):
 
         # Initialize the screen printer
         self.sp = StatusPrinter(self.file)
-        if not disable: self.sp.print_status(format_meter(0, total, 0, ncols, self.prefix, unit, unit_scale, ascii))
+        if not disable:
+            self.sp.print_status(format_meter(
+                0, total, 0, ncols, self.prefix, unit, unit_scale, ascii))
 
         # Init the time/iterations counters
         self.start_t = self.last_print_t = time.time()
@@ -255,19 +269,27 @@ class tqdm(object):
 
     def __iter__(self):
         ''' For backward-compatibility to use: for x in tqdm(iterable) '''
-        if self.disable: # if the bar is disabled, then just walk the iterable (note that we keep this condition above the loop for performance, so that we don't have to repeatedly check the condition inside the loop)
+        # if the bar is disabled, then just walk the iterable
+        # (note that we keep this condition above the loop for performance,
+        # so that we don't have to repeatedly check the condition inside
+        # the loop)
+        if self.disable:
             for obj in self.iterable:
                 yield obj
         else:
             for obj in self.iterable:
                 yield obj
-                # Now the object was created and processed, so we can print the meter.
+                # Now that the iterable object was created and processed,
+                # we can print the progress meter.
                 self.update(1)
             self.close()
 
     def update(self, n=1):
         """
-        Manually update the progress bar, useful for streams such as reading files (set init(total=filesize) and then in the reading loop, use update(len(current_buffer)) )
+        Manually update the progress bar, useful for streams
+        such as reading files.
+        Eg, initialize tqdm(total=filesize), and then in the reading loop,
+        use update(len(current_buffer)).
 
         Parameters
         ----------
@@ -278,26 +300,33 @@ class tqdm(object):
             n = 1
         self.n += n
 
-        if self.disable: return
+        if self.disable:
+            return
 
         delta_it = self.n - self.last_print_n
         if delta_it >= self.miniters:
             # We check the counter first, to reduce the overhead of time.time()
             cur_t = time.time()
             if cur_t - self.last_print_t >= self.mininterval:
-                self.sp.print_status(format_meter(self.n, self.total, cur_t-self.start_t, self.ncols, self.prefix, self.unit, self.unit_scale, self.ascii))
-                if self.dynamic_miniters: self.miniters = max(self.miniters, delta_it)
+                self.sp.print_status(format_meter(
+                    self.n, self.total, cur_t-self.start_t, self.ncols,
+                    self.prefix, self.unit, self.unit_scale, self.ascii))
+                if self.dynamic_miniters:
+                    self.miniters = max(self.miniters, delta_it)
                 self.last_print_n = self.n
                 self.last_print_t = cur_t
 
     def close(self):
         """
-        Call this method to force print the last progress bar update based on the latest n value
+        Call this method to force print the last progress bar update
+        based on the latest n value
         """
         if self.leave:
             if self.last_print_n < self.n:
                 cur_t = time.time()
-                self.sp.print_status(format_meter(self.n, self.total, cur_t-self.start_t, self.ncols, self.prefix, self.unit, self.unit_scale, self.ascii))
+                self.sp.print_status(format_meter(
+                    self.n, self.total, cur_t-self.start_t, self.ncols,
+                    self.prefix, self.unit, self.unit_scale, self.ascii))
             self.file.write('\n')
         else:
             self.sp.print_status('')

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -42,7 +42,7 @@ def format_interval(t):
 
 
 def format_meter(n, total, elapsed, ncols=None, prefix='',
-                          unit=None, unit_scale=False, ascii=False):
+         unit=None, unit_scale=False, ascii=False):
     """
     Return a string-based progress bar given some parameters
 
@@ -112,8 +112,8 @@ def format_meter(n, total, elapsed, ncols=None, prefix='',
 
         l_bar = '{1}{0:.0f}%|'.format(percentage, prefix) if prefix else \
                 '{0:3.0f}%|'.format(percentage)
-        r_bar = '| {0}/{1}{2} [{3}<{4}, {5} {6}/s]'.format( \
-                n_fmt, total_fmt, unit, elapsed_str, remaining_str, \
+        r_bar = '| {0}/{1}{2} [{3}<{4}, {5} {6}/s]'.format(
+                n_fmt, total_fmt, unit, elapsed_str, remaining_str,
                 rate, rate_unit)
 
         if ncols == 0:
@@ -123,7 +123,8 @@ def format_meter(n, total, elapsed, ncols=None, prefix='',
                              else 10
 
             if ascii:
-                bar_length, frac_bar_length = divmod(int(frac * N_BARS * 10), 10)
+                bar_length, frac_bar_length = divmod(
+                    int(frac * N_BARS * 10), 10)
 
                 bar = '#'*bar_length
                 frac_bar = chr(48 + frac_bar_length) if frac_bar_length \
@@ -145,8 +146,8 @@ def format_meter(n, total, elapsed, ncols=None, prefix='',
 
         return l_bar + full_bar + r_bar
 
-    else: # no progressbar nor ETA, just progress statistics
-        return '{0}{1} [{2}, {3} {4}/s]'.format( \
+    else:  # no progressbar nor ETA, just progress statistics
+        return '{0}{1} [{2}, {3} {4}/s]'.format(
             n_fmt, unit, elapsed_str, rate, rate_unit)
 
 
@@ -219,8 +220,9 @@ class tqdm(object):
     """
 
     def __init__(self, iterable=None, desc=None, total=None, leave=False,
-                      file=sys.stderr, ncols=None, mininterval=0.1, miniters=None,
-                      unit=None, unit_scale=False, ascii=None, disable=False):
+                      file=sys.stderr, ncols=None, mininterval=0.1,
+                      miniters=None, unit=None, unit_scale=False, ascii=None,
+                      disable=False):
 
         # Preprocess the arguments
         if total is None and iterable is not None:

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -58,10 +58,10 @@ def format_meter(n, total, elapsed, ncols=None, prefix='', unit=None, unit_scale
     unit  : str, optional
         String that will be used to define the unit of each iteration.
         [default: "it"]
-    unit_scale  : str, optional
+    unit_scale  : bool, optional
         If set, the number of iterations will be reduced/scaled automatically
         and a metric prefix following the International System of Units standard
-        will be added (kilo, mega, etc.).
+        will be added (kilo, mega, etc.). [default: False]
     ascii  : bool, optional
         If not set, use unicode (smooth blocks) to fill the meter
         [default: False]. The fallback is to use ASCII characters (1-9 #).
@@ -183,10 +183,10 @@ class tqdm(object):
     unit  : str, optional
         String that will be used to define the unit of each iteration.
         [default: "it"]
-    unit_scale  : str, optional
+    unit_scale  : bool, optional
         If set, the number of iterations will be reduced/scaled automatically
         and a metric prefix following the International System of Units standard
-        will be added (kilo, mega, etc.).
+        will be added (kilo, mega, etc.). [default: False]
     ascii  : bool, optional
         If not set, use unicode (smooth blocks) to fill the meter
         [default: False]. The fallback is to use ASCII characters (1-9 #).

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -149,9 +149,10 @@ class StatusPrinter(object):
         self.last_printed_len = 0
 
     def print_status(self, s):
-        self.file.write('\r'+s+' '*max(self.last_printed_len-len(s), 0))
+        len_s = len(s)
+        self.file.write('\r'+s+' '*max(self.last_printed_len-len_s, 0))
         self.file.flush()
-        self.last_printed_len = len(s)
+        self.last_printed_len = len_s
 
 
 class tqdm(object):

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -23,9 +23,9 @@ def format_sizeof(num, suffix='bytes'):
     """
     for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
         if abs(num) < 1000.0:
-            return "%3.1f%s%s" % (num, unit, suffix)
+            return '{0:3.1f}{1}{2}'.format(num, unit, suffix)
         num /= 1000.0
-    return "%.1f%s%s" % (num, 'Y', suffix)
+    return '{0:.1f}Y{1}'.format(num, suffix)
 
 
 def format_interval(t):
@@ -117,7 +117,7 @@ def format_meter(n, total, elapsed, ncols=None, prefix='', \
                 bar_length, frac_bar_length = divmod(int(frac * N_BARS * 10), 10)
 
                 bar = '#'*bar_length
-                frac_bar = chr(48 + frac_bar_length) if frac_bar_length else '0'
+                frac_bar = chr(48 + frac_bar_length) if frac_bar_length else ' '
 
             else:
                 bar_length, frac_bar_length = divmod(int(frac * N_BARS * 8), 8)
@@ -128,15 +128,15 @@ def format_meter(n, total, elapsed, ncols=None, prefix='', \
 
         if bar_length < N_BARS:
             full_bar = bar + frac_bar + \
-                '-' * max(N_BARS - bar_length - 1, 0) # spacing
+                ' ' * max(N_BARS - bar_length - 1, 0) # spacing
         else:
             full_bar = bar + \
-            '-' * max(N_BARS - bar_length, 0) # spacing
+            ' ' * max(N_BARS - bar_length, 0) # spacing
 
-        return "%s%s%s" % (l_bar,  full_bar, r_bar)
+        return l_bar + full_bar + r_bar
 
-    else:
-        return '{0:d}{1} [{2}, {3} {4}/s]'.format(n_fmt, unit, elapsed_str, rate, rate_unit)
+    else: # no progressbar nor ETA, just progress statistics (number of iterations spent, time spent)
+        return '{0}{1} [{2}, {3} {4}/s]'.format(n_fmt, unit, elapsed_str, rate, rate_unit)
 
 
 class StatusPrinter(object):
@@ -150,7 +150,7 @@ class StatusPrinter(object):
 
     def print_status(self, s):
         len_s = len(s)
-        self.file.write('\r'+s+' '*max(self.last_printed_len-len_s, 0))
+        self.file.write('\r'+s+' '*max(self.last_printed_len - len_s, 0))
         self.file.flush()
         self.last_printed_len = len_s
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -21,11 +21,12 @@ def format_sizeof(num, suffix='bytes'):
     """
     Readable size format, courtesy of Sridhar Ratnakumar
     """
-    for unit in ['','K','M','G','T','P','E','Z']:
+    for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
         if abs(num) < 1000.0:
             return "%3.1f%s%s" % (num, unit, suffix)
         num /= 1000.0
     return "%.1f%s%s" % (num, 'Y', suffix)
+
 
 def format_interval(t):
     mins, s = divmod(int(t), 60)
@@ -36,7 +37,8 @@ def format_interval(t):
         return '{0:02d}:{1:02d}'.format(m, s)
 
 
-def format_meter(n, total, elapsed, ncols=None, prefix='', unit=None, unit_scale=False, ascii=False):
+def format_meter(n, total, elapsed, ncols=None, prefix='', \
+     unit=None, unit_scale=False, ascii=False):
     """
     Return a string-based progress bar given some parameters
 
@@ -59,9 +61,10 @@ def format_meter(n, total, elapsed, ncols=None, prefix='', unit=None, unit_scale
         String that will be used to define the unit of each iteration.
         [default: "it"]
     unit_scale  : bool, optional
-        If set, the number of iterations will be reduced/scaled automatically
-        and a metric prefix following the International System of Units standard
-        will be added (kilo, mega, etc.). [default: False]
+        If set, the number of iterations will be reduced/scaled
+        automatically and a metric prefix following the
+        International System of Units standard will be added
+        (kilo, mega, etc.). [default: False]
     ascii  : bool, optional
         If not set, use unicode (smooth blocks) to fill the meter
         [default: False]. The fallback is to use ASCII characters (1-9 #).
@@ -70,7 +73,10 @@ def format_meter(n, total, elapsed, ncols=None, prefix='', unit=None, unit_scale
     -------
     out  : Formatted meter and stats, ready to display.
     """
-    if total and n > total: # in case the total is wrong (n is above the total), then we switch to the mode without showing the total prediction (since ETA would be wrong anyway)
+
+    # in case the total is wrong (n is above the total), then we switch to the mode without showing
+    # the total prediction (since ETA would be wrong anyway)
+    if total and n > total:
         total = None
 
     elapsed_str = format_interval(elapsed)
@@ -184,9 +190,10 @@ class tqdm(object):
         String that will be used to define the unit of each iteration.
         [default: "it"]
     unit_scale  : bool, optional
-        If set, the number of iterations will be reduced/scaled automatically
-        and a metric prefix following the International System of Units standard
-        will be added (kilo, mega, etc.). [default: False]
+        If set, the number of iterations will be reduced/scaled
+        automatically and a metric prefix following the
+        International System of Units standard will be added
+        (kilo, mega, etc.). [default: False]
     ascii  : bool, optional
         If not set, use unicode (smooth blocks) to fill the meter
         [default: False]. The fallback is to use ASCII characters (1-9 #).

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -7,7 +7,7 @@ Usage:
   for i in trange(10):
     ...
 """
-from __future__ import division, absolute_import
+from __future__ import division, absolute_import # future division is important to divide integers and get as a result precise floating numbers (instead of truncated int)
 from ._utils import _supports_unicode, _environ_cols, _range, _unich
 import sys
 import time
@@ -17,6 +17,15 @@ __author__ = {"github.com/": ["noamraph", "JackMc", "arkottke", "obiwanus",
                               "fordhurley", "kmike", "hadim", "casperdcl"]}
 __all__ = ['tqdm', 'trange', 'format_interval', 'format_meter']
 
+def format_sizeof(num, suffix='bytes'):
+    """
+    Readable size format, courtesy of Sridhar Ratnakumar
+    """
+    for unit in ['','K','M','G','T','P','E','Z']:
+        if abs(num) < 1000.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1000.0
+    return "%.1f%s%s" % (num, 'Y', suffix)
 
 def format_interval(t):
     mins, s = divmod(int(t), 60)
@@ -27,25 +36,32 @@ def format_interval(t):
         return '{0:02d}:{1:02d}'.format(m, s)
 
 
-def format_meter(n, total, elapsed, ncols=None, prefix='', ascii=False):
+def format_meter(n, total, elapsed, ncols=None, prefix='', unit=None, unit_scale=False, ascii=False):
     """
-    Parameter parsing and formatting for output
+    Return a string-based progress bar given some parameters
 
     Parameters
     ----------
     n  : int
-        Number of finished iterations
+        Number of finished iterations.
     total  : int
-        The number of expected iterations. If None, only basic progress
-        statistics are displayed.
+        The expected total number of iterations. If None, only basic progress
+        statistics are displayed (no ETA).
     elapsed  : float
-        Number of seconds passed since start
+        Number of seconds passed since start.
     ncols  : int, optional
         The width of the entire output message. If sepcified, dynamically
         resizes the progress meter [default: None]. The fallback meter
         width is 10.
     prefix  : str, optional
-        Prefix message (included in total width)
+        Prefix message (included in total width).
+    unit  : str, optional
+        String that will be used to define the unit of each iteration.
+        [default: "it"]
+    unit_scale  : str, optional
+        If set, the number of iterations will be reduced/scaled automatically
+        and a metric prefix following the International System of Units standard
+        will be added (kilo, mega, etc.).
     ascii  : bool, optional
         If not set, use unicode (smooth blocks) to fill the meter
         [default: False]. The fallback is to use ASCII characters (1-9 #).
@@ -54,77 +70,101 @@ def format_meter(n, total, elapsed, ncols=None, prefix='', ascii=False):
     -------
     out  : Formatted meter and stats, ready to display.
     """
-    if total and n > total:
+    if total and n > total: # in case the total is wrong (n is above the total), then we switch to the mode without showing the total prediction (since ETA would be wrong anyway)
         total = None
 
     elapsed_str = format_interval(elapsed)
-    rate = '{0:5.2f}'.format(n / elapsed) if elapsed else '?'
+    if elapsed:
+        if unit_scale:
+            rate = format_sizeof(n / elapsed, suffix='')
+        else:
+            rate = '{0:5.2f}'.format(n / elapsed)
+    else:
+        rate = '?'
+
+    rate_unit = unit if unit else 'it'
+    if not unit: unit = ''
+
+    n_fmt = str(n)
+    total_fmt = str(total)
+    if unit_scale:
+        n_fmt = format_sizeof(n, suffix='')
+        if total: total_fmt = format_sizeof(total, suffix='')
 
     if total:
-        frac = float(n) / total
+        frac = n / total
+        percentage = frac * 100
+        
+        remaining_str = format_interval(elapsed * (total-n) / n) if n else '?'
 
-        left_str = format_interval(elapsed * (total-n) / n) if n else '?'
+        l_bar = '{1}{0:.0f}%|'.format(percentage, prefix) if prefix else \
+                '{0:3.0f}%|'.format(percentage)
+        r_bar = '| {0}/{1}{2} [{3}<{4}, {5} {6}/s]'.format(
+                n_fmt, total_fmt, unit, elapsed_str, remaining_str, rate, rate_unit)
 
-        l_bar = '{1}{0:.0f}%|'.format(frac * 100, prefix) if prefix else \
-                '{0:3.0f}%|'.format(frac * 100)
-        r_bar = '| {0}/{1} [{2}<{3}, {4} it/s]'.format(
-                n, total, elapsed_str, left_str, rate)
-
-        N_BARS = max(1, ncols - len(l_bar) - len(r_bar)) if ncols else 10
-
-        if ascii:
-            bar_length, frac_bar_length = divmod(int(frac * N_BARS * 10), 10)
-
-            bar = '#'*bar_length
-            frac_bar = chr(48 + frac_bar_length) if frac_bar_length else ' '
-
+        if ncols == 0:
+            bar = ''
         else:
-            bar_length, frac_bar_length = divmod(int(frac * N_BARS * 8), 8)
+            N_BARS = max(1, ncols - len(l_bar) - len(r_bar)) if ncols else 10
 
-            bar = _unich(0x2588)*bar_length
-            frac_bar = _unich(0x2590 - frac_bar_length) \
-                if frac_bar_length else ' '
+            if ascii:
+                bar_length, frac_bar_length = divmod(int(frac * N_BARS * 10), 10)
+
+                bar = '#'*bar_length
+                frac_bar = chr(48 + frac_bar_length) if frac_bar_length else '0'
+
+            else:
+                bar_length, frac_bar_length = divmod(int(frac * N_BARS * 8), 8)
+
+                bar = _unich(0x2588)*bar_length
+                frac_bar = _unich(0x2590 - frac_bar_length) \
+                    if frac_bar_length else ' '
 
         if bar_length < N_BARS:
-            return l_bar + bar + frac_bar + \
-                ' '*max(N_BARS - bar_length - 1, 0) + r_bar
+            full_bar = bar + frac_bar + \
+                '-' * max(N_BARS - bar_length - 1, 0) # spacing
         else:
-            return l_bar + bar + r_bar
+            full_bar = bar + \
+            '-' * max(N_BARS - bar_length, 0) # spacing
+
+        return "%s%s%s" % (l_bar,  full_bar, r_bar)
 
     else:
-        return '{0:d} [{1}, {2} it/s]'.format(n, elapsed_str, rate)
+        return '{0:d}{1} [{2}, {3} {4}/s]'.format(n_fmt, unit, elapsed_str, rate, rate_unit)
 
 
 class StatusPrinter(object):
+    """
+    Manage the printing and in-place updating of a line of characters.
+    Note that if the string is longer than a line, then in-place updating may not work (it will print a new line at each refresh).
+    """
     def __init__(self, file):
         self.file = file
         self.last_printed_len = 0
 
     def print_status(self, s):
-        len_s = len(s)
-        self.file.write('\r'+s+' '*max(self.last_printed_len - len_s, 0))
+        self.file.write('\r'+s+' '*max(self.last_printed_len-len(s), 0))
         self.file.flush()
-        self.last_printed_len = len_s
+        self.last_printed_len = len(s)
 
 
-def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
-         ncols=None, mininterval=0.1, miniters=None,
-         ascii=None, disable=False):
+class tqdm(object):
     """
     Decorate an iterable object, returning an iterator which acts exactly
     like the orignal iterable, but prints a dynamically updating
-    progressbar.
+    progressbar every time a value is requested.
 
     Parameters
     ----------
-    iterable  : iterable
-        Iterable to decorate with a progressbar.
+    iterable  : iterable, optional
+        Iterable to decorate with a progressbar. You can leave
+        it to None if you want to manually manage the updates.
     desc  : str, optional
         Prefix for the progressbar.
     total  : int, optional
         The number of expected iterations. If not given, len(iterable) is
         used if possible. As a last resort, only basic progress statistics
-        are displayed.
+        are displayed (no ETA, no progressbar).
     file  : `io.TextIOWrapper` or `io.StringIO`, optional
         Specifies where to output the progress messages.
         Uses file.write(str) and file.flush() methods.
@@ -132,13 +172,21 @@ def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
         if unset, removes all traces of the progressbar upon termination of
         iteration [default: False].
     ncols  : int, optional
-        The width of the entire output message. If sepcified, dynamically
-        resizes the progress meter [default: None]. The fallback meter
-        width is 10.
+        The width of the entire output message. If specified, dynamically
+        resizes the progress meter to stay within this bound [default: None].
+        The fallback meter width is 10 for the progress bar + no limit for
+        the iterations counter and statistics.
     mininterval  : float, optional
         Minimum progress update interval, in seconds [default: 0.1].
     miniters  : int, optional
         Minimum progress update interval, in iterations [default: None].
+    unit  : str, optional
+        String that will be used to define the unit of each iteration.
+        [default: "it"]
+    unit_scale  : str, optional
+        If set, the number of iterations will be reduced/scaled automatically
+        and a metric prefix following the International System of Units standard
+        will be added (kilo, mega, etc.).
     ascii  : bool, optional
         If not set, use unicode (smooth blocks) to fill the meter
         [default: False]. The fallback is to use ASCII characters (1-9 #).
@@ -150,61 +198,102 @@ def tqdm(iterable, desc=None, total=None, leave=False, file=sys.stderr,
     out  : decorated iterator.
     """
 
-    if disable:
-        for obj in iterable:
-            yield obj
-        return
+    def __init__(self, iterable=None, desc=None, total=None, leave=False, file=sys.stderr,
+         ncols=None, mininterval=0.1, miniters=None, unit=None, unit_scale=False,
+         ascii=None, disable=False):
 
-    if total is None:
-        try:
-            total = len(iterable)
-        except (TypeError, AttributeError):
-            total = None
+        # Preprocess the arguments
+        if total is None and iterable is not None:
+            try:
+                total = len(iterable)
+            except (TypeError, AttributeError):
+                total = None
 
-    if (ncols is None) and (file in (sys.stderr, sys.stdout)):
-        ncols = _environ_cols(file)
+        if (ncols is None) and (file in (sys.stderr, sys.stdout)):
+            ncols = _environ_cols(file)
 
-    if miniters is None:
-        miniters = 0
-        dynamic_miniters = True
-    else:
-        dynamic_miniters = False
+        if miniters is None:
+            miniters = 0
+            dynamic_miniters = True
+        else:
+            dynamic_miniters = False
 
-    if ascii is None:
-        ascii = not _supports_unicode(file)
+        if ascii is None:
+            ascii = not _supports_unicode(file)
 
-    prefix = desc+': ' if desc else ''
+        # Store the arguments
+        self.iterable = iterable
+        self.total = total
+        self.prefix = desc+': ' if desc else ''
+        self.leave = leave
+        self.file = file
+        self.ncols = ncols
+        self.mininterval = mininterval
+        self.miniters = miniters
+        self.dynamic_miniters = dynamic_miniters
+        self.unit = unit
+        self.unit_scale = unit_scale
+        self.ascii = ascii
+        self.disable = disable
 
-    sp = StatusPrinter(file)
-    sp.print_status(format_meter(0, total, 0, ncols, prefix, ascii))
+        # Initialize the screen printer
+        self.sp = StatusPrinter(self.file)
+        if not disable: self.sp.print_status(format_meter(0, total, 0, ncols, self.prefix, unit, unit_scale, ascii))
 
-    start_t = last_print_t = time.time()
-    last_print_n = 0
-    n = 0
-    for obj in iterable:
-        yield obj
-        # Now the object was created and processed, so we can print the meter.
-        n += 1
-        if n - last_print_n >= miniters:
+        # Init the time/iterations counters
+        self.start_t = self.last_print_t = time.time()
+        self.last_print_n = 0
+        self.n = 0
+
+    def __iter__(self):
+        ''' For backward-compatibility to use: for x in tqdm(iterable) '''
+        if self.disable: # if the bar is disabled, then just walk the iterable (note that we keep this condition above the loop for performance, so that we don't have to repeatedly check the condition inside the loop)
+            for obj in self.iterable:
+                yield obj
+        else:
+            for obj in self.iterable:
+                yield obj
+                # Now the object was created and processed, so we can print the meter.
+                self.update(1)
+            self.close()
+
+    def update(self, n=1):
+        """
+        Manually update the progress bar, useful for streams such as reading files (set init(total=filesize) and then in the reading loop, use update(len(current_buffer)) )
+
+        Parameters
+        ----------
+        n  : int
+            Increment to add to the internal counter of iterations.
+        """
+        if n < 1:
+            n = 1
+        self.n += n
+
+        if self.disable: return
+
+        delta_it = self.n - self.last_print_n
+        if delta_it >= self.miniters:
             # We check the counter first, to reduce the overhead of time.time()
             cur_t = time.time()
-            if cur_t - last_print_t >= mininterval:
-                sp.print_status(format_meter(
-                    n, total, cur_t-start_t, ncols, prefix, ascii))
-                if dynamic_miniters:
-                    miniters = max(miniters, n - last_print_n)
-                last_print_n = n
-                last_print_t = cur_t
+            if cur_t - self.last_print_t >= self.mininterval:
+                self.sp.print_status(format_meter(self.n, self.total, cur_t-self.start_t, self.ncols, self.prefix, self.unit, self.unit_scale, self.ascii))
+                if self.dynamic_miniters: self.miniters = max(self.miniters, delta_it)
+                self.last_print_n = self.n
+                self.last_print_t = cur_t
 
-    if leave:
-        if last_print_n < n:
-            cur_t = time.time()
-            sp.print_status(format_meter(
-                n, total, cur_t-start_t, ncols, prefix, ascii))
-        file.write('\n')
-    else:
-        sp.print_status('')
-        file.write('\r')
+    def close(self):
+        """
+        Call this method to force print the last progress bar update based on the latest n value
+        """
+        if self.leave:
+            if self.last_print_n < self.n:
+                cur_t = time.time()
+                self.sp.print_status(format_meter(self.n, self.total, cur_t-self.start_t, self.ncols, self.prefix, self.unit, self.unit_scale, self.ascii))
+            self.file.write('\n')
+        else:
+            self.sp.print_status('')
+            self.file.write('\r')
 
 
 def trange(*args, **kwargs):

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -139,3 +139,12 @@ def test_disable():
         pass
     our_file.seek(0)
     assert our_file.read() == ""
+
+
+def test_unit():
+    our_file = StringIO()
+    for i in tqdm(range(3), file=our_file, mininterval=1e-10, unit="bytes"):
+        pass
+    our_file.seek(0)
+    assert "bytes/s" in our_file.read()
+    our_file.close()


### PR DESCRIPTION
Tqdm is great, but it is bound to the iterator, which limits its usage with files and streams read in buffers.

I converted the function tqdm() into a class and it can now be called without an iterable, but I kept a full retrocompatibility (you can still use it directly on an iterator, and trange() also works perfectly well). This change allows to manually call update(n) and close(), so now if you use a buffer and process more than one unit per iteration of loop, you can update your progress bar accordingly.

But to be complete about files, I also added two new arguments:

- unit is a string which will replace the unit "it" in the progress stats.
- unit_scale is a boolean, and if set to True it will reduce the numbers according to the International System of Units and add the corresponding metric prefix.

For example, if you combine unit="B" and unit_scale=True, and if you manually update tqdm depending on your buffer, the progress bar will show the reading rate in "B/s" and if your code is speedy enough, you'll see "K B/s" or even "M B/s" (or above up to Yotta).

I also added a bit of documentation and fixed some here and there.

I also edited the progress bar to fill "------" instead of "     " in the empty space, just like the original TQDM bar (I feel this is more useful as it clearly shows how much remains, as opposed to when it's empty it's hard to evaluate with a glimpse).

A dummy example:

    import tqdm
    total_it = 10000000
    buffer_size = 50
    total_size = total_it * buffer_size
    bardisp = tqdm.tqdm(total=total_size, leave=True, desc='STREAM', unit='B', unit_scale=True, ncols=79, mininterval=0.5) # display progress bar based on the number of bytes read
    for _ in xrange(total_it):
        bardisp.update(buffer_size)
    bardisp.close()

Signed-off-by: Stephen L. <lrq3000@gmail.com>