### PR TITLE
Fix for IronPython 2.7

### DIFF
--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -41,11 +41,11 @@ def _environ_cols_wrapper():  # pragma: no cover
     import platform
     current_os = platform.system()
     _environ_cols = None
-    if current_os in {'Windows', 'cli'}:
+    if current_os in ['Windows', 'cli']:
         _environ_cols = _environ_cols_windows
         if _environ_cols is None:
             _environ_cols = _environ_cols_tput
-    if current_os in {'Linux', 'Darwin', 'SunOS', 'FreeBSD'} or \
+    if current_os in ['Linux', 'Darwin', 'SunOS', 'FreeBSD'] or \
             current_os.startswith('CYGWIN'):
         _environ_cols = _environ_cols_linux
     return _environ_cols

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -41,11 +41,11 @@ def _environ_cols_wrapper():  # pragma: no cover
     import platform
     current_os = platform.system()
     _environ_cols = None
-    if current_os == 'Windows':
+    if current_os in {'Windows', 'cli'}:
         _environ_cols = _environ_cols_windows
         if _environ_cols is None:
             _environ_cols = _environ_cols_tput
-    if current_os in ['Linux', 'Darwin', 'SunOS', 'FreeBSD'] or \
+    if current_os in {'Linux', 'Darwin', 'SunOS', 'FreeBSD'} or \
             current_os.startswith('CYGWIN'):
         _environ_cols = _environ_cols_linux
     return _environ_cols


### PR DESCRIPTION
fix for:

    File "tqdm\_tqdm.py", line 337, in __init__
    TypeError: NoneType is not callable

in IronPython