### PR TITLE
Fix: both mininterval and miniters can be used at the same time

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -266,7 +266,6 @@ class tqdm(object):
             dynamic_miniters = True
         else:
             dynamic_miniters = False
-            mininterval = 0
 
         if mininterval is None:
             mininterval = 0

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -188,10 +188,17 @@ def test_dynamic_min_iters():
     assert "70%" in out
 
     our_file = StringIO()
-    t = tqdm(range(10), file=our_file, miniters=None, mininterval=None)
+    t = tqdm(range(10), file=our_file, miniters=None, mininterval=None,
+             leave=True)
     for i in t:
         pass
     assert t.dynamic_miniters
+
+    our_file = StringIO()
+    t = tqdm(range(10), file=our_file, miniters=1, mininterval=None)
+    for i in t:
+        pass
+    assert not t.dynamic_miniters
 
     our_file.close()
 
@@ -240,7 +247,7 @@ def test_unit():
 def test_update():
     """ Test manual creation and updates """
     our_file = StringIO()
-    progressbar = tqdm(total=2, file=our_file, miniters=1)
+    progressbar = tqdm(total=2, file=our_file, miniters=1, mininterval=0)
     assert len(progressbar) == 2
     progressbar.update(2)
     our_file.seek(0)


### PR DESCRIPTION
Mininterval was always set to 0 when miniters was >= 1. I think these two options can be used at the same time.

I removed the statement that was doing that and adapted the tests to keep 100% branch coverage.