### PR TITLE
Fixed setup.py so that it doesn't throw encoding error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,8 @@ if sys.argv[1].lower().strip() == 'make':
 
 
 README_rst = ''
-with open('README.rst', 'r', encoding = 'utf-8') as fd:
+import io
+with io.open('README.rst', mode = 'r', encoding = 'utf-8') as fd:
     README_rst = fd.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ if sys.argv[1].lower().strip() == 'make':
 
 
 README_rst = ''
-with open('README.rst', 'r') as fd:
+with open('README.rst', 'r', encoding = 'utf-8') as fd:
     README_rst = fd.read()
 
 setup(


### PR DESCRIPTION
Without this change, the installation via python setup.py install is broken in certain Windows system with encoding set to other than 'utf-8'.

Without specifying the encoding of the README file, the open defaults to system config encoding, which doesn't have to be 'utf-8'. Opening the file in UTF-8 mode fixes that.

Traceback of the error thrown without the fix:

`Traceback (most recent call last):
  File "setup.py", line 156, in <module>
    README_rst = fd.read()
  File "C:\Users\n0272436\Downloads\WinPython-32bit-3.4.3.4\python-3.4.3\lib\encodings\cp1252.py", line 23,
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 17233: character maps to <undefined>
`