### PR TITLE
Add performance test via bytecode opcode analysis

### DIFF
--- a/tqdm/tests/bytecode_tracer/__init__.py
+++ b/tqdm/tests/bytecode_tracer/__init__.py
@@ -1,0 +1,3 @@
+from .bytecode_tracer import BytecodeTracer, rewrite_function
+
+__all__ = ['BytecodeTracer', 'rewrite_function']

--- a/tqdm/tests/bytecode_tracer/bytecode_tracer.py
+++ b/tqdm/tests/bytecode_tracer/bytecode_tracer.py
@@ -1,0 +1,293 @@
+import opcode
+import os
+import re
+
+from types import CodeType, MethodType
+
+from . import code_rewriting_importer
+
+from .py_frame_object import get_value_stack_top
+
+
+class ValueStack(object):
+    """CPython stack that holds values used and generated during computation.
+
+    Right before a function call value stack looks like this:
+
+        +---------------------  <--- frame.f_valuestack
+        | function object
+        +----------
+        | ...
+        | list of positional arguments
+        | ...
+        +----------
+        | ...
+        | flat list of keyword arguments (key-value pairs)
+        | ...
+        +----------
+        | *varargs tuple
+        +----------
+        | **kwargs dictionary
+        +---------------------  <--- frame.f_stacktop
+
+    When a function is called with no arguments, the function object is at the
+    top of the stack. When arguments are present, they are placed above the
+    function object. Two bytes after the CALL_FUNCTION bytecode contain number
+    of positional and keyword arguments passed. Bytecode number tells us whether
+    a call included single star (*args) and/or double star (**kwargs) arguments.
+
+    To get to the values at the stack we look at it from the top, from
+    frame.f_stacktop downwards. Since f_stacktop points at the memory right
+    after the last value, all offsets have to be negative. For example,
+    frame.f_stacktop[-1] is an object at the top of the value stack.
+    """
+    def __init__(self, frame, bcode):
+        assert bcode.name.startswith("CALL_FUNCTION")
+
+        self.stack = get_value_stack_top(frame)
+        self.positional_args_count = bcode.arg1
+        self.keyword_args_count = bcode.arg2
+        self.args_count = self.positional_args_count + 2*self.keyword_args_count
+
+        # There are four bytecodes for function calls, that tell use whether
+        # single star (*args) and/or double star (**kwargs) notation was
+        # used: CALL_FUNCTION, CALL_FUNCTION_VAR, CALL_FUNCTION_KW
+        # and CALL_FUNCTION_VAR_KW.
+        self.singlestar = "_VAR" in bcode.name
+        self.doublestar = "_KW" in bcode.name
+
+    def bottom(self):
+        """The first object at the value stack.
+
+        It's the function being called for all CALL_FUNCTION_* bytecodes.
+        """
+        offset = 1 + self.args_count + self.singlestar + self.doublestar
+        return self.stack[-offset]
+
+    def positional_args(self):
+        """List of all positional arguments passed to a C function.
+        """
+        args = self.positional_args_from_stack()[:]
+        if self.singlestar:
+            args.extend(self.positional_args_from_varargs())
+        return args
+
+    def values(self, offset, count):
+        """Return a list of `count` values from stack starting at `offset`.
+        """
+        def v():
+            for i in range(-offset, -offset + count):
+                yield self.stack[i]
+        return list(v())
+
+    def positional_args_from_stack(self):
+        """Objects explicitly placed on stack as positional arguments.
+        """
+        offset = self.args_count + self.singlestar + self.doublestar
+        return self.values(offset, self.positional_args_count)
+
+    def positional_args_from_varargs(self):
+        """Iterable placed on stack as "*args".
+        """
+        return self.stack[-1 - self.doublestar]
+
+    def keyword_args(self):
+        """Dictionary of all keyword arguments passed to a C function.
+        """
+        kwds = self.keyword_args_from_stack().copy()
+        if self.doublestar:
+            kwds.update(self.keyword_args_from_double_star())
+        return kwds
+
+    def keyword_args_from_stack(self):
+        """Key/value pairs placed explicitly on stack as keyword arguments.
+        """
+        offset = 2*self.keyword_args_count + self.singlestar + self.doublestar
+        args = self.values(offset, 2*self.keyword_args_count)
+        return flatlist_to_dict(args)
+
+    def keyword_args_from_double_star(self):
+        """Dictionary passed as "**kwds".
+        """
+        return self.stack[-1]
+
+
+def flatlist_to_dict(alist):
+    return dict(zip(alist[::2], alist[1::2]))
+
+class Bytecode(object):
+    def __init__(self, name, arg1=None, arg2=None):
+        self.name = name
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+def current_bytecode(frame):
+    code = frame.f_code.co_code[frame.f_lasti:]
+    op = ord(code[0])
+    name = opcode.opname[op]
+    arg1, arg2 = None, None
+    if op >= opcode.HAVE_ARGUMENT:
+        arg1 = ord(code[1])
+        arg2 = ord(code[2])
+    return Bytecode(name=name, arg1=arg1, arg2=arg2)
+
+def is_c_func(func):
+    """Return True if given function object was implemented in C,
+    via a C extension or as a builtin.
+
+    >>> is_c_func(repr)
+    True
+    >>> import sys
+    >>> is_c_func(sys.exit)
+    True
+    >>> import doctest
+    >>> is_c_func(doctest.testmod)
+    False
+    """
+    return not hasattr(func, 'func_code')
+
+
+class BytecodeTracer(object):
+    """A tracer that goes over each bytecode and reports events that couldn't
+    be traced by other means.
+
+    Usage example:
+        def trace(frame, event, arg):
+            bytecode_events = list(btracer.trace(frame, event))
+            if bytecode_events:
+                for ev, rest in bytecode_events:
+                    pass # Here handle BytecodeTracer events, like 'c_call', 'c_return', 'print' or 'print_to'.
+            else:
+                pass # Here handle the usual tracer events, like 'call', 'return' and 'exception'.
+            return trace
+        sys.settrace(trace)
+        try:
+            pass # Some code to trace... You may need to call rewrite_function first.
+        finally:
+            sys.settrace(None)
+    """
+    def __init__(self):
+        # Will contain False for calls to Python functions and True for calls to
+        # C functions.
+        self.call_stack = []
+
+    def setup(self):
+        code_rewriting_importer.install(rewrite_lnotab)
+
+    def teardown(self):
+        code_rewriting_importer.uninstall()
+
+    def trace(self, frame, event):
+        """Tries to recognize the current event in terms of calls to and returns
+        from C.
+
+        Currently supported events:
+         * ('c_call', (function, positional_arguments, keyword_arguments))
+           A call to a C function with given arguments is about to happen.
+         * ('c_return', return_value)
+           A C function returned with given value (it will always be the function
+           for the most recent 'c_call' event.
+         * ('print', value)
+         * ('print_to', (value, output))
+           A print statement is about to be executed.
+
+        It is a generator and it yields a sequence of events, as a single
+        bytecode may generate more than one event. Canonical example is
+        a sequence of CALL_FUNCTION bytecodes. Execution of the first bytecode
+        causes a 'c_call' event. Execution of the second bytecode causes two
+        consecutive events: 'c_return' and another 'c_call'.
+        """
+        if event == 'line':
+            if self.call_stack[-1]:
+                self.call_stack.pop()
+                stack = get_value_stack_top(frame)
+                # Rewrite a code object each time it is returned by some
+                # C function. Most commonly that will be the 'compile' function.
+                # TODO: Make sure the old code is garbage collected.
+                if type(stack[-1]) is CodeType:
+                    stack[-1] = rewrite_lnotab(stack[-1])
+                yield 'c_return', stack[-1]
+            bcode = current_bytecode(frame)
+            if bcode.name.startswith("CALL_FUNCTION"):
+                value_stack = ValueStack(frame, bcode)
+                function = value_stack.bottom()
+                # Python functions are handled by the standard trace mechanism, but
+                # we have to make sure any C calls the function makes can be traced
+                # by us later, so we rewrite its bytecode.
+                if not is_c_func(function):
+                    rewrite_function(function)
+                    return
+                self.call_stack.append(True)
+                pargs = value_stack.positional_args()
+                kargs = value_stack.keyword_args()
+                # Rewrite all callables that may have been passed to the C function.
+                rewrite_all(pargs + kargs.values())
+                yield 'c_call', (function, pargs, kargs)
+            elif bcode.name == "PRINT_NEWLINE":
+                yield 'print', os.linesep
+            elif bcode.name == "PRINT_NEWLINE_TO":
+                stack = get_value_stack_top(frame)
+                yield 'print_to', (os.linesep, stack[-1])
+            elif bcode.name == "PRINT_ITEM":
+                stack = get_value_stack_top(frame)
+                yield 'print', stack[-1]
+            elif bcode.name == "PRINT_ITEM_TO":
+                stack = get_value_stack_top(frame)
+                yield 'print_to', (stack[-2], stack[-1])
+        elif event == 'call':
+            self.call_stack.append(False)
+        # When an exception happens in Python code, 'exception' and 'return' events
+        # are reported in succession. Exceptions raised from C functions don't
+        # generate the 'return' event, so we have to pop from the stack right away.
+        elif event == 'exception' and self.call_stack[-1]:
+            self.call_stack.pop()
+        # Python functions always generate a 'return' event, even when an exception
+        # has been raised, so let's just check for that.
+        elif event == 'return':
+            self.call_stack.pop()
+
+def rewrite_lnotab(code):
+    """Replace a code object's line number information to claim that every
+    byte of the bytecode is a new line. Returns a new code object.
+    Also recurses to hack the line numbers in nested code objects.
+
+    Based on Ned Batchelder's hackpyc.py:
+      http://nedbatchelder.com/blog/200804/wicked_hack_python_bytecode_tracing.html
+    """
+    if has_been_rewritten(code):
+        return code
+    n_bytes = len(code.co_code)
+    new_lnotab = "\x01\x01" * (n_bytes-1)
+    new_consts = []
+    for const in code.co_consts:
+        if type(const) is CodeType:
+            new_consts.append(rewrite_lnotab(const))
+        else:
+            new_consts.append(const)
+    return CodeType(code.co_argcount, code.co_nlocals, code.co_stacksize,
+        code.co_flags, code.co_code, tuple(new_consts), code.co_names,
+        code.co_varnames, code.co_filename, code.co_name, 0, new_lnotab,
+        code.co_freevars, code.co_cellvars)
+
+def rewrite_function(function):
+    if isinstance(function, MethodType):
+        function = function.im_func
+    function.func_code = rewrite_lnotab(function.func_code)
+
+def rewrite_all(objects):
+    for obj in objects:
+        if hasattr(obj, 'func_code'):
+            rewrite_function(obj)
+
+def has_been_rewritten(code):
+    """Return True if the code has been rewritten by rewrite_lnotab already.
+
+    >>> def fun():
+    ...     pass
+    >>> has_been_rewritten(fun.func_code)
+    False
+    >>> rewrite_function(fun)
+    >>> has_been_rewritten(fun.func_code)
+    True
+    """
+    return re.match(r"\A(\x01\x01)+\Z", code.co_lnotab) is not None

--- a/tqdm/tests/bytecode_tracer/code_rewriting_importer.py
+++ b/tqdm/tests/bytecode_tracer/code_rewriting_importer.py
@@ -1,0 +1,118 @@
+"""
+Custom importer that additionally rewrites code of all imported modules.
+
+Based on Demo/imputil/importers.py file distributed with Python 2.x.
+"""
+
+import imp
+import imputil
+import marshal
+import os
+import struct
+import sys
+
+from types import CodeType
+
+# byte-compiled file suffic character
+_suffix_char = __debug__ and 'c' or 'o'
+
+# byte-compiled file suffix
+_suffix = '.py' + _suffix_char
+
+# the C_EXTENSION suffixes
+_c_suffixes = filter(lambda x: x[2] == imp.C_EXTENSION, imp.get_suffixes())
+
+
+def _timestamp(pathname):
+    "Return the file modification time as a Long."
+    try:
+        s = os.stat(pathname)
+    except OSError:
+        return None
+    return long(s[8])
+
+def _compile(path):
+    "Read and compile Python source code from file."
+    f = open(path)
+    c = f.read()
+    f.close()
+    return compile(c, path, 'exec')
+
+def _fs_import(dir, modname, fqname):
+    "Fetch a module from the filesystem."
+
+    pathname = os.path.join(dir, modname)
+    if os.path.isdir(pathname):
+        values = { '__pkgdir__' : pathname, '__path__' : [ pathname ] }
+        ispkg = 1
+        pathname = os.path.join(pathname, '__init__')
+    else:
+        values = { }
+        ispkg = 0
+
+        # look for dynload modules
+        for desc in _c_suffixes:
+            file = pathname + desc[0]
+            try:
+                fp = open(file, desc[1])
+            except IOError:
+                pass
+            else:
+                module = imp.load_module(fqname, fp, file, desc)
+                values['__file__'] = file
+                return 0, module, values
+
+    t_py = _timestamp(pathname + '.py')
+    t_pyc = _timestamp(pathname + _suffix)
+    if t_py is None and t_pyc is None:
+        return None
+    code = None
+    if t_py is None or (t_pyc is not None and t_pyc >= t_py):
+        file = pathname + _suffix
+        f = open(file, 'rb')
+        if f.read(4) == imp.get_magic():
+            t = struct.unpack('<I', f.read(4))[0]
+            if t == t_py:
+                code = marshal.load(f)
+        f.close()
+    if code is None:
+        file = pathname + '.py'
+        code = _compile(file)
+
+    values['__file__'] = file
+    return ispkg, code, values
+
+class PathImporter(imputil.Importer):
+    def __init__(self, path, callback):
+        self.path = path
+        self.callback = callback
+
+    def rewrite(self, retvals):
+        if isinstance(retvals, tuple) and type(retvals[1]) == CodeType:
+            return (retvals[0], self.callback(retvals[1]), retvals[2])
+        return retvals
+
+    def get_code(self, parent, modname, fqname):
+        if parent:
+            # we are looking for a module inside of a specific package
+            return self.rewrite(_fs_import(parent.__pkgdir__, modname, fqname))
+
+        # scan sys.path, looking for the requested module
+        for dir in self.path:
+            if isinstance(dir, str):
+                result = _fs_import(dir, modname, fqname)
+                if result:
+                    return self.rewrite(result)
+
+        # not found
+        return None
+
+import_manager = imputil.ImportManager()
+
+def install(callback):
+    "Install callback as a code-rewriting function for each imported module."
+    import_manager.install()
+    sys.path.insert(0, PathImporter(sys.path, callback))
+
+def uninstall():
+    import_manager.uninstall()

--- a/tqdm/tests/bytecode_tracer/py_frame_object.py
+++ b/tqdm/tests/bytecode_tracer/py_frame_object.py
@@ -1,0 +1,39 @@
+"""Definition of PyFrameObject CPython's structure in ctypes. With this you can
+get into frame internals without going to the C level.
+
+See frameobject.h for reference:
+  http://svn.python.org/view/python/trunk/Include/frameobject.h?view=markup
+
+Note that not all fields are defined, only those that I needed.
+"""
+
+from ctypes import c_int, c_long, py_object, cast, Structure, POINTER
+
+
+ssize_t = c_long
+
+class PyFrameObject(Structure):
+    _fields_ = [("ob_refcnt", ssize_t),
+                ("ob_type", py_object),
+                ("ob_size", ssize_t),
+                ("f_back", py_object),
+                ("f_code", py_object),
+                ("f_builtins", py_object),
+                ("f_globals", py_object),
+                ("f_locals", py_object),
+                ("f_valuestack", POINTER(py_object)),
+                ("f_stacktop", POINTER(py_object)),
+                ("f_trace", py_object),
+                ("f_exc_type", py_object),
+                ("f_exc_value", py_object),
+                ("f_exc_traceback", py_object),
+                ("f_tstate", py_object),
+                ("f_lasti", c_int),
+                ("f_lineno", c_int),
+                ("f_iblock", c_int)]
+
+def _frame_internals(frame):
+    return cast(id(frame), POINTER(PyFrameObject)).contents
+
+def get_value_stack_top(frame):
+    return _frame_internals(frame).f_stacktop

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -1,4 +1,15 @@
+from __future__ import print_function, division
+
+from nose.plugins.skip import SkipTest
+
+from contextlib import contextmanager
+
+import inspect
+import re
+import sys
 from time import time
+from bytecode_tracer import BytecodeTracer
+from bytecode_tracer import rewrite_function
 
 from tqdm import trange
 from tqdm import tqdm
@@ -30,6 +41,116 @@ def tic():
 
 def toc():
     return time() - _tic_toc[0]
+
+
+btracer = BytecodeTracer()
+
+
+def trace(frame, event, arg):
+    '''Custom tracer callback with bytecode offset instead of line number'''
+    bytecode_events = list(btracer.trace(frame, event))
+    if bytecode_events:
+        for ev, rest in bytecode_events:
+            if ev == 'c_call':
+                func, pargs, kargs = rest
+                print("C_CALL", func.__name__, repr(pargs), repr(kargs))
+            elif ev == 'c_return':
+                print("C_RETURN", repr(rest))
+            elif ev == 'print':
+                print("PRINT", repr(rest))
+            elif ev == 'print_to':
+                value, output = rest
+                print("PRINT_TO", repr(value), repr(output))
+            else:
+                print("C_OTHER:", repr(value), repr(rest))
+    else:
+        if event == 'call':
+            args = inspect.getargvalues(frame)
+            try:
+                args = str(args)
+            except Exception:
+                args = "<unknown>"
+            print("CALL", frame.f_code.co_name, args)
+        elif event == 'return':
+            print("RETURN", frame.f_code.co_name, repr(arg))
+        elif event == 'exception':
+            print("EXCEPTION", arg)
+        elif event == 'line':
+            # Most important statement for us: show each executed line and its
+            # bytecode offset
+            print("LINE", frame.f_code.co_filename, frame.f_lineno)
+        else:
+            print("OTHER", event, frame.f_code.co_name, repr(arg))
+    return trace
+
+
+@contextmanager
+def captureStdOut(output):
+    '''Capture stdout temporarily, use along a with statement'''
+    stdout = sys.stdout
+    sys.stdout = output
+    yield
+    sys.stdout = stdout
+
+
+def getOpcodes(func, *args, **kwargs):
+    '''Get the bytecode opcodes for a function'''
+    # Redirect all printed outputs to a variable
+    out = StringIO()
+    with captureStdOut(out):
+        # Setup bytecode tracer
+        btracer.setup()
+
+        #  dis.dis(func)  # not needed in our case
+
+        # Rewrite the function to allow bytecode tracing
+        rewrite_function(func)
+
+        # Start the tracing
+        sys.settrace(trace)
+        try:
+            # Execute the function
+            func(*args, **kwargs)
+        finally:
+            # Stop the tracer
+            sys.settrace(None)
+            btracer.teardown()
+
+    return out
+
+
+def getOpcodesCount(func, *args, **kwargs):
+    '''Get the total number of bytecode opcodes for a function'''
+    out = getOpcodes(func, *args, **kwargs)
+
+    # Filter tracing events to keep only executed lines
+    opcodes = [s for s in out.getvalue().split('\n')
+               if s.startswith('LINE') or s.startswith('C_CALL')]
+
+    # Return the total number of opcodes
+    return len(opcodes)
+
+
+def getOpcodesCountHard(func, *args, **kwargs):
+    '''Get the total number of bytecode opcodes for a function (pessimistic)'''
+    out = getOpcodes(func, *args, **kwargs)
+
+    # Hard mode: extract bytecode offsets and get the highest number for each
+    # sequence, this should theoretically compute the exact timesteps taken for
+    # each statement.
+    # TODO: not sure this is correct, we may be overestimating a lot!
+    RE_opcodes = re.compile(r'\S+\s+\S+\s+(\d+)')
+    opcodes = [s for s in out.getvalue().split('\n') if s.startswith('LINE')]
+    opcodes_offsets = [int(RE_opcodes.search(s).group(1))
+                       if s.startswith('LINE') else 0 for s in opcodes]
+
+    opcodes_total = 0
+    for i in _range(1, len(opcodes_offsets)):
+        if opcodes_offsets[i] <= opcodes_offsets[i - 1]:
+            opcodes_total += opcodes_offsets[i]
+    opcodes_total += opcodes_offsets[-1]
+
+    return opcodes_total
 
 
 def test_iter_overhead():
@@ -83,3 +204,78 @@ def test_manual_overhead():
     except AssertionError:
         raise AssertionError('tqdm(%g): %f, range(%g): %f' %
                              (total, time_tqdm, total, time_bench))
+
+
+def test_iter_overhead_hard_opcodes():
+    """ Test overhead of iteration based tqdm (hard with opcodes) """
+    try:
+        import imputil
+    except ImportError:
+        raise SkipTest
+
+    total = int(10)
+
+    def f1():
+        with closing(StringIO()) as our_file:
+            a = 0
+            for i in trange(total, file=our_file, leave=True,
+                            miniters=1, mininterval=0, maxinterval=0):
+                a += i
+            assert(a == (total * total - total) / 2.0)
+
+    def f2():
+        with closing(StringIO()) as our_file:
+            a = 0
+            for i in _range(total):
+                a += i
+                our_file.write(("%i" % a) * 40)
+
+    # Compute opcodes overhead of tqdm against native range()
+    count1 = getOpcodesCount(f1)
+    count2 = getOpcodesCount(f2)
+    count1h = getOpcodesCountHard(f1)
+    count2h = getOpcodesCountHard(f2)
+    try:
+        assert(count1 < 7 * count2)
+        # assert(count1h < 20 * count2h)  # useless to test static bytecode
+    except AssertionError:
+        raise AssertionError('trange(%g): %i-%i, range(%g): %i-%i' %
+                             (total, count1, count1h, total, count2, count2h))
+
+
+def test_manual_overhead_hard_opcodes():
+    """ Test overhead of manual tqdm (hard with opcodes) """
+    try:
+        import imputil
+    except ImportError:
+        raise SkipTest
+
+    total = int(10)
+
+    def f1():
+        with closing(StringIO()) as our_file:
+            t = tqdm(total=total * 10, file=our_file, leave=True,
+                     miniters=1, mininterval=0, maxinterval=0)
+            a = 0
+            for i in _range(total):
+                a += i
+                t.update(10)
+
+    def f2():
+        with closing(StringIO()) as our_file:
+            a = 0
+            for i in _range(total):
+                a += i
+                our_file.write(("%i" % a) * 40)
+
+    # Compute opcodes overhead of tqdm against native range()
+    count1 = getOpcodesCount(f1)
+    count2 = getOpcodesCount(f2)
+    count1h = getOpcodesCountHard(f1)
+    count2h = getOpcodesCountHard(f2)
+    try:
+        assert(count1 < 20 * count2)
+        # assert(count1h < 20 * count2h)  # useless to test static bytecode
+    except AssertionError:
+        raise AssertionError('tqdm(%g): %i-%i, range(%g): %i-%i' %
+                             (total, count1, count1h, total, count2, count2h))


### PR DESCRIPTION
This PR provides dynamic bytecode opcodes analysis in `tests_perf.py`, to compare the number of opcodes required to run `tqdm` vs a native `range()`.

The idea is to run `tqdm` and dynamically analyze the number of bytecode opcodes executed at runtime for a standard run. This would provide a way to discretize and virtualize the time taken to run `tqdm` compared to native `range`.

The problem is that it works only on Python 2.x because the required library [bytecode_tracer](https://github.com/mkwiatkowski/bytecode-hack) requires `implib`, but `implib` was removed from Python 3.x and replaced by `importlib`, but the API is quite different. On the other hand, `importlib` wasn't backported to Python 2.x. We should thus rewrite `code_rewriting_importer.py` to use `implib` on Py2 and `importlib` on Py3, I don't think it should be a lot of work for someone with experience in making `custom importers`, but I don't have this experience so I cannot do much more.

TODO:
- [ ] Fix [bytecode_tracer](https://github.com/mkwiatkowski/bytecode-hack) Py3 compatibility (ie, need to use `importlib` instead of `implib` in `code_rewriting_importer.py`).
- [ ] Fix nosetests trying to test `bytecode_tracer` module.
