### PR TITLE
Fix over-estimated rate

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 noamraph
+Copyright (c) 2016 noamraph, Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -457,7 +457,7 @@ class tqdm(object):
                     if delta_t >= mininterval:
                         elapsed = cur_t - start_t
                         # EMA (not just overall average)
-                        if smoothing and delta_t:
+                        if smoothing:
                             avg_time = delta_t / delta_it \
                                 if avg_time is None \
                                 else smoothing * delta_t / delta_it + \
@@ -530,7 +530,7 @@ class tqdm(object):
             if delta_t >= self.mininterval:
                 elapsed = cur_t - self.start_t
                 # EMA (not just overall average)
-                if self.smoothing and delta_t:
+                if self.smoothing:
                     self.avg_time = delta_t / delta_it \
                         if self.avg_time is None \
                         else self.smoothing * delta_t / delta_it + \

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -376,7 +376,7 @@ class tqdm(object):
         self.gui = gui
         self.dynamic_ncols = dynamic_ncols
         self.smoothing = smoothing
-        self.avg_rate = None
+        self.avg_time = None
         # if nested, at initial sp() call we replace '\r' by '\n' to
         # not overwrite the outer progress bar
         self.nested = nested
@@ -435,7 +435,7 @@ class tqdm(object):
             n = self.n
             dynamic_ncols = self.dynamic_ncols
             smoothing = self.smoothing
-            avg_rate = self.avg_rate
+            avg_time = self.avg_time
             bar_format = self.bar_format
 
             try:
@@ -458,17 +458,17 @@ class tqdm(object):
                         elapsed = cur_t - start_t
                         # EMA (not just overall average)
                         if smoothing and delta_t:
-                            avg_rate = delta_it / delta_t \
-                                if avg_rate is None \
-                                else smoothing * delta_it / delta_t + \
-                                (1 - smoothing) * avg_rate
+                            avg_time = delta_t / delta_it \
+                                if avg_time is None \
+                                else smoothing * delta_t / delta_it + \
+                                (1 - smoothing) * avg_time
 
                         sp(format_meter(
                             n, self.total, elapsed,
                             (dynamic_ncols(self.fp) if dynamic_ncols
                              else ncols),
-                            self.desc, ascii, unit, unit_scale, avg_rate,
-                            bar_format))
+                            self.desc, ascii, unit, unit_scale,
+                            1 / avg_time if avg_time else None, bar_format))
 
                         # If no `miniters` was specified, adjust automatically
                         # to the maximum iteration rate seen so far.
@@ -531,10 +531,10 @@ class tqdm(object):
                 elapsed = cur_t - self.start_t
                 # EMA (not just overall average)
                 if self.smoothing and delta_t:
-                    self.avg_rate = delta_it / delta_t \
-                        if self.avg_rate is None \
-                        else self.smoothing * delta_it / delta_t + \
-                        (1 - self.smoothing) * self.avg_rate
+                    self.avg_time = delta_t / delta_it \
+                        if self.avg_time is None \
+                        else self.smoothing * delta_t / delta_it + \
+                        (1 - self.smoothing) * self.avg_time
 
                 if not hasattr(self, "sp"):
                     raise DeprecationWarning('Please use tqdm_gui(...)'
@@ -545,7 +545,7 @@ class tqdm(object):
                     (self.dynamic_ncols(self.fp) if self.dynamic_ncols
                      else self.ncols),
                     self.desc, self.ascii, self.unit, self.unit_scale,
-                    self.avg_rate, self.bar_format))
+                    1 / self.avg_time if self.avg_time else None, self.bar_format))
 
                 # If no `miniters` was specified, adjust automatically to the
                 # maximum iteration rate seen so far.

--- a/tqdm/_tqdm_gui.py
+++ b/tqdm/_tqdm_gui.py
@@ -116,7 +116,7 @@ class tqdm_gui(tqdm):  # pragma: no cover
         n = self.n
         # dynamic_ncols = self.dynamic_ncols
         smoothing = self.smoothing
-        avg_rate = self.avg_rate
+        avg_time = self.avg_time
         bar_format = self.bar_format
 
         plt = self.plt
@@ -141,10 +141,10 @@ class tqdm_gui(tqdm):  # pragma: no cover
                     elapsed = cur_t - start_t
                     # EMA (not just overall average)
                     if smoothing and delta_t:
-                        avg_rate = delta_it / delta_t \
-                            if avg_rate is None \
-                            else smoothing * delta_it / delta_t + \
-                            (1 - smoothing) * avg_rate
+                        avg_time = delta_t / delta_it \
+                            if avg_time is None \
+                            else smoothing * delta_t / delta_it + \
+                            (1 - smoothing) * avg_time
 
                     # Inline due to multiple calls
                     total = self.total
@@ -194,8 +194,8 @@ class tqdm_gui(tqdm):  # pragma: no cover
 
                     ax.set_title(format_meter(
                         n, total, elapsed, 0,
-                        self.desc, ascii, unit, unit_scale, avg_rate,
-                        bar_format),
+                        self.desc, ascii, unit, unit_scale,
+                        1 / avg_time if avg_time else None, bar_format),
                         fontname="DejaVu Sans Mono", fontsize=11)
                     plt.pause(1e-9)
 
@@ -243,10 +243,10 @@ class tqdm_gui(tqdm):  # pragma: no cover
                 elapsed = cur_t - self.start_t
                 # EMA (not just overall average)
                 if self.smoothing and delta_t:
-                    self.avg_rate = delta_it / delta_t \
-                        if self.avg_rate is None \
-                        else self.smoothing * delta_it / delta_t + \
-                        (1 - self.smoothing) * self.avg_rate
+                    self.avg_time = delta_t / delta_it \
+                        if self.avg_time is None \
+                        else self.smoothing * delta_t / delta_it + \
+                        (1 - self.smoothing) * self.avg_time
 
                 # Inline due to multiple calls
                 total = self.total
@@ -298,7 +298,7 @@ class tqdm_gui(tqdm):  # pragma: no cover
                 ax.set_title(format_meter(
                     self.n, total, elapsed, 0,
                     self.desc, self.ascii, self.unit, self.unit_scale,
-                    self.avg_rate, self.bar_format),
+                    1 / self.avg_time if self.avg_time else None, self.bar_format),
                     fontname="DejaVu Sans Mono", fontsize=11)
                 self.plt.pause(1e-9)
 

--- a/tqdm/_tqdm_gui.py
+++ b/tqdm/_tqdm_gui.py
@@ -140,7 +140,7 @@ class tqdm_gui(tqdm):  # pragma: no cover
                 if delta_t >= mininterval:  # pragma: no cover
                     elapsed = cur_t - start_t
                     # EMA (not just overall average)
-                    if smoothing and delta_t:
+                    if smoothing:
                         avg_time = delta_t / delta_it \
                             if avg_time is None \
                             else smoothing * delta_t / delta_it + \
@@ -242,7 +242,7 @@ class tqdm_gui(tqdm):  # pragma: no cover
             if delta_t >= self.mininterval:
                 elapsed = cur_t - self.start_t
                 # EMA (not just overall average)
-                if self.smoothing and delta_t:
+                if self.smoothing:
                     self.avg_time = delta_t / delta_it \
                         if self.avg_time is None \
                         else self.smoothing * delta_t / delta_it + \


### PR DESCRIPTION
The formula of average rate should be something similar to
`1/average(t for t in samples)`. But current implementation is similar to
`average(1/t for t in samples)`, which is incorrect.

Following code can demo this problem
```python
import random
import time
from tqdm import trange

for i in trange(10000, smoothing=0.01, leave=True, miniters=1, mininterval=0, ncols=0):
    time.sleep(random.random() / 100)
```

Output before this fix:
```
100% 10000/10000 [00:53<00:00, 413.96it/s]
```
After:
```
100% 10000/10000 [00:54<00:00, 187.06it/s]
```
10000/54=185.18 near 187.06