### PR TITLE
relative timing for unit tests (rebased)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,10 @@ all:
 	@+make build
 
 flake8:
-	@+flake8 --max-line-length=80 --count --statistics --exit-zero tqdm/
+	@+flake8 --max-line-length=80 --count --statistics --exit-zero tqdm/*.py
 	@+flake8 --max-line-length=80 --count --statistics --exit-zero examples/
-	@+flake8 --max-line-length=80 --count --statistics --exit-zero .
-	@+flake8 --max-line-length=80 --count --statistics --exit-zero tqdm/tests/
+	@+flake8 --max-line-length=80 --count --statistics --exit-zero *.py
+	@+flake8 --max-line-length=80 --count --statistics --exit-zero --ignore=E731 tqdm/tests/
 
 test:
 	tox --skip-missing-interpreters

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,8 @@ Here's what the output looks like:
 
 |Screenshot|
 
-Overhead is low -- about 60ns per iteration (80ns with ``gui=True``).
+Overhead is low -- about 60ns per iteration (80ns with ``gui=True``), and is
+unit tested against performance regression.
 By comparison, the well established
 `ProgressBar <https://github.com/niltonvolpato/python-progressbar>`__ has
 an 800ns/iter overhead.
@@ -40,7 +41,8 @@ for a negligible overhead in most cases.
 in any console or in a GUI, and is also friendly with IPython/Jupyter notebooks.
 
 ``tqdm`` does not require any library (not even curses!) to run, just a
-vanilla Python interpreter will do.
+vanilla Python interpreter will do and an environment supporting ``carriage
+return \r`` and ``line feed \n`` control characters.
 
 ------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def parse_makefile_aliases(filepath):
     # and put the current alias back in the queue to be processed again later.
 
     # Create the queue of aliases to process
-    aliases_todo = commands.keys()
+    aliases_todo = list(commands.keys())
     # Create the dict that will hold the full commands
     commands_new = {}
     # Loop until we have processed all aliases

--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,10 @@ commands =
 [testenv:flake8]
 deps = flake8
 commands =
-    flake8 --max-line-length=80 --count --statistics --exit-zero tqdm/
+    flake8 --max-line-length=80 --count --statistics --exit-zero tqdm/*.py
     flake8 --max-line-length=80 --count --statistics --exit-zero examples/
-    flake8 --max-line-length=80 --count --statistics --exit-zero .
-    flake8 --max-line-length=80 --count --statistics --exit-zero tqdm/tests/
+    flake8 --max-line-length=80 --count --statistics --exit-zero *.py
+    flake8 --max-line-length=80 --count --statistics --exit-zero --ignore=E731 tqdm/tests/
 
 [testenv:setup.py]
 deps =

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -377,6 +377,7 @@ class tqdm(object):
         self.dynamic_ncols = dynamic_ncols
         self.smoothing = smoothing
         self.avg_rate = None
+        self._time = time
         # if nested, at initial sp() call we replace '\r' by '\n' to
         # not overwrite the outer progress bar
         self.nested = nested
@@ -397,7 +398,7 @@ class tqdm(object):
                         self.desc, ascii, unit, unit_scale, None, bar_format))
 
         # Init the time counter
-        self.start_t = self.last_print_t = time()
+        self.start_t = self.last_print_t = self._time()
 
     def __len__(self):
         return len(self.iterable) if self.iterable else self.total
@@ -437,6 +438,7 @@ class tqdm(object):
             smoothing = self.smoothing
             avg_rate = self.avg_rate
             bar_format = self.bar_format
+            _time = self._time
 
             try:
                 sp = self.sp
@@ -452,7 +454,7 @@ class tqdm(object):
                 delta_it = n - last_print_n
                 # check the counter first (avoid calls to time())
                 if delta_it >= miniters:
-                    cur_t = time()
+                    cur_t = _time()
                     delta_t = cur_t - last_print_t
                     if delta_t >= mininterval:
                         elapsed = cur_t - start_t
@@ -525,7 +527,7 @@ class tqdm(object):
         delta_it = self.n - self.last_print_n  # should be n?
         if delta_it >= self.miniters:
             # We check the counter first, to reduce the overhead of time()
-            cur_t = time()
+            cur_t = self._time()
             delta_t = cur_t - self.last_print_t
             if delta_t >= self.mininterval:
                 elapsed = cur_t - self.start_t
@@ -577,7 +579,7 @@ class tqdm(object):
 
         if self.leave:
             if self.last_print_n < self.n:
-                cur_t = time()
+                cur_t = self._time()
                 # stats for overall rate (no weighted average)
                 self.sp(format_meter(
                     self.n, self.total, cur_t - self.start_t,
@@ -594,7 +596,7 @@ class tqdm(object):
         """
         Restart tqdm timer from last print time.
         """
-        cur_t = time()
+        cur_t = self._time()
         self.start_t += cur_t - self.last_print_t
         self.last_print_t = cur_t
 

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -1,4 +1,4 @@
-from time import time
+from contextlib import contextmanager
 
 from tqdm import trange
 from tqdm import tqdm
@@ -20,66 +20,139 @@ try:
 except:
     _range = range
 
+# Use relative/cpu timer to have reliable timings when there is a sudden load
+try:
+    from time import process_time
+except ImportError:
+    from time import clock
+    process_time = clock
 
-_tic_toc = [None]
+
+# def cpu_sleep(t):
+#     '''Sleep the given amount of cpu time'''
+#     start = process_time()
+#     while((process_time() - start) < t):
+#         pass
 
 
-def tic():
-    _tic_toc[0] = time()
+def get_relative_time(prevtime=0):
+    return process_time() - prevtime
 
 
-def toc():
-    return time() - _tic_toc[0]
+@contextmanager
+def relative_timer():
+    start = process_time()
+    elapser = lambda: process_time() - start
+    yield lambda: elapser()
+    spent = process_time() - start
+    elapser = lambda: spent
+
+
+class MockFileNoWrite(StringIO):
+    """ Wraps StringIO to mock a file with no I/O """
+    def write(self, data):
+        return
 
 
 def test_iter_overhead():
     """ Test overhead of iteration based tqdm """
     total = int(1e6)
 
-    with closing(StringIO()) as our_file:
+    with closing(MockFileNoWrite()) as our_file:
         a = 0
-        tic()
-        for i in trange(total, file=our_file):
-            a += i
-        time_tqdm = toc()
+        with relative_timer() as time_tqdm:
+            for i in trange(total, file=our_file):
+                a += i
         assert(a == (total * total - total) / 2.0)
 
-    a = 0
-    tic()
-    for i in _range(total):
-        a += i
-    time_bench = toc()
+        a = 0
+        with relative_timer() as time_bench:
+            for i in _range(total):
+                a += i
+                our_file.write(a)
 
     # Compute relative overhead of tqdm against native range()
     try:
-        assert(time_tqdm < 9 * time_bench)
+        assert(time_tqdm() < 3 * time_bench())
     except AssertionError:
         raise AssertionError('trange(%g): %f, range(%g): %f' %
-                             (total, time_tqdm, total, time_bench))
+                             (total, time_tqdm(), total, time_bench()))
 
 
 def test_manual_overhead():
     """ Test overhead of manual tqdm """
     total = int(1e6)
 
-    with closing(StringIO()) as our_file:
+    with closing(MockFileNoWrite()) as our_file:
         t = tqdm(total=total * 10, file=our_file, leave=True)
         a = 0
-        tic()
-        for i in _range(total):
-            a += i
-            t.update(10)
-        time_tqdm = toc()
+        with relative_timer() as time_tqdm:
+            for i in _range(total):
+                a += i
+                t.update(10)
 
-    a = 0
-    tic()
-    for i in _range(total):
-        a += i
-    time_bench = toc()
+        a = 0
+        with relative_timer() as time_bench:
+            for i in _range(total):
+                a += i
+                our_file.write(a)
 
     # Compute relative overhead of tqdm against native range()
     try:
-        assert(time_tqdm < 19 * time_bench)
+        assert(time_tqdm() < 10 * time_bench())
     except AssertionError:
         raise AssertionError('tqdm(%g): %f, range(%g): %f' %
-                             (total, time_tqdm, total, time_bench))
+                             (total, time_tqdm(), total, time_bench()))
+
+
+def test_iter_overhead_hard():
+    """ Test overhead of iteration based tqdm (hard) """
+    total = int(1e5)
+
+    with closing(MockFileNoWrite()) as our_file:
+        a = 0
+        with relative_timer() as time_tqdm:
+            for i in trange(total, file=our_file, leave=True,
+                            miniters=1, mininterval=0, maxinterval=0):
+                a += i
+        assert(a == (total * total - total) / 2.0)
+
+        a = 0
+        with relative_timer() as time_bench:
+            for i in _range(total):
+                a += i
+                our_file.write(("%i" % a) * 40)
+
+    # Compute relative overhead of tqdm against native range()
+    try:
+        assert(time_tqdm() < 60 * time_bench())
+    except AssertionError:
+        raise AssertionError('trange(%g): %f, range(%g): %f' %
+                             (total, time_tqdm(), total, time_bench()))
+
+
+def test_manual_overhead_hard():
+    """ Test overhead of manual tqdm (hard) """
+    total = int(1e5)
+
+    with closing(MockFileNoWrite()) as our_file:
+        t = tqdm(total=total * 10, file=our_file, leave=True,
+                 miniters=1, mininterval=0, maxinterval=0)
+        a = 0
+        with relative_timer() as time_tqdm:
+            for i in _range(total):
+                a += i
+                t.update(10)
+
+        a = 0
+        with relative_timer() as time_bench:
+            for i in _range(total):
+                a += i
+                our_file.write(("%i" % a) * 40)
+
+    # Compute relative overhead of tqdm against native range()
+    try:
+        assert(time_tqdm() < 100 * time_bench())
+    except AssertionError:
+        raise AssertionError('tqdm(%g): %f, range(%g): %f' %
+                             (total, time_tqdm(), total, time_bench()))

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -70,13 +70,14 @@ def relative_timer():
     elapser = lambda: spent
 
 
-class MockFileNoWrite(StringIO):
+class MockIO(StringIO):
     """ Wraps StringIO to mock a file with no I/O """
     def write(self, data):
         return
 
 
-def simple_progress(iterable=None, total=None, file=sys.stdout, desc='', leave=False, miniters=1, mininterval=0.1, width=60):
+def simple_progress(iterable=None, total=None, file=sys.stdout, desc='',
+                    leave=False, miniters=1, mininterval=0.1, width=60):
     """ Simple progress bar reproducing tqdm's major features """
     n = [0]  # use a closure
     start_t = [time()]
@@ -97,7 +98,7 @@ def simple_progress(iterable=None, total=None, file=sys.stdout, desc='', leave=F
         n[0] += i
         if (n[0] - last_n[0]) >= miniters:
             last_n[0] = n[0]
-            
+
             cur_t = time()
             if (cur_t - last_t[0]) >= mininterval:
                 last_t[0] = cur_t
@@ -106,7 +107,7 @@ def simple_progress(iterable=None, total=None, file=sys.stdout, desc='', leave=F
                 spent_fmt = format_interval(spent)
                 eta = spent / n[0] * total if n[0] else 0
                 frac = n[0] / total
-                rate =  n[0] / spent if spent > 0 else 0
+                rate = n[0] / spent if spent > 0 else 0
                 eta = (total - n[0]) / rate if rate > 0 else 0
                 eta_fmt = format_interval(eta)
                 if 0.0 < rate < 1.0:
@@ -121,9 +122,9 @@ def simple_progress(iterable=None, total=None, file=sys.stdout, desc='', leave=F
                 bar = '#' * bar_length
                 frac_bar = chr(48 + frac_bar_length) if frac_bar_length \
                     else ' '
-                file.write("\r%s %i%%|%s%s%s| %i/%i [%s<%s, %s]" % (desc,
-                                    percentage, bar, frac_bar, barfill, n[0],
-                                    total, spent_fmt, eta_fmt, rate_fmt))
+                file.write("\r%s %i%%|%s%s%s| %i/%i [%s<%s, %s]"
+                           % (desc, percentage, bar, frac_bar, barfill, n[0],
+                              total, spent_fmt, eta_fmt, rate_fmt))
                 if n[0] == total and leave:
                     file.write("\n")
                 file.flush()
@@ -149,7 +150,7 @@ def test_iter_overhead():
 
     total = int(1e6)
 
-    with closing(MockFileNoWrite()) as our_file:
+    with closing(MockIO()) as our_file:
         a = 0
         with relative_timer() as time_tqdm:
             for i in trange(total, file=our_file):
@@ -179,7 +180,7 @@ def test_manual_overhead():
 
     total = int(1e6)
 
-    with closing(MockFileNoWrite()) as our_file:
+    with closing(MockIO()) as our_file:
         t = tqdm(total=total * 10, file=our_file, leave=True)
         a = 0
         with relative_timer() as time_tqdm:
@@ -210,7 +211,7 @@ def test_iter_overhead_hard():
 
     total = int(1e5)
 
-    with closing(MockFileNoWrite()) as our_file:
+    with closing(MockIO()) as our_file:
         a = 0
         with relative_timer() as time_tqdm:
             for i in trange(total, file=our_file, leave=True,
@@ -241,7 +242,7 @@ def test_manual_overhead_hard():
 
     total = int(1e5)
 
-    with closing(MockFileNoWrite()) as our_file:
+    with closing(MockIO()) as our_file:
         t = tqdm(total=total * 10, file=our_file, leave=True,
                  miniters=1, mininterval=0, maxinterval=0)
         a = 0
@@ -273,7 +274,7 @@ def test_iter_overhead_simplebar_hard():
 
     total = int(1e4)
 
-    with closing(MockFileNoWrite()) as our_file:
+    with closing(MockIO()) as our_file:
         a = 0
         with relative_timer() as time_tqdm:
             for i in trange(total, file=our_file, leave=True,
@@ -284,7 +285,8 @@ def test_iter_overhead_simplebar_hard():
         a = 0
         with relative_timer() as time_bench:
             simplebar_iter = simple_progress(_range(total), file=our_file,
-                                        leave=True, miniters=1, mininterval=0)
+                                             leave=True, miniters=1,
+                                             mininterval=0)
             for i in simplebar_iter():
                 a += i
 
@@ -305,7 +307,7 @@ def test_manual_overhead_simplebar_hard():
 
     total = int(1e4)
 
-    with closing(MockFileNoWrite()) as our_file:
+    with closing(MockIO()) as our_file:
         t = tqdm(total=total * 10, file=our_file, leave=True,
                  miniters=1, mininterval=0, maxinterval=0)
         a = 0
@@ -315,7 +317,8 @@ def test_manual_overhead_simplebar_hard():
                 t.update(10)
 
         simplebar_update = simple_progress(total=total, file=our_file,
-                                        leave=True, miniters=1, mininterval=0)
+                                           leave=True, miniters=1,
+                                           mininterval=0)
         a = 0
         with relative_timer() as time_bench:
             for i in _range(total):
@@ -328,4 +331,3 @@ def test_manual_overhead_simplebar_hard():
     except AssertionError:
         raise AssertionError('tqdm(%g): %f, simple_progress(%g): %f' %
                              (total, time_tqdm(), total, time_bench()))
-

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -1,4 +1,11 @@
+from __future__ import print_function, division
+
+from nose.plugins.skip import SkipTest
+
 from contextlib import contextmanager
+
+import sys
+from time import sleep, time
 
 from tqdm import trange
 from tqdm import tqdm
@@ -28,15 +35,30 @@ except ImportError:
     process_time = clock
 
 
-# def cpu_sleep(t):
-#     '''Sleep the given amount of cpu time'''
-#     start = process_time()
-#     while((process_time() - start) < t):
-#         pass
-
-
 def get_relative_time(prevtime=0):
     return process_time() - prevtime
+
+
+def cpu_sleep(t):
+    '''Sleep the given amount of cpu time'''
+    start = process_time()
+    while((process_time() - start) < t):
+        pass
+
+
+def checkCpuTime(sleeptime=0.2):
+    '''Check if cpu time works correctly'''
+    # First test that sleeping does not consume cputime
+    start1 = process_time()
+    sleep(sleeptime)
+    t1 = process_time() - start1
+
+    # secondly check by comparing to cpusleep (where we actually do something)
+    start2 = process_time()
+    cpu_sleep(sleeptime)
+    t2 = process_time() - start2
+
+    return (abs(t1) < 0.0001 and (t1 < t2 / 10))
 
 
 @contextmanager
@@ -54,8 +76,77 @@ class MockFileNoWrite(StringIO):
         return
 
 
+def simple_progress(iterable=None, total=None, file=sys.stdout, desc='', leave=False, miniters=1, mininterval=0.1, width=60):
+    """ Simple progress bar reproducing tqdm's major features """
+    n = [0]  # use a closure
+    start_t = [time()]
+    last_n = [0]
+    last_t = [0]
+    if iterable is not None:
+        total = len(iterable)
+
+    def format_interval(t):
+        mins, s = divmod(int(t), 60)
+        h, m = divmod(mins, 60)
+        if h:
+            return '{0:d}:{1:02d}:{2:02d}'.format(h, m, s)
+        else:
+            return '{0:02d}:{1:02d}'.format(m, s)
+
+    def update_and_print(i=1):
+        n[0] += i
+        if (n[0] - last_n[0]) >= miniters:
+            last_n[0] = n[0]
+            
+            cur_t = time()
+            if (cur_t - last_t[0]) >= mininterval:
+                last_t[0] = cur_t
+
+                spent = cur_t - start_t[0]
+                spent_fmt = format_interval(spent)
+                eta = spent / n[0] * total if n[0] else 0
+                frac = n[0] / total
+                rate =  n[0] / spent if spent > 0 else 0
+                eta = (total - n[0]) / rate if rate > 0 else 0
+                eta_fmt = format_interval(eta)
+                if 0.0 < rate < 1.0:
+                    rate_fmt = "%.2fs/it" % (1.0 / rate)
+                else:
+                    rate_fmt = "%.2fit/s" % rate
+                percentage = int(frac * 100)
+                bar = "#" * int(frac * width)
+                barfill = " " * int((1.0 - frac) * width)
+                bar_length, frac_bar_length = divmod(
+                    int(frac * width * 10), 10)
+                bar = '#' * bar_length
+                frac_bar = chr(48 + frac_bar_length) if frac_bar_length \
+                    else ' '
+                file.write("\r%s %i%%|%s%s%s| %i/%i [%s<%s, %s]" % (desc,
+                                    percentage, bar, frac_bar, barfill, n[0],
+                                    total, spent_fmt, eta_fmt, rate_fmt))
+                if n[0] == total and leave:
+                    file.write("\n")
+                file.flush()
+
+    def update_and_yield():
+        for elt in iterable:
+            yield elt
+            update_and_print()
+
+    update_and_print(0)
+    if iterable is not None:
+        return update_and_yield
+    else:
+        return update_and_print
+
+
 def test_iter_overhead():
     """ Test overhead of iteration based tqdm """
+    try:
+        assert checkCpuTime()
+    except:
+        raise SkipTest
+
     total = int(1e6)
 
     with closing(MockFileNoWrite()) as our_file:
@@ -81,6 +172,11 @@ def test_iter_overhead():
 
 def test_manual_overhead():
     """ Test overhead of manual tqdm """
+    try:
+        assert checkCpuTime()
+    except:
+        raise SkipTest
+
     total = int(1e6)
 
     with closing(MockFileNoWrite()) as our_file:
@@ -107,6 +203,11 @@ def test_manual_overhead():
 
 def test_iter_overhead_hard():
     """ Test overhead of iteration based tqdm (hard) """
+    try:
+        assert checkCpuTime()
+    except:
+        raise SkipTest
+
     total = int(1e5)
 
     with closing(MockFileNoWrite()) as our_file:
@@ -133,6 +234,11 @@ def test_iter_overhead_hard():
 
 def test_manual_overhead_hard():
     """ Test overhead of manual tqdm (hard) """
+    try:
+        assert checkCpuTime()
+    except:
+        raise SkipTest
+
     total = int(1e5)
 
     with closing(MockFileNoWrite()) as our_file:
@@ -156,3 +262,70 @@ def test_manual_overhead_hard():
     except AssertionError:
         raise AssertionError('tqdm(%g): %f, range(%g): %f' %
                              (total, time_tqdm(), total, time_bench()))
+
+
+def test_iter_overhead_simplebar_hard():
+    """ Test overhead of iteration based tqdm vs simple progress bar (hard) """
+    try:
+        assert checkCpuTime()
+    except:
+        raise SkipTest
+
+    total = int(1e4)
+
+    with closing(MockFileNoWrite()) as our_file:
+        a = 0
+        with relative_timer() as time_tqdm:
+            for i in trange(total, file=our_file, leave=True,
+                            miniters=1, mininterval=0, maxinterval=0):
+                a += i
+        assert(a == (total * total - total) / 2.0)
+
+        a = 0
+        with relative_timer() as time_bench:
+            simplebar_iter = simple_progress(_range(total), file=our_file,
+                                        leave=True, miniters=1, mininterval=0)
+            for i in simplebar_iter():
+                a += i
+
+    # Compute relative overhead of tqdm against native range()
+    try:
+        assert(time_tqdm() < 2 * time_bench())
+    except AssertionError:
+        raise AssertionError('trange(%g): %f, simple_progress(%g): %f' %
+                             (total, time_tqdm(), total, time_bench()))
+
+
+def test_manual_overhead_simplebar_hard():
+    """ Test overhead of manual tqdm vs simple progress bar (hard) """
+    try:
+        assert checkCpuTime()
+    except:
+        raise SkipTest
+
+    total = int(1e4)
+
+    with closing(MockFileNoWrite()) as our_file:
+        t = tqdm(total=total * 10, file=our_file, leave=True,
+                 miniters=1, mininterval=0, maxinterval=0)
+        a = 0
+        with relative_timer() as time_tqdm:
+            for i in _range(total):
+                a += i
+                t.update(10)
+
+        simplebar_update = simple_progress(total=total, file=our_file,
+                                        leave=True, miniters=1, mininterval=0)
+        a = 0
+        with relative_timer() as time_bench:
+            for i in _range(total):
+                a += i
+                simplebar_update(10)
+
+    # Compute relative overhead of tqdm against native range()
+    try:
+        assert(time_tqdm() < 2 * time_bench())
+    except AssertionError:
+        raise AssertionError('tqdm(%g): %f, simple_progress(%g): %f' %
+                             (total, time_tqdm(), total, time_bench()))
+

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -4,7 +4,6 @@
 from __future__ import unicode_literals
 
 import csv
-from time import sleep
 import re
 
 from tqdm import format_interval
@@ -33,6 +32,31 @@ try:
     _unicode = unicode
 except NameError:
     _unicode = str
+
+
+class DiscreteTimer(object):
+    '''Virtual discrete time manager, to precisely control time for tests'''
+
+    def __init__(self):
+        self.t = 0.0
+
+    def sleep(self, t):
+        '''Sleep = increment the time counter (almost no CPU used)'''
+        self.t += t
+
+    def time(self):
+        '''Get the current time'''
+        return self.t
+
+
+def cpu_timify(t, timer=None):
+    '''Force tqdm to use the specified timer instead of system-wide time()'''
+    if timer is None:
+        timer = DiscreteTimer()
+    t._time = timer.time
+    t.start_t = t.last_print_t = t._time()
+    return timer
+
 
 RE_rate = re.compile(r'(\d+\.\d+)it/s')
 
@@ -189,6 +213,7 @@ def test_max_interval():
     total = 100
     bigstep = 10
     smallstep = 5
+    timer = DiscreteTimer()
 
     # Test without maxinterval
     with closing(StringIO()) as our_file:
@@ -196,9 +221,12 @@ def test_max_interval():
             # with maxinterval but higher than loop sleep time
             t = tqdm(total=total, file=our_file, miniters=None, mininterval=0,
                      smoothing=1, maxinterval=1e-2)
+            cpu_timify(t, timer)
+
             # without maxinterval
             t2 = tqdm(total=total, file=our_file2, miniters=None, mininterval=0,
                       smoothing=1, maxinterval=None)
+            cpu_timify(t2, timer)
 
             assert t.dynamic_miniters
             assert t2.dynamic_miniters
@@ -210,7 +238,7 @@ def test_max_interval():
             for _ in _range(4):
                 t.update(smallstep)
                 t2.update(smallstep)
-                sleep(1e-5)
+                timer.sleep(1e-5)
 
             our_file.seek(0)
             our_file2.seek(0)
@@ -223,13 +251,14 @@ def test_max_interval():
     with closing(StringIO()) as our_file:
         t = tqdm(total=total, file=our_file, miniters=None, mininterval=0,
                  smoothing=1, maxinterval=1e-4)
+        cpu_timify(t, timer)
 
         # Increase 10 iterations at once
         t.update(bigstep)
         # The next iterations should trigger maxinterval (step 5)
         for _ in _range(4):
             t.update(smallstep)
-            sleep(1e-2)
+            timer.sleep(1e-2)
 
         our_file.seek(0)
         out = our_file.read()
@@ -237,10 +266,13 @@ def test_max_interval():
 
     # Test iteration based tqdm with maxinterval effect
     with closing(StringIO()) as our_file:
-        for i in tqdm(_range(total), file=our_file, miniters=None,
-                      mininterval=1e-5, smoothing=1, maxinterval=1e-4):
+        t2 = tqdm(_range(total), file=our_file, miniters=None,
+                  mininterval=1e-5, smoothing=1, maxinterval=1e-4)
+        cpu_timify(t2, timer)
+
+        for i in t2:
             if i >= (bigstep - 1) and ((i - (bigstep - 1)) % smallstep) == 0:
-                sleep(1e-2)
+                timer.sleep(1e-2)
             if i >= 3 * bigstep:
                 break
 
@@ -321,10 +353,13 @@ def test_big_min_interval():
 
 def test_smoothed_dynamic_min_iters():
     """ Test smoothed dynamic miniters """
+    timer = DiscreteTimer()
+
     with closing(StringIO()) as our_file:
         total = 100
         t = tqdm(total=total, file=our_file, miniters=None, mininterval=0,
                  smoothing=0.5, maxinterval=0)
+        cpu_timify(t, timer)
 
         # Increase 10 iterations at once
         t.update(10)
@@ -349,6 +384,8 @@ def test_smoothed_dynamic_min_iters():
 
 def test_smoothed_dynamic_min_iters_with_min_interval():
     """ Test smoothed dynamic miniters with mininterval """
+    timer = DiscreteTimer()
+
     # Basically in this test, miniters should gradually decline
     with closing(StringIO()) as our_file:
         total = 100
@@ -356,20 +393,25 @@ def test_smoothed_dynamic_min_iters_with_min_interval():
         # Test manual updating tqdm
         t = tqdm(total=total, file=our_file, miniters=None, mininterval=1e-3,
                  smoothing=1, maxinterval=0)
+        cpu_timify(t, timer)
+
         t.update(10)
-        sleep(1e-2)
+        timer.sleep(1e-2)
         for _ in _range(4):
             t.update()
-            sleep(1e-2)
+            timer.sleep(1e-2)
         our_file.seek(0)
         out = our_file.read()
 
     with closing(StringIO()) as our_file:
         # Test iteration-based tqdm
-        for i in tqdm(_range(total), file=our_file, miniters=None,
-                      mininterval=0.01, smoothing=1, maxinterval=0):
+        t2 = tqdm(_range(total), file=our_file, miniters=None,
+                  mininterval=0.01, smoothing=1, maxinterval=0)
+        cpu_timify(t2, timer)
+
+        for i in t2:
             if i >= 10:
-                sleep(0.1)
+                timer.sleep(0.1)
             if i >= 14:
                 break
         our_file.seek(0)
@@ -497,10 +539,14 @@ def test_close():
 
 def test_smoothing():
     """ Test exponential weighted average smoothing """
+    timer = DiscreteTimer()
 
     # -- Test disabling smoothing
     with closing(StringIO()) as our_file:
-        for _ in tqdm(_range(3), file=our_file, smoothing=None, leave=True):
+        t = tqdm(_range(3), file=our_file, smoothing=None, leave=True)
+        cpu_timify(t, timer)
+
+        for _ in t:
             pass
         our_file.seek(0)
         assert '| 3/3 ' in our_file.read()
@@ -512,16 +558,21 @@ def test_smoothing():
         with closing(StringIO()) as our_file:
             t = tqdm(_range(3), file=our_file2, smoothing=None, leave=True,
                      miniters=1, mininterval=0)
-            for i in tqdm(_range(3), file=our_file, smoothing=None, leave=True,
-                          miniters=1, mininterval=0):
+            cpu_timify(t, timer)
+
+            t2 = tqdm(_range(3), file=our_file, smoothing=None, leave=True,
+                      miniters=1, mininterval=0)
+            cpu_timify(t2, timer)
+
+            for i in t2:
                 # Sleep more for first iteration and
                 # see how quickly rate is updated
                 if i == 0:
-                    sleep(0.01)
+                    timer.sleep(0.01)
                 else:
                     # Need to sleep in all iterations to calculate smoothed rate
                     # (else delta_t is 0!)
-                    sleep(0.001)
+                    timer.sleep(0.001)
                 t.update()
             # Get result for iter-based bar
             our_file.seek(0)
@@ -535,12 +586,17 @@ def test_smoothing():
         with closing(StringIO()) as our_file:
             t = tqdm(_range(3), file=our_file2, smoothing=1, leave=True,
                      miniters=1, mininterval=0)
-            for i in tqdm(_range(3), file=our_file, smoothing=1, leave=True,
-                          miniters=1, mininterval=0):
+            cpu_timify(t, timer)
+
+            t2 = tqdm(_range(3), file=our_file, smoothing=1, leave=True,
+                      miniters=1, mininterval=0)
+            cpu_timify(t2, timer)
+
+            for i in t2:
                 if i == 0:
-                    sleep(0.01)
+                    timer.sleep(0.01)
                 else:
-                    sleep(0.001)
+                    timer.sleep(0.001)
                 t.update()
             # Get result for iter-based bar
             our_file.seek(0)
@@ -554,12 +610,17 @@ def test_smoothing():
         with closing(StringIO()) as our_file:
             t = tqdm(_range(3), file=our_file2, smoothing=0.5, leave=True,
                      miniters=1, mininterval=0)
-            for i in tqdm(_range(3), file=our_file, smoothing=0.5, leave=True,
-                          miniters=1, mininterval=0):
+            cpu_timify(t, timer)
+
+            t2 = tqdm(_range(3), file=our_file, smoothing=0.5, leave=True,
+                      miniters=1, mininterval=0)
+            cpu_timify(t2, timer)
+
+            for i in t2:
                 if i == 0:
-                    sleep(0.01)
+                    timer.sleep(0.01)
                 else:
-                    sleep(0.001)
+                    timer.sleep(0.001)
                 t.update()
             # Get result for iter-based bar
             our_file.seek(0)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -767,42 +767,45 @@ def test_bar_format():
         for i in trange(2, file=our_file, leave=True, bar_format=bar_format):
             pass
         out = our_file.getvalue()
-    assert "\r  0%|          |0/2-0/20.0None?it/s00:00?\r" in out
+        assert "\r  0%|          |0/2-0/20.0None?it/s00:00?\r" in out
 
-    # Test unicode string auto conversion
-    bar_format = r'hello world'
-    t = tqdm(ascii=False, bar_format=bar_format)
-    assert isinstance(t.bar_format, _unicode)
+        # Test unicode string auto conversion
+        bar_format = r'hello world'
+        t = tqdm(file=our_file, ascii=False, bar_format=bar_format)
+        assert isinstance(t.bar_format, _unicode)
 
 
 def test_unpause():
     """ Test unpause """
+    timer = DiscreteTimer()
     with closing(StringIO()) as our_file:
         t = trange(10, file=our_file, leave=True, mininterval=0)
-        sleep(0.01)
+        cpu_timify(t, timer)
+        timer.sleep(0.01)
         t.update()
-        sleep(0.01)
+        timer.sleep(0.01)
         t.update()
-        sleep(0.1)  # longer wait time
+        timer.sleep(0.1)  # longer wait time
         t.unpause()
-        sleep(0.01)
+        timer.sleep(0.01)
         t.update()
-        sleep(0.01)
+        timer.sleep(0.01)
         t.update()
         t.close()
         r_before = progressbar_rate(get_bar(our_file.getvalue(), 2))
         r_after = progressbar_rate(get_bar(our_file.getvalue(), 3))
-    assert abs(r_before - r_after) < 1  # TODO: replace equal when DiscreteTimer
+    assert r_before == r_after
 
 
 def test_set_description():
     """ Test set description """
-    t = tqdm(desc='Hello')
-    assert t.desc == 'Hello: '
-    t.set_description('World')
-    assert t.desc == 'World: '
-    t.set_description()
-    assert t.desc == ''
+    with closing(StringIO()) as our_file:
+        t = tqdm(file=our_file, desc='Hello')
+        assert t.desc == 'Hello: '
+        t.set_description('World')
+        assert t.desc == 'World: '
+        t.set_description()
+        assert t.desc == ''
 
 
 def test_no_gui():


### PR DESCRIPTION
Should fix #59, #100 and #103 by using relative (cpu) timing (`time.process_time()` for Py3.3+ or `time.clock()` for Py2) instead of absolute timing (`time.time()`). This should allow to reliably execute the unit tests that are time dependent, even if the Travis server is suddenly overloaded in the middle of a test.

Signed-off-by: Stephen L. <lrq3000@gmail.com>