### PR TITLE
Travis Py32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ branches:  # remove travis double-check on pull requests in main repo
 env:
   - TOXENV=py26
   - TOXENV=py27
-  - TOXENV=py32
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=py35


### PR DESCRIPTION
travis has dropped support for py32, see #112 and:

- https://travis-ci.org/tqdm/tqdm/jobs/103891787
- https://travis-ci.org/tqdm/tqdm/jobs/103908760

Basically the latest version of pip uses the "u" prefix notation for unicode which py32 doesn't like. It's not tqdm's fault so I've left py32 in the tox env list. It's just a Travis environment issue.