### PR TITLE
Move new commands to Makefile

### DIFF
--- a/CONTRIBUTE
+++ b/CONTRIBUTE
@@ -4,6 +4,9 @@ HOW TO CONTRIBUTE TO TQDM
 This file describes how to contribute changes to the project, and how to
 upload to the pypi repository.
 
+Most of the management commands have been directly placed inside
+the Makefile, so you just have to run `make [alias]`.
+
 
 HOW TO COMMIT YOUR CONTRIBUTIONS
 --------------------------------
@@ -34,12 +37,10 @@ To run the tests,
 
 - install `tox`
 - `cd` to the root of the `tqdm` directory (in the same folder as this file)
-- run the following commands:
+- run the following command:
 
 ```
-make test
-make coverage
-make flake8
+make alltests
 ```
 
 Alternatively (if you can't use `make`)
@@ -51,3 +52,6 @@ Alternatively (if you can't use `make`)
 nosetests --with-coverage --cover-package=tqdm -v tqdm/
 python -m flake8 tqdm/_tqdm.py
 ```
+
+Then wait for the tests to finish, and check your console to see if there's
+any issue.

--- a/CONTRIBUTE
+++ b/CONTRIBUTE
@@ -7,6 +7,9 @@ upload to the pypi repository.
 Most of the management commands have been directly placed inside
 the Makefile, so you just have to run `make [alias]`.
 
+Note: to use the Makefile on Windows, you need to install make.exe,
+for example by installing [MinGW MSYS](http://www.mingw.org/wiki/msys).
+
 
 HOW TO COMMIT YOUR CONTRIBUTIONS
 --------------------------------

--- a/CONTRIBUTE
+++ b/CONTRIBUTE
@@ -36,7 +36,7 @@ TESTING
 To test functionality on your machine (such as before submitting a Pull
 Request), there are a number of unit tests.
 
-To run the tests,
+To run the tests for only your Python distribution:
 
 - install `tox`
 - `cd` to the root of the `tqdm` directory (in the same folder as this file)
@@ -55,6 +55,17 @@ Alternatively (if you can't use `make`)
 nosetests --with-coverage --cover-package=tqdm -v tqdm/
 python -m flake8 tqdm/_tqdm.py
 ```
+
+To run the tests for all Python distributions (better, but more time consuming):
+
+- install `tox`
+- install all versions of the Python interpreter that are specified in
+[tox.ini](tox.ini). You can use MiniConda to install a minimal setup.
+You must also make sure that each distribution has an alias to call
+the Python interpreter: python27 for Python 2.7's interpreter,
+python32 for Python 3.2's, etc.
+- `cd` to the root of the `tqdm` directory (in the same folder as this file)
+- run the following command: `tox`
 
 Then wait for the tests to finish, and check your console to see if there's
 any issue.

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ testsetup:
 testcoverage:
 	nosetests tqdm --with-coverage --cover-package=tqdm -v
 
+allenvtests: tox
+
 installdev:
 	python setup.py develop --uninstall
 	python setup.py develop

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all flake8 test coverage
 
-alltests: test coverage flake8 testsetup
+alltests: testcoverage flake8 testsetup
 all: alltests build
 
 flake8:
@@ -13,7 +13,7 @@ test:
 testsetup:
 	python setup.py check --restructuredtext --strict
 
-coverage:
+testcoverage:
 	nosetests tqdm --with-coverage --cover-package=tqdm -v
 
 installdev:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all flake8 test coverage
 
-all: flake8 coverage
+alltests: test coverage flake8 testsetup
+all: alltests build
+
 flake8:
 	flake8 --max-line-length=80 --count --statistics --exit-zero tqdm/
 	flake8 --max-line-length=80 --count --statistics --exit-zero examples/
@@ -8,5 +10,25 @@ flake8:
 test:
 	nosetests tqdm -v
 
+testsetup:
+	python setup.py check --restructuredtext --strict
+
 coverage:
 	nosetests tqdm --with-coverage --cover-package=tqdm -v
+
+installdev:
+	python setup.py develop --uninstall
+	python setup.py develop
+
+install:
+	python setup.py install
+
+build:
+	python setup.py sdist --formats=gztar,zip bdist_wininst
+	python setup.py sdist bdist_wheel
+
+pypimeta:
+	python setup.py register
+
+pypi:
+	twine upload dist/*

--- a/RELEASE
+++ b/RELEASE
@@ -7,6 +7,9 @@ how to update, build and upload a new release.
 Most of the management commands have been directly placed inside
 the Makefile, so you just have to run `make [alias]`.
 
+Note: to use the Makefile on Windows, you need to install make.exe,
+for example by installing [MinGW MSYS](http://www.mingw.org/wiki/msys).
+
 
 SEMANTIC VERSIONING
 -------------------

--- a/RELEASE
+++ b/RELEASE
@@ -4,6 +4,9 @@ HOW TO MANAGE A NEW RELEASE
 This file is intended for the project's maintainers and it describes
 how to update, build and upload a new release.
 
+Most of the management commands have been directly placed inside
+the Makefile, so you just have to run `make [alias]`.
+
 
 SEMANTIC VERSIONING
 -------------------
@@ -34,7 +37,7 @@ python setup.py check --restructuredtext --strict
 ```
 
 Also, if you happen to mistakenly upload a broken release to PyPi,
-you can fix the metadata by using: `python setup.py register`.
+you can fix the metadata by using: `make pypimeta` or `python setup.py register`
 
 
 BUILDING A RELEASE AND UPLOADING TO PYPI
@@ -46,15 +49,13 @@ process and info that will be uploaded to [pypi](pypi.python.org).
 Check the result by using the following commands:
 
 ```
-python setup.py develop --uninstall
-python setup.py develop
+make installdev
 ```
 
 Secondly, build tqdm into a distributable python package:
 
 ```
-python setup.py sdist --formats=gztar,zip bdist_wininst --plat-name=win32
-python setup.py sdist bdist_wheel --plat-name=win32
+make build
 ```
 
 This will generate several builds in the `dist/` folder.
@@ -63,7 +64,7 @@ Finally, we can upload everything to pypi. Uploading to pypi can be done
 easily using the [twine](https://github.com/pypa/twine) module:
 
 ```
-twine upload dist/*
+make pypi
 ```
 
 NOTE:
@@ -74,7 +75,7 @@ before the real deployment
 cannot re-upload another with the same version number!
 - in case of a mistake in the metadata on pypi (like the long description README
 getting garbled because of a silent error), you can use the following
-command to update the metadata: `python setup.py register`
+command to update the metadata: `make pypimeta` or `python setup.py register`
 
 Also, the new release can be added to the Github by creating a new release
 from the web interface.

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,6 @@ setup(
         'Intended Audience :: Developers',
     ],
     keywords = 'progressbar progressmeter progress bar meter rate eta console terminal time',
+    test_suite='nose.collector',
+    tests_require=['nose', 'flake8', 'coverage'],
 )


### PR DESCRIPTION
I added all the new commands that were specified in RELEASE and CONTRIBUTE, into the Makefile. I updated the doc accordingly.

You can now use `make alltests` to run all tests, and `make all` to run all tests + build (or `make build` just to build the redistributable packages).

I also took a look on how we could avoid using make as suggested by @kmike. We can either use a third-party management tool such as SCons or we can use the standard setup.py [command] thank's to distutils. However, the latter seems to be quite complicated, adding a lot of boilerplate code in setup.py just to add new commands:

- http://www.ianbicking.org/pythons-makefile.html
- http://ziade.org/2007/09/30/extending-setuptools-adding-a-new-command/

So for the moment, my opinion is that we should stick to the Makefile :) I added a note in the Makefile on how to get make.exe on Windows, so I think anyone can use it whatever their OS.