### PR TITLE
#egg to refer to the project name, not the branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ version is much more visually appealing.
 
 ```sh
 # newer, faster, prettier, stable version
-pip install -e git+https://github.com/tqdm/tqdm.git#egg=master
+pip install -e git+https://github.com/tqdm/tqdm.git#egg=tqdm
 # or (old version on pypi)
 pip install tqdm
 ```


### PR DESCRIPTION
https://pip.pypa.io/en/latest/reference/pip_install.html#vcs-support

> The "project name" component of the url suffix `egg=<project name>-<version>` is used by pip in its dependency logic to identify the project prior to pip downloading and analyzing the metadata.