### PR TITLE
tox nose-timer as suggested in #52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@
 	testsetup
 	testcoverage
 	testperf
+	testtimer
 	installdev
 	install
 	build
@@ -49,7 +50,7 @@ test:
 	tox --skip-missing-interpreters
 
 testnose:
-	nosetests tqdm --ignore-files="tests_perf\.py" -d -v
+	nosetests tqdm -d -v
 
 testsetup:
 	python setup.py check --restructuredtext --strict
@@ -59,8 +60,11 @@ testcoverage:
 	rm -f .coverage  # coverage erase
 	nosetests tqdm --with-coverage --cover-package=tqdm --cover-erase --cover-min-percentage=80 --ignore-files="tests_perf\.py" -d -v
 
-testperf:  # do not use coverage, slows down the perf test and fail
+testperf:  # do not use coverage (which is extremely slow)
 	nosetests tqdm/tests/tests_perf.py -d -v
+
+testtimer:
+	nosetests tqdm --with-timer -d -v
 
 installdev:
 	python setup.py develop --uninstall

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,11 @@ envlist = py26, py27, py32, py33, py34, pypy, pypy3, flake8, setup.py, perf
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
     nose
+    nose-timer
     coverage<4
     coveralls
 commands =
-    nosetests --with-coverage --cover-package=tqdm --ignore-files="tests_perf\.py" -d -v tqdm/
+    nosetests --with-coverage --with-timer --cover-package=tqdm --ignore-files="tests_perf\.py" -d -v tqdm/
     coveralls
 
 [testenv:flake8]
@@ -35,5 +36,6 @@ commands =
 [testenv:perf]
 deps =
     nose
+    nose-timer
 commands =
-    nosetests tqdm/tests/tests_perf.py -d -v
+    nosetests --with-timer tqdm/tests/tests_perf.py -d -v


### PR DESCRIPTION
Added a new option to the makefile (so users without `nose-timer` installed don't crash when trying to run tests)