### PR TITLE
Better handling of `tqdm.update(n)` where `n<1`

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -531,7 +531,7 @@ class tqdm(object):
             return
 
         if n < 1:
-            n = 1
+            raise ValueError("n cannot be below 1")
         self.n += n
 
         delta_it = self.n - self.last_print_n  # should be n?


### PR DESCRIPTION
I know this is a bit of an opinion/pedantic-heavy change, but it is something that threw me off. `.update(-5)` will increase the progress by 1, which I don't think is desired by anyone who enters that.

Regardless if whether a progress bar can decrease or not (which I'm assuming is currently "not"), if someone types in `.update(-5)` or any other negative number, they do not expect an increase, and so it is unexpected behavior unless that person reads the source-code of tqdm.

If this change isn't accepted, I would suggest either adding support for decreasing the value, or noting the behavior in the documentation.