### PR TITLE
Add tqdm.unpause()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,9 +139,9 @@ Documentation
 
       def __init__(self, iterable=None, desc=None, total=None, leave=False,
                    file=sys.stderr, ncols=None, mininterval=0.1,
-                   maxinterval= 10.0, miniters=None, ascii=None,
+                   maxinterval=10.0, miniters=None, ascii=None,
                    disable=False, unit='it', unit_scale=False,
-                   dynamic_ncols=False, smoothing=0.3, nested =False,
+                   dynamic_ncols=False, smoothing=0.3, nested=False,
                    bar_format=None, initial=0, gui=False):
 
 Parameters

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -590,6 +590,14 @@ class tqdm(object):
             self.sp('')  # clear up last bar
             self.fp.write('\r' + _term_move_up() if self.nested else '\r')
 
+    def unpause(self):
+        """
+        Restart tqdm timer from last print time.
+        """
+        cur_t = time()
+        self.start_t += cur_t - self.last_print_t
+        self.last_print_t = cur_t
+
     def set_description(self, desc=None):
         """
         Set/modify description of the progress bar.

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -240,9 +240,9 @@ class tqdm(object):
     """
     def __init__(self, iterable=None, desc=None, total=None, leave=False,
                  file=sys.stderr, ncols=None, mininterval=0.1,
-                 maxinterval= 10.0, miniters=None, ascii=None,
+                 maxinterval=10.0, miniters=None, ascii=None,
                  disable=False, unit='it', unit_scale=False,
-                 dynamic_ncols=False, smoothing=0.3, nested =False,
+                 dynamic_ncols=False, smoothing=0.3, nested=False,
                  bar_format=None, initial=0, gui=False):
         """
         Parameters

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -36,6 +36,10 @@ except NameError:
 
 RE_rate = re.compile(r'(\d+\.\d+)it/s')
 
+def get_bar(all_bars, i):
+    """ Get a specific update from a whole bar traceback """
+    return all_bars.strip('\r').split('\r')[i]
+
 
 def progressbar_rate(bar_str):
     return float(RE_rate.search(bar_str).group(1))
@@ -520,10 +524,10 @@ def test_smoothing():
                 t.update()
             # Get result for iter-based bar
             our_file.seek(0)
-            a = progressbar_rate(our_file.read().strip('\r').split('\r')[3])
+            a = progressbar_rate(get_bar(our_file.read(), 3))
         # Get result for manually updated bar
         our_file2.seek(0)
-        a2 = progressbar_rate(our_file2.read().strip('\r').split('\r')[3])
+        a2 = progressbar_rate(get_bar(our_file2.read(), 3))
 
     # 2nd case: use max smoothing (= instant rate)
     with closing(StringIO()) as our_file2:
@@ -539,10 +543,10 @@ def test_smoothing():
                 t.update()
             # Get result for iter-based bar
             our_file.seek(0)
-            b = progressbar_rate(our_file.read().strip('\r').split('\r')[3])
+            b = progressbar_rate(get_bar(our_file.read(), 3))
         # Get result for manually updated bar
         our_file2.seek(0)
-        b2 = progressbar_rate(our_file2.read().strip('\r').split('\r')[3])
+        b2 = progressbar_rate(get_bar(our_file2.read(), 3))
 
     # 3rd case: use medium smoothing
     with closing(StringIO()) as our_file2:
@@ -558,10 +562,10 @@ def test_smoothing():
                 t.update()
             # Get result for iter-based bar
             our_file.seek(0)
-            c = progressbar_rate(our_file.read().strip('\r').split('\r')[3])
+            c = progressbar_rate(get_bar(our_file.read(), 3))
         # Get result for manually updated bar
         our_file2.seek(0)
-        c2 = progressbar_rate(our_file2.read().strip('\r').split('\r')[3])
+        c2 = progressbar_rate(get_bar(our_file2.read(), 3))
 
     # Check that medium smoothing's rate is between no and max smoothing rates
     assert a < c < b
@@ -707,6 +711,26 @@ def test_bar_format():
     bar_format = r'hello world'
     t = tqdm(ascii=False, bar_format=bar_format)
     assert isinstance(t.bar_format, _unicode)
+
+
+def test_unpause():
+    """ Test unpause """
+    with closing(StringIO()) as our_file:
+        t = trange(10, file=our_file, leave=True, mininterval=0)
+        sleep(0.01)
+        t.update()
+        sleep(0.01)
+        t.update()
+        sleep(0.1)  # longer wait time
+        t.unpause()
+        sleep(0.01)
+        t.update()
+        sleep(0.01)
+        t.update()
+        t.close()
+        r_before = progressbar_rate(get_bar(our_file.getvalue(), 2))
+        r_after = progressbar_rate(get_bar(our_file.getvalue(), 3))
+    assert abs(r_before - r_after) < 1  # TODO: replace equal when DiscreteTimer
 
 
 def test_set_description():

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -36,6 +36,7 @@ except NameError:
 
 RE_rate = re.compile(r'(\d+\.\d+)it/s')
 
+
 def get_bar(all_bars, i):
     """ Get a specific update from a whole bar traceback """
     return all_bars.strip('\r').split('\r')[i]


### PR DESCRIPTION
Complement PR #74 to fix #73 and #70.

`tqdm.unpause()` allows to start back where the last printing left off. This is interesting because then we don't need to implement a `pause()` method, nor create any new internal variable. Thus, this should work for all subclasses.

Example:

```
from tqdm import trange
from time import sleep
t = trange(10, leave=True)
sleep(0.5)
t.update()
sleep(0.5)
t.update()
sleep(2) # longer wait time
t.unpause()
sleep(0.5)
t.update()
sleep(0.5)
t.update()
t.close()
```

The rate and ETA should stay stable all along.