### PR TITLE
Async coroutine support

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, division
 from .utils import _supports_unicode, _screen_shape_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
     Comparable, _is_ascii, FormatReplace, disp_len, disp_trim, \
-    SimpleTextIOWrapper, CallbackIOWrapper, _coroutine
+    SimpleTextIOWrapper, CallbackIOWrapper, coroutine
 from ._monitor import TMonitor
 # native libraries
 from contextlib import contextmanager
@@ -1095,12 +1095,12 @@ class tqdm(Comparable):
     def __hash__(self):
         return id(self)
 
-    @_coroutine
+    @coroutine
     def __aiter__(self):
         self.start()
         return self
 
-    @_coroutine
+    @coroutine
     def __anext__(self):
         try:
             self.update()
@@ -1108,6 +1108,9 @@ class tqdm(Comparable):
         except StopIteration:
             self.close()
             raise StopAsyncIteration
+        except:
+            self.close()
+            raise
 
     def __iter__(self):
         """Backward-compatibility to use: for x in tqdm(iterable)"""

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, division
 from .utils import _supports_unicode, _screen_shape_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
     Comparable, _is_ascii, FormatReplace, disp_len, disp_trim, \
-    SimpleTextIOWrapper, CallbackIOWrapper
+    SimpleTextIOWrapper, CallbackIOWrapper, _coroutine
 from ._monitor import TMonitor
 # native libraries
 from contextlib import contextmanager
@@ -1094,6 +1094,20 @@ class tqdm(Comparable):
 
     def __hash__(self):
         return id(self)
+
+    @_coroutine
+    def __aiter__(self):
+        self.start()
+        return self
+
+    @_coroutine
+    def __anext__(self):
+        try:
+            self.update()
+            return next(self.iterable)
+        except StopIteration:
+            self.close()
+            raise StopAsyncIteration
 
     def __iter__(self):
         """Backward-compatibility to use: for x in tqdm(iterable)"""

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -57,6 +57,12 @@ if True:  # pragma: no cover
     except NameError:
         _basestring = str
 
+    try:
+        from asyncio import coroutine
+    except ImportError:
+        def coroutine(func):
+            return func
+
     try:  # py>=2.7,>=3.1
         from collections import OrderedDict as _OrderedDict
     except ImportError:
@@ -357,14 +363,6 @@ def _environ_cols_wrapper():  # pragma: no cover
 
 def _term_move_up():  # pragma: no cover
     return '' if (os.name == 'nt') and (colorama is None) else '\x1b[A'
-
-
-try:
-    from asyncio import coroutine
-    _coroutine = coroutine
-except ImportError:
-    def _coroutine(func):
-        return func
 
 
 try:

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -360,6 +360,14 @@ def _term_move_up():  # pragma: no cover
 
 
 try:
+    from asyncio import coroutine
+    _coroutine = coroutine
+except ImportError:
+    def _coroutine(func):
+        return func
+
+
+try:
     # TODO consider using wcswidth third-party package for 0-width characters
     from unicodedata import east_asian_width
 except ImportError:


### PR DESCRIPTION
Add asynchronized coroutine support in `tqdm` as proposed in #65.

Code thank's to @aplavin, from [here](https://github.com/aplavin/ipy-progressbar/blob/5c2f9a8cfe1e92e0ec2ceb741e92519e73d5b6b7/ipy_progressbar/base.py) and [here](https://github.com/aplavin/ipy-progressbar/commit/324148943f3a133b1d34325f36302673a6d10649).

This code wasn't tested out, can someone devise an example case? (I'm inexperienced with Python coroutines :S).
