### PR TITLE
fix nested + leave completed cursor placement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,10 +198,10 @@ Parameters
     Exponential moving average smoothing factor for speed estimates
     (ignored in GUI mode). Ranges from 0 (average speed) to 1
     (current/instantaneous speed) [default: 0.3].
-* nested  : bool, optional  
+* nested  : bool/int, optional  
     Whether this iterable is nested in another one also managed by
     `tqdm` [default: False]. Allows display of multiple, nested
-    progress bars.
+    progress bars. Most outer loop can specify total nesting depth.
 
 Returns
 ~~~~~~~
@@ -352,14 +352,15 @@ Nested progress bars
 
 ``tqdm`` supports nested progress bars, you just need to specify the
 `nested=True` argument for all tqdm instantiations except the **outermost**
-bar. Here's an example:
+bar, which should specify `nested=x` where x is the total number of nested
+loops to correctly place the cursor after the bars finish. Here's an example:
 
 .. code:: python
 
     from tqdm import trange
     from time import sleep
 
-    for i in trange(10, desc='1st loop', leave=True):
+    for i in trange(10, desc='1st loop', leave=True, nested=3):
         for j in trange(5, desc='2nd loop', leave=True, nested=True):
             for k in trange(100, desc='3nd loop', leave=True, nested=True):
                 sleep(0.01)

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,11 @@ Here's what the output looks like:
 Overhead is low -- about 60ns per iteration (80ns with ``gui=True``).
 By comparison, the well established
 `ProgressBar <https://code.google.com/p/python-progressbar/>`__ has
-an 800ns/iter overhead. It's a matter of taste, but we also like to think our
-version is much more visually appealing.
+an 800ns/iter overhead. In addition to its low overhead, ``tqdm`` uses smart
+algorithms to predict the remaining time and to skip useless iterations
+displays, which allows to make the overhead negligible in most cases.
+It's a matter of taste, but we also like to think our version is much more
+visually appealing.
 
 ``tqdm`` works on any platform (Linux/Windows/Mac), in any console or in a
 GUI, and is also friendly with IPython/Jupyter notebooks.

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ GUI, and is also friendly with IPython/Jupyter notebooks.
 
 .. contents:: Table of contents
    :backlinks: top
+   :local:
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -330,7 +330,7 @@ this by ourselves:
 ``process_content_with_progress2()`` is better than the naive approach because
 now we have predictive information:
 
-`` 50%|██████████████████████                      | 2/4 [00:00<00:00,  4.06it/s]``
+50%|██████████████████████\                      \| 2/4 [00:00<00:00,  4.06it/s]
 
 However, the progress is not smooth: it increments in steps, 1 step being
 1 file processed. The problem is that we do not just walk through files tree,
@@ -373,7 +373,7 @@ because ``tqdm`` will work on size, while the for loop works on files paths
 And here is the result: a much smoother progress bar with meaningful
 predicted time and statistics:
 
-`` 47%|██████████████████▍                    | 152K/321K [00:03<00:03, 46.2KB/s]``
+47%|██████████████████▍\                    \| 152K/321K [00:03<00:03, 46.2KB/s]
 
 Hooks and callbacks
 ~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,10 @@ version is much more visually appealing.
 ``tqdm`` works on any platform (Linux/Windows/Mac), in any console or in a
 GUI, and is also friendly with IPython/Jupyter notebooks.
 
+------------------------------------------
+
+.. contents:: Table of contents
+   :backlinks: top
 
 Installation
 ------------
@@ -469,14 +473,12 @@ Contributions
 To run the testing suite please make sure tox (http://tox.testrun.org/)
 is installed, then type ``tox`` from the command line.
 
-Alternatively if you don't want to use ``tox``, a Makefile is provided
-with the following commands:
+Alternatively if you don't want to use ``tox``, a Makefile-like setup is
+provided with the following command:
 
 .. code:: sh
 
-    $ make flake8
-    $ make test
-    $ make coverage
+    $ python setup.py make alltests
 
 See the `CONTRIBUTE <https://raw.githubusercontent.com/tqdm/tqdm/master/CONTRIBUTE>`__
 file for more information.

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ tqdm
 
 ``tqdm`` (read taqadum, تقدّم) means "progress" in arabic.
 
-Instantly make your loops show a progress meter - just wrap any
+Instantly make your loops show a smart progress meter - just wrap any
 iterable with "tqdm(iterable)", and you're done!
 
 .. code:: python
@@ -30,11 +30,11 @@ Here's what the output looks like:
 Overhead is low -- about 60ns per iteration (80ns with ``gui=True``).
 By comparison, the well established
 `ProgressBar <https://code.google.com/p/python-progressbar/>`__ has
-an 800ns/iter overhead. In addition to its low overhead, ``tqdm`` uses smart
-algorithms to predict the remaining time and to skip useless iterations
-displays, which allows to make the overhead negligible in most cases.
-It's a matter of taste, but we also like to think our version is much more
-visually appealing.
+an 800ns/iter overhead.
+
+In addition to its low overhead, ``tqdm`` uses smart algorithms to predict
+the remaining time and to skip unneccessary iteration displays, which allows
+for a negligible overhead in most cases.
 
 ``tqdm`` works on any platform (Linux/Windows/Mac), in any console or in a
 GUI, and is also friendly with IPython/Jupyter notebooks.
@@ -65,29 +65,29 @@ Pull and install in the current directory:
     pip install -e git+https://github.com/tqdm/tqdm.git@master#egg=tqdm
 
 Usage
--------------
+-----
 
-There are basically two ways of using ``tqdm``:
+``tqdm`` is very versatile and can be used in a number of ways.
+The two main ones are given below.
 
 Iterable-based
 ~~~~~~~~~~~~~~
 
-If you have an iterable, you can directly wrap ``tqdm()`` around your iterable:
+Wrap ``tqdm()`` around any iterable:
 
 .. code:: python
 
     for char in tqdm(["a", "b", "c", "d"]):
         print char
 
-``trange()`` is a special optimized instance of ``tqdm(range(x))``:
+``trange(i)`` is a special optimised instance of ``tqdm(range(i))``:
 
 .. code:: python
 
     for i in trange(100):
         pass
 
-You can also wrap ``tqdm()`` outside of the loop and assign to a variable,
-this allows you to still get a manual control over your progress bar:
+Instantiation outside of the loop allows for manual control over ``tqdm()``:
 
 .. code:: python
 
@@ -96,9 +96,9 @@ this allows you to still get a manual control over your progress bar:
         pbar.set_description("Processing %s" % char)
 
 Manual
-~~~~~~~
+~~~~~~
 
-You can have a manual control on ``tqdm()`` by using a ``with`` statement:
+Manual control on ``tqdm()`` updates by using a ``with`` statement:
 
 .. code:: python
 
@@ -106,10 +106,10 @@ You can have a manual control on ``tqdm()`` by using a ``with`` statement:
         for i in range(10):
             pbar.update(10)
 
-Note that ``total`` is optional, but specifying it (or an iterable with len)
-allows to display predictive stats.
+If the optional variable ``total`` (or an iterable with ``len()``) is
+provided, predictive stats are displayed.
 
-``with`` is also optional, you can just assign ``tqdm()`` to a variable,
+``with`` is also optional (you can just assign ``tqdm()`` to a variable,
 but in this case don't forget to ``close()`` at the end:
 
 .. code:: python
@@ -477,12 +477,18 @@ Contributions
 To run the testing suite please make sure tox (http://tox.testrun.org/)
 is installed, then type ``tox`` from the command line.
 
-Alternatively if you don't want to use ``tox``, a Makefile-like setup is
+Where ``tox`` is unavailable, a Makefile-like setup is
 provided with the following command:
 
 .. code:: sh
 
     $ python setup.py make alltests
+
+To see all options, run:
+
+.. code:: sh
+
+    $ python setup.py make
 
 See the `CONTRIBUTE <https://raw.githubusercontent.com/tqdm/tqdm/master/CONTRIBUTE>`__
 file for more information.

--- a/README.rst
+++ b/README.rst
@@ -316,8 +316,8 @@ no prediction:
 ``4it [00:03,  2.79it/s]``
 
 The way to get predictive information is to know the total amount of work to be
-done. Since os.walkdir() cannot give us this information, we need to precompute
-this by ourselves:
+done. Since ``os.walkdir()`` cannot give us this information, we need to
+precompute this by ourselves:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -373,7 +373,7 @@ because ``tqdm`` will work on size, while the for loop works on files paths
                         while (buf):
                             buf = fh.read(blocksize)
                             dosomething(buf)
-                            pbar.update(len(buf))
+                            if buf: pbar.update(len(buf))
 
 And here is the result: a much smoother progress bar with meaningful
 predicted time and statistics:

--- a/examples/simple_examples.py
+++ b/examples/simple_examples.py
@@ -19,6 +19,9 @@ stmts = (
     # Some decorations
     'import tqdm\nfor i in tqdm.trange(int(1e8), miniters=int(1e6),'
     ' ascii=True, desc="cool", dynamic_ncols=True):\n\tpass',
+    # Nested bars
+    'from tqdm import trange\nfor i in trange(10):\n\t'
+    'for j in trange(int(1e7), nested=True):\n\t\tpass',
     # Experimental GUI demo
     'import tqdm\nfor i in tqdm.tgrange(int(1e8)):\n\tpass',
     # Comparison to https://code.google.com/p/python-progressbar/

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -526,10 +526,6 @@ class tqdm(object):
         if self.disable:
             return
 
-        endchar = '\r'
-        if self.nested:
-            endchar += _term_move_up()
-
         if self.leave:
             if self.last_print_n < self.n:
                 cur_t = time()
@@ -539,13 +535,10 @@ class tqdm(object):
                     (self.dynamic_ncols(self.fp) if self.dynamic_ncols
                      else self.ncols),
                     self.desc, self.ascii, self.unit, self.unit_scale))
-            if self.nested:
-                self.fp.write(endchar)
-            else:
-                self.fp.write('\n')
+            self.fp.write('\r' + _term_move_up() if self.nested else '\n')
         else:
             self.sp('')
-            self.fp.write(endchar)
+            self.fp.write('\r' + _term_move_up() if self.nested else '\r')
 
     def set_description(self, desc=None):
         """

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -536,10 +536,15 @@ class tqdm(object):
                     (self.dynamic_ncols(self.fp) if self.dynamic_ncols
                      else self.ncols),
                     self.desc, self.ascii, self.unit, self.unit_scale))
-            self.fp.write('\r' + _term_move_up() if self.nested is True else '\n' * max(1, self.nested))
+            self.fp.write('\r' + _term_move_up() if self.nested is True
+                          else '\n')
         else:
             self.sp('')
-            self.fp.write('\r' + _term_move_up() if self.nested is True else '\r')
+            self.fp.write('\r' + _term_move_up() if self.nested is True
+                          else '\r')
+
+        if self.nested > 1:
+            self.fp.write('\n' * max(1, self.nested - self.leave))
 
     def set_description(self, desc=None):
         """

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -269,10 +269,10 @@ class tqdm(object):
             Exponential moving average smoothing factor for speed estimates
             (ignored in GUI mode). Ranges from 0 (average speed) to 1
             (current/instantaneous speed) [default: 0.3].
-        nested  : bool, optional
+        nested  : bool/int, optional
             Whether this iterable is nested in another one also managed by
             `tqdm` [default: False]. Allows display of multiple, nested
-            progress bars.
+            progress bars. Most outer loop can specify total nesting depth.
         gui  : bool, optional
             WARNING: internal parameter - do not use.
             Use tqdm_gui(...) instead. If set, will attempt to use
@@ -536,10 +536,10 @@ class tqdm(object):
                     (self.dynamic_ncols(self.fp) if self.dynamic_ncols
                      else self.ncols),
                     self.desc, self.ascii, self.unit, self.unit_scale))
-            self.fp.write('\r' + _term_move_up() if self.nested else '\n')
+            self.fp.write('\r' + _term_move_up() if self.nested is True else '\n' * max(1, self.nested))
         else:
             self.sp('')
-            self.fp.write('\r' + _term_move_up() if self.nested else '\r')
+            self.fp.write('\r' + _term_move_up() if self.nested is True else '\r')
 
     def set_description(self, desc=None):
         """

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -683,12 +683,51 @@ def test_nested():
                    '\r\x1b[A\rinner1 loop: 100%',
                    '\r\x1b[A\router0 loop: 100%',
                    '\n']
+
+    # Test 2 nested loops with leave and correct end cursor placement
+    our_file = StringIO()
+    for i in trange(2, file=our_file, miniters=1, mininterval=0,
+                    maxinterval=0, desc='outer0 loop', leave=True,
+                        nested=3):  # most outer loop must specify nesting depth
+        for j in trange(2, file=our_file, miniters=1, mininterval=0,
+                        maxinterval=0, desc='inner1 loop', leave=True,
+                        nested=True):
+            for k in trange(2, file=our_file, miniters=1, mininterval=0,
+                            maxinterval=0, desc='inner2 loop', leave=True,
+                            nested=True):
+                pass
+    our_file.seek(0)
+    out = our_file.read()
+    res = [m[0] for m in RE_nested2.findall(out)]
+    assert res == ['\n\router0 loop:   0%',
+                   '\n\rinner1 loop:   0%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r\x1b[A\rinner1 loop:  50%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r\x1b[A\rinner1 loop: 100%',
+                   '\r\x1b[A\router0 loop:  50%',
+                   '\n\rinner1 loop:   0%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r\x1b[A\rinner1 loop:  50%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r\x1b[A\rinner1 loop: 100%',
+                   '\r\x1b[A\router0 loop: 100%',
+                   '\n\n\n']
     # TODO: test degradation on windows without colorama?
 
 
 def test_set_description():
     """ Test set description """
-    t = tqdm(desc='Hello')
+    our_file = StringIO()
+    t = tqdm(desc='Hello', file=our_file)
     assert t.desc == 'Hello: '
     t.set_description('World')
     assert t.desc == 'World: '

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -688,7 +688,7 @@ def test_nested():
     our_file = StringIO()
     for i in trange(2, file=our_file, miniters=1, mininterval=0,
                     maxinterval=0, desc='outer0 loop', leave=True,
-                        nested=3):  # most outer loop must specify nesting depth
+                    nested=3):  # most outer loop must specify nesting depth
         for j in trange(2, file=our_file, miniters=1, mininterval=0,
                         maxinterval=0, desc='inner1 loop', leave=True,
                         nested=True):
@@ -726,7 +726,7 @@ def test_nested():
     our_file = StringIO()
     for i in trange(2, file=our_file, miniters=1, mininterval=0,
                     maxinterval=0, desc='outer0 loop', leave=True,
-                        nested=3):  # most outer loop must specify nesting depth
+                    nested=3):  # most outer loop must specify nesting depth
         for j in trange(2, file=our_file, miniters=1, mininterval=0,
                         maxinterval=0, desc='inner1 loop', leave=False,
                         nested=True):
@@ -737,7 +737,6 @@ def test_nested():
     our_file.seek(0)
     out = our_file.read()
     res = [m[0] for m in RE_nested2.findall(out)]
-    print(repr(res))
     assert res == ['\n\router0 loop:   0%',
                    '\n\rinner1 loop:   0%',
                    '\n\rinner2 loop:   0%',
@@ -762,6 +761,49 @@ def test_nested():
                    '\r      ',
                    '\r\x1b[A\router0 loop: 100%',
                    '\n\n\n']
+
+    # Test mixed leave again (leave only middle bar)
+    our_file = StringIO()
+    for i in trange(2, file=our_file, miniters=1, mininterval=0,
+                    maxinterval=0, desc='outer0 loop', leave=False,
+                    nested=3):  # most outer loop must specify nesting depth
+        for j in trange(2, file=our_file, miniters=1, mininterval=0,
+                        maxinterval=0, desc='inner1 loop', leave=True,
+                        nested=True):
+            for k in trange(2, file=our_file, miniters=1, mininterval=0,
+                            maxinterval=0, desc='inner2 loop', leave=False,
+                            nested=True):
+                pass
+    our_file.seek(0)
+    out = our_file.read()
+    res = [m[0] for m in RE_nested2.findall(out)]
+    assert res == ['\n\router0 loop:   0%',
+                   '\n\rinner1 loop:   0%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r      ',
+                   '\r\x1b[A\rinner1 loop:  50%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r      ',
+                   '\r\x1b[A\rinner1 loop: 100%',
+                   '\r\x1b[A\router0 loop:  50%',
+                   '\n\rinner1 loop:   0%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r      ',
+                   '\r\x1b[A\rinner1 loop:  50%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r      ',
+                   '\r\x1b[A\rinner1 loop: 100%',
+                   '\r\x1b[A\router0 loop: 100%',
+                   '\r      ',
+                   '\r\n\n\n']
     # TODO: test degradation on windows without colorama?
 
 

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -562,7 +562,7 @@ def test_smoothing():
 
 def test_nested():
     """ Test nested progress bars """
-    # Use regexp because the it rates can change
+    # Use regexp to break tqdm's output at each printing iteration
     RE_nested = re.compile(r'((\x1b\[A|\r|\n)+((outer|inner) loop:\s+\d+%|\s{3,6})?)')  # NOQA
     RE_nested2 = re.compile(r'((\x1b\[A|\r|\n)+((outer0|inner1|inner2) loop:\s+\d+%|\s{3,6})?)')  # NOQA
 
@@ -719,6 +719,47 @@ def test_nested():
                    '\rinner2 loop:  50%',
                    '\rinner2 loop: 100%',
                    '\r\x1b[A\rinner1 loop: 100%',
+                   '\r\x1b[A\router0 loop: 100%',
+                   '\n\n\n']
+
+    # Test mixed leave (middle bar will be erased at the end)
+    our_file = StringIO()
+    for i in trange(2, file=our_file, miniters=1, mininterval=0,
+                    maxinterval=0, desc='outer0 loop', leave=True,
+                        nested=3):  # most outer loop must specify nesting depth
+        for j in trange(2, file=our_file, miniters=1, mininterval=0,
+                        maxinterval=0, desc='inner1 loop', leave=False,
+                        nested=True):
+            for k in trange(2, file=our_file, miniters=1, mininterval=0,
+                            maxinterval=0, desc='inner2 loop', leave=True,
+                            nested=True):
+                pass
+    our_file.seek(0)
+    out = our_file.read()
+    res = [m[0] for m in RE_nested2.findall(out)]
+    print(repr(res))
+    assert res == ['\n\router0 loop:   0%',
+                   '\n\rinner1 loop:   0%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r\x1b[A\rinner1 loop:  50%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r\x1b[A\rinner1 loop: 100%',
+                   '\r      ',
+                   '\r\x1b[A\router0 loop:  50%',
+                   '\n\rinner1 loop:   0%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r\x1b[A\rinner1 loop:  50%',
+                   '\n\rinner2 loop:   0%',
+                   '\rinner2 loop:  50%',
+                   '\rinner2 loop: 100%',
+                   '\r\x1b[A\rinner1 loop: 100%',
+                   '\r      ',
                    '\r\x1b[A\router0 loop: 100%',
                    '\n\n\n']
     # TODO: test degradation on windows without colorama?


### PR DESCRIPTION
Example usage:

```
from tqdm import trange
from time import sleep
lv = True
ns = True
for i in trange(2, desc='outer0 loop', leave=True, nested=4):
    for j in trange(3, desc='inner1 loop', leave=lv, nested=ns):
        for k in trange(4, desc='inner2 loop', leave=lv, nested=ns):
            for l in trange(100, desc='inner3 loop', leave=lv, nested=ns):
                sleep(0.005)
```

Need to:
- [x] Fix unit test for 100% coverage
- [ ] rebase and fix conflicts