### PR TITLE
Add ipython/jupyter notebook support

### DIFF
--- a/tqdm/__init__.py
+++ b/tqdm/__init__.py
@@ -5,7 +5,9 @@ from ._tqdm import format_meter
 from ._tqdm_gui import tqdm_gui
 from ._tqdm_gui import tgrange
 from ._tqdm_pandas import tqdm_pandas
+from ._tqdm_notebook import tqdm_notebook
+from ._tqdm_notebook import tnrange
 from ._version import __version__  # NOQA
 
-__all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'format_interval',
-           'format_meter', 'tqdm_pandas', '__version__']
+__all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_notebook', 'tnrange',
+           'format_interval', 'format_meter', 'tqdm_pandas', '__version__']

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -70,7 +70,7 @@ def format_interval(t):
 
 
 def format_meter(n, total, elapsed, ncols=None, prefix='', ascii=False,
-                 unit='it', unit_scale=False, rate=None):
+                 unit='it', unit_scale=False, rate=None, notebook=False, nobar=False):
     """
     Return a string-based progress bar given some parameters
 
@@ -174,7 +174,10 @@ def format_meter(n, total, elapsed, ncols=None, prefix='', ascii=False,
             full_bar = bar + \
                 ' ' * max(N_BARS - bar_length, 0)
 
-        return l_bar + full_bar + r_bar
+        if nobar:
+            return l_bar[:-1] + ' ' + r_bar
+        else:
+            return l_bar + full_bar + r_bar
 
     # no total: no progressbar, ETA, just progress stats
     else:
@@ -194,7 +197,8 @@ def StatusPrinter(file):
 
     last_printed_len = [0]  # closure over mutable variable (fast)
 
-    def print_status(s):
+    def print_status(*args, **kwargs):
+        s = '' if args[0] is None else format_meter(*args, **kwargs)
         len_s = len(s)
         fp.write('\r' + s + ' ' * max(last_printed_len[0] - len_s, 0))
         fp.flush()
@@ -333,9 +337,9 @@ class tqdm(object):
             # Initialize the screen printer
             self.sp = StatusPrinter(self.fp)
             if not disable:
-                self.sp(format_meter(0, total, 0,
+                self.sp(0, total, 0,
                         (dynamic_ncols(file) if dynamic_ncols else ncols),
-                        self.desc, ascii, unit, unit_scale))
+                        self.desc, ascii, unit, unit_scale)
 
         # Init the time/iterations counters
         self.start_t = self.last_print_t = time()
@@ -405,11 +409,10 @@ class tqdm(object):
                                 else smoothing * delta_it / delta_t + \
                                 (1 - smoothing) * avg_rate
 
-                        sp(format_meter(
-                            n, self.total, elapsed,
+                        sp(n, self.total, elapsed,
                             (dynamic_ncols(self.fp) if dynamic_ncols
                              else ncols),
-                            self.desc, ascii, unit, unit_scale, avg_rate))
+                            self.desc, ascii, unit, unit_scale, avg_rate)
 
                         # If no `miniters` was specified, adjust automatically
                         # to the maximum iteration rate seen so far.
@@ -481,12 +484,11 @@ class tqdm(object):
                     raise DeprecationWarning('Please use tqdm_gui(...)'
                                              ' instead of tqdm(..., gui=True)')
 
-                self.sp(format_meter(
-                    self.n, self.total, elapsed,
+                self.sp(self.n, self.total, elapsed,
                     (self.dynamic_ncols(self.fp) if self.dynamic_ncols
                      else self.ncols),
                     self.desc, self.ascii, self.unit, self.unit_scale,
-                    self.avg_rate))
+                    self.avg_rate)
 
                 # If no `miniters` was specified, adjust automatically to the
                 # maximum iteration rate seen so far.
@@ -520,14 +522,13 @@ class tqdm(object):
             if self.last_print_n < self.n:
                 cur_t = time()
                 # stats for overall rate (no weighted average)
-                self.sp(format_meter(
-                    self.n, self.total, cur_t - self.start_t,
+                self.sp(self.n, self.total, cur_t - self.start_t,
                     (self.dynamic_ncols(self.fp) if self.dynamic_ncols
                      else self.ncols),
-                    self.desc, self.ascii, self.unit, self.unit_scale))
+                    self.desc, self.ascii, self.unit, self.unit_scale)
             self.fp.write('\n')
         else:
-            self.sp('')
+            self.sp(None)
             self.fp.write('\r')
 
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -70,8 +70,7 @@ def format_interval(t):
 
 
 def format_meter(n, total, elapsed, ncols=None, prefix='', ascii=False,
-                 unit='it', unit_scale=False, rate=None, notebook=False,
-                 nobar=False):
+                 unit='it', unit_scale=False, rate=None, nobar=False):
     """
     Return a string-based progress bar given some parameters
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -70,7 +70,8 @@ def format_interval(t):
 
 
 def format_meter(n, total, elapsed, ncols=None, prefix='', ascii=False,
-                 unit='it', unit_scale=False, rate=None, notebook=False, nobar=False):
+                 unit='it', unit_scale=False, rate=None, notebook=False,
+                 nobar=False):
     """
     Return a string-based progress bar given some parameters
 
@@ -485,10 +486,10 @@ class tqdm(object):
                                              ' instead of tqdm(..., gui=True)')
 
                 self.sp(self.n, self.total, elapsed,
-                    (self.dynamic_ncols(self.fp) if self.dynamic_ncols
-                     else self.ncols),
-                    self.desc, self.ascii, self.unit, self.unit_scale,
-                    self.avg_rate)
+                        (self.dynamic_ncols(self.fp) if self.dynamic_ncols
+                         else self.ncols),
+                        self.desc, self.ascii, self.unit, self.unit_scale,
+                        self.avg_rate)
 
                 # If no `miniters` was specified, adjust automatically to the
                 # maximum iteration rate seen so far.
@@ -523,9 +524,9 @@ class tqdm(object):
                 cur_t = time()
                 # stats for overall rate (no weighted average)
                 self.sp(self.n, self.total, cur_t - self.start_t,
-                    (self.dynamic_ncols(self.fp) if self.dynamic_ncols
-                     else self.ncols),
-                    self.desc, self.ascii, self.unit, self.unit_scale)
+                        (self.dynamic_ncols(self.fp) if self.dynamic_ncols
+                         else self.ncols),
+                        self.desc, self.ascii, self.unit, self.unit_scale)
             self.fp.write('\n')
         else:
             self.sp(None)

--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -1,0 +1,83 @@
+"""
+IPython/Jupyter Notebook progressbar decorator for iterators.
+Includes a default (x)range iterator printing to stderr.
+
+Usage:
+  >>> from tqdm_notebook import tnrange[, tqdm_notebook]
+  >>> for i in tnrange(10): #same as: for i in tqdm_notebook(xrange(10))
+  ...     ...
+"""
+# future division is important to divide integers and get as
+# a result precise floating numbers (instead of truncated int)
+from __future__ import division, absolute_import
+# import compatibility functions and utilities
+from ._utils import _range
+from time import time
+import sys
+# import IPython/Jupyter base widget and display utilities
+try:  # pragma: no cover
+    # For IPython 4.x using ipywidgets
+    from ipywidgets import IntProgress, HBox, HTML
+except ImportError:  # pragma: no cover
+    try:  # pragma: no cover
+        # For IPython 3.x
+        from IPython.html.widgets import IntProgress, HBox, HTML
+    except ImportError:  # pragma: no cover
+        # For IPython 2.x
+        from IPython.html.widgets import IntProgressWidget as IntProgress
+        from IPython.html.widgets import ContainerWidget as HBox
+        from IPython.html.widgets import HTML
+from IPython.display import display, clear_output
+# to inherit from the tqdm class
+from ._tqdm import tqdm, format_meter, StatusPrinter
+
+
+__author__ = {"github.com/": ["casperdcl", "lrq3000"]}
+__all__ = ['tqdm_notebook', 'tnrange']
+
+
+def NotebookPrinter(total=None):  # pragma: no cover
+    """
+    Manage the printing of an IPython/Jupyter Notebook progress bar widget.
+    """
+    if not total:
+        return StatusPrinter(sys.stdout)
+
+    pbar = IntProgress(min=0, max=total)
+    ptext = HTML()
+    # Only way to place text to the right of the bar is to use a container
+    container = HBox(children=[pbar, ptext])
+    display(container)
+    def print_status(*args, **kwargs):
+        #clear_output(wait=1)
+        if args[0]:
+            pbar.value = args[0]
+            ptext.value = format_meter(*args, nobar=True, **kwargs)
+        elif args[0] is None:
+            container.visible = False
+    return print_status
+
+
+class tqdm_notebook(tqdm):  # pragma: no cover
+    """
+    Experimental IPython/Jupyter Notebook widget using tqdm!
+    """
+    def __init__(self, *args, **kwargs):
+
+        kwargs['file'] = sys.stdout
+        super(tqdm_notebook, self).__init__(*args, **kwargs)
+
+        self.sp(None)
+        self.sp = NotebookPrinter(self.total)
+        if not self.disable:
+            self.sp(0, self.total, 0,
+                        (dynamic_ncols(self.file) if self.dynamic_ncols else self.ncols),
+                        self.desc, self.ascii, self.unit, self.unit_scale)
+
+
+def tnrange(*args, **kwargs):  # pragma: no cover
+    """
+    A shortcut for tqdm_notebook(xrange(*args), **kwargs).
+    On Python3+ range is used instead of xrange.
+    """
+    return tqdm_notebook(_range(*args), **kwargs)

--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -30,7 +30,7 @@ except ImportError:  # pragma: no cover
         except ImportError:  # pragma: no cover
             pass
 try:  # pragma: no cover
-    from IPython.display import display, clear_output
+    from IPython.display import display  # , clear_output
 except ImportError:  # pragma: no cover
     pass
 # to inherit from the tqdm class
@@ -60,7 +60,7 @@ def NotebookPrinter(total=None, desc=None):  # pragma: no cover
     display(container)
 
     def print_status(*args, **kwargs):
-        #clear_output(wait=1)
+        # clear_output(wait=1)
         # Update progress bar with new values
         if args[0] is not None:
             pbar.value = args[0]
@@ -90,8 +90,9 @@ class tqdm_notebook(tqdm):  # pragma: no cover
         # Print initial bar state
         if not self.disable:
             self.sp(0, self.total, 0,
-                        (dynamic_ncols(self.file) if self.dynamic_ncols else self.ncols),
-                        self.desc, self.ascii, self.unit, self.unit_scale)
+                    (self.dynamic_ncols(self.file) if self.dynamic_ncols
+                     else self.ncols),
+                    self.desc, self.ascii, self.unit, self.unit_scale)
 
 
 def tnrange(*args, **kwargs):  # pragma: no cover

--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -41,7 +41,7 @@ __author__ = {"github.com/": ["casperdcl", "lrq3000"]}
 __all__ = ['tqdm_notebook', 'tnrange']
 
 
-def NotebookPrinter(total=None):  # pragma: no cover
+def NotebookPrinter(total=None, desc=None):  # pragma: no cover
     """
     Manage the printing of an IPython/Jupyter Notebook progress bar widget.
     """
@@ -51,6 +51,8 @@ def NotebookPrinter(total=None):  # pragma: no cover
 
     # Prepare IPython progress bar
     pbar = IntProgress(min=0, max=total)
+    if desc:
+        pbar.description = desc
     # Prepare status text
     ptext = HTML()
     # Only way to place text to the right of the bar is to use a container
@@ -60,11 +62,11 @@ def NotebookPrinter(total=None):  # pragma: no cover
     def print_status(*args, **kwargs):
         #clear_output(wait=1)
         # Update progress bar with new values
-        if args[0]:
+        if args[0] is not None:
             pbar.value = args[0]
             ptext.value = format_meter(*args, nobar=True, **kwargs)
         # If n is None, then special signal to close the bar
-        elif args[0] is None:
+        else:
             container.visible = False
     return print_status
 
@@ -82,7 +84,10 @@ class tqdm_notebook(tqdm):  # pragma: no cover
         # Delete the text progress bar display
         self.sp(None)
         # Replace with IPython progress bar display
-        self.sp = NotebookPrinter(self.total)
+        self.sp = NotebookPrinter(self.total, self.desc)
+        self.desc = None  # trick to place description before the bar
+
+        # Print initial bar state
         if not self.disable:
             self.sp(0, self.total, 0,
                         (dynamic_ncols(self.file) if self.dynamic_ncols else self.ncols),

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -66,6 +66,8 @@ def test_format_meter():
         "100KiB [00:13, 7.69KiB/s]"
     assert format_meter(100, 1000, 12, ncols=0, rate=7.33) == \
         " 10% 100/1000 [00:12<02:02,  7.33it/s]"
+    assert format_meter(0, 1000, 13, nobar=True) == \
+        "  0% | 0/1000 [00:13<?,  0.00it/s]"
 
 
 def test_si_format():


### PR DESCRIPTION
Support for IPython/Jupyter notebook progress bar (fix for #50).

This should work on all IPython versions from v2-dev, but I only tested on the latest (Jupyter v4), but now the widgets API should be stable (this was not the case for IPython 3, there was an "experimental warning" message). Here's what it looks like:

![tqdm-ipython](https://cloud.githubusercontent.com/assets/1118942/11509633/75f2744e-985f-11e5-99c7-15c1ba8cb807.png)

Also, this supports inner progress bars up to any level:

```
from tqdm import tqdm_notebook, tnrange
from time import sleep
for i in tnrange(10, desc='1st loop', leave=True):
    for j in tnrange(100, desc='2nd loop'):
        sleep(0.01)
```

Result:
![tqdm-inner-pbar](https://cloud.githubusercontent.com/assets/1118942/11509373/0998977a-985e-11e5-83c5-01b0d92f2ee6.png)

To do it as cleanly as possible, I had to decouple format_meter() from tqdm() and moved it to StatusPrinter(). This will probably benefit to future derived classes (because they can define their own StatusPrinter() or format_meter() without having to redefine all tqdm functions). I also added a `nobar=False` argument to format_meter() to return only status indicators without the bar.

I didn't test the performance hit, I hope it's not significant. This should be assessed before merging.

Todo list (please help with your ideas! :D):
- [x] perf test if base tqdm() still has the same speed (after format_meter() decoupling)
- [x] perf quantify how much tqdm_notebook() is slower compares to base tqdm().
- [x] select one of the two bar designs: using ipywidgets or using custom HTML+JS+CSS ?
- [ ] coverage?
- [ ] add to readme
- [ ] bump version