### PR TITLE
Print message

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,6 +256,21 @@ Returns
           Cleanup and (if leave=False) close the progressbar.
           """
 
+      def clear(self):
+          """
+          Clear current bar display
+          """
+
+      def refresh(self):
+          """
+          Force refresh the display of this bar
+          """
+
+      def write(cls, s, file=sys.stdout, end="\n"):
+          """
+          Print a message via tqdm (without overlap with bars)
+          """
+
     def trange(*args, **kwargs):
         """
         A shortcut for tqdm(xrange(*args), **kwargs).
@@ -389,6 +404,28 @@ For manual control over positioning (e.g. for multi-threaded use),
 you may specify `position=n` where `n=0` for the outermost bar,
 `n=1` for the next, and so on.
 
+Writing messages
+~~~~~~~~~~~~~~~~~~~~
+Since ``tqdm`` uses a simple printing mechanism to display progress bars,
+you should not write any message in the terminal using ``print()``.
+
+To write messages in the terminal without any collision with ``tqdm`` bar
+display, a ``.write()`` method is provided:
+
+.. code:: python
+
+    from tqdm import tqdm, trange
+    from time import sleep
+
+    bar = trange(10)
+    for i in bar:
+        # Print using tqdm class method .write()
+        tqdm.write("Done task %i" % i)
+        # Can also use instance method bar.write()
+
+By default, this will print to standard output ``sys.stdout``. but you can
+specify any file-like object using the ``file`` argument. For example, this
+can be used to redirect the messages writing to a log file or class.
 
 How to make a good progress bar
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -784,8 +784,9 @@ class tqdm(object):
         Force refresh the display of this bar
         """
         self.moveto(self.pos)
+        # clear up line (can't rely on sp(''))
         self.fp.write('\r')
-        self.fp.write(' ' * self.ncols)  # clear up line (can't rely on sp(''))
+        self.fp.write(' ' * (self.ncols if self.ncols else 10))
         self.fp.write('\r')
         # Print current/last bar state
         self.fp.write(self.__repr__())
@@ -796,8 +797,9 @@ class tqdm(object):
         Clear current bar display
         """
         self.moveto(self.pos)
+        # clear up this bar
         self.fp.write('\r')
-        self.fp.write(' ' * self.ncols)  # clear up this bar
+        self.fp.write(' ' * (self.ncols if self.ncols else 10))
         self.fp.write('\r')  # place cursor back at the beginning of line
         self.moveto(-self.pos)
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -779,28 +779,28 @@ class tqdm(object):
     def moveto(self, n):
         self.fp.write(_unicode('\n' * n + _term_move_up() * -n))
 
+    def clear(self, nomove=False):
+        """
+        Clear current bar display
+        """
+        if not nomove:
+            self.moveto(self.pos)
+        # clear up the bar (can't rely on sp(''))
+        self.fp.write('\r')
+        self.fp.write(' ' * (self.ncols if self.ncols else 10))
+        self.fp.write('\r')  # place cursor back at the beginning of line
+        if not nomove:
+            self.moveto(-self.pos)
+
     def refresh(self):
         """
         Force refresh the display of this bar
         """
         self.moveto(self.pos)
-        # clear up line (can't rely on sp(''))
-        self.fp.write('\r')
-        self.fp.write(' ' * (self.ncols if self.ncols else 10))
-        self.fp.write('\r')
+        # clear up this line's content (whatever there was)
+        self.clear(nomove=True)
         # Print current/last bar state
         self.fp.write(self.__repr__())
-        self.moveto(-self.pos)
-
-    def clear(self):
-        """
-        Clear current bar display
-        """
-        self.moveto(self.pos)
-        # clear up this bar
-        self.fp.write('\r')
-        self.fp.write(' ' * (self.ncols if self.ncols else 10))
-        self.fp.write('\r')  # place cursor back at the beginning of line
         self.moveto(-self.pos)
 
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -254,10 +254,13 @@ class tqdm(object):
                 n_fmt, unit, elapsed_str, rate_fmt)
 
     def __new__(cls, *args, **kwargs):
+        # Create a new instance
         instance = object.__new__(cls)
+        # Add to the list of instances
         if "_instances" not in cls.__dict__:
             cls._instances = WeakSet()
         cls._instances.add(instance)
+        # Return the instance
         return instance
 
     @classmethod
@@ -284,6 +287,22 @@ class tqdm(object):
                     inst.pos -= 1
         except KeyError:
             pass
+
+    @classmethod
+    def write(cls, s, file=sys.stdout, end="\n"):
+        """
+        Print a message via tqdm (without overlap with bars)
+        """
+        # Clear all bars
+        for inst in cls._instances:
+            inst.clear()
+        # Write the message
+        file.write(s)
+        file.write(end)
+        # Force refresh display of all bars
+        for inst in cls._instances:
+            inst.refresh()
+        # TODO: make a list with all instances including absolutely positioned ones?
 
     def __init__(self, iterable=None, desc=None, total=None, leave=True,
                  file=sys.stderr, ncols=None, mininterval=0.1,
@@ -759,6 +778,23 @@ class tqdm(object):
 
     def moveto(self, n):
         self.fp.write(_unicode('\n' * n + _term_move_up() * -n))
+
+    def refresh(self):
+        """
+        Force refresh the display of this bar
+        """
+        self.moveto(self.pos)
+        self.fp.write(self.__repr__())
+        self.moveto(-self.pos)
+
+    def clear(self):
+        """
+        Clear current bar display
+        """
+        self.moveto(self.pos)
+        self.sp('')  # clear up this bar
+        self.fp.write('\r')  # place cursor back at the beginning of line
+        self.moveto(-self.pos)
 
 
 def trange(*args, **kwargs):

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -616,8 +616,8 @@ class tqdm(object):
                                     (1 - smoothing) * miniters
 
                         # Store old values for next call
-                        last_print_n = n
-                        last_print_t = cur_t
+                        self.n = self.last_print_n = last_print_n = n
+                        self.last_print_t = last_print_t = cur_t
 
             # Closing the progress bar.
             # Update some internal variables for close().
@@ -784,6 +784,10 @@ class tqdm(object):
         Force refresh the display of this bar
         """
         self.moveto(self.pos)
+        self.fp.write('\r')
+        self.fp.write(' ' * self.ncols)  # clear up line (can't rely on sp(''))
+        self.fp.write('\r')
+        # Print current/last bar state
         self.fp.write(self.__repr__())
         self.moveto(-self.pos)
 
@@ -792,7 +796,8 @@ class tqdm(object):
         Clear current bar display
         """
         self.moveto(self.pos)
-        self.sp('')  # clear up this bar
+        self.fp.write('\r')
+        self.fp.write(' ' * self.ncols)  # clear up this bar
         self.fp.write('\r')  # place cursor back at the beginning of line
         self.moveto(-self.pos)
 


### PR DESCRIPTION
Should fix #116 as discussed in #113.

This adds a `tqdm.write()` class method (but can be used as classical method too on an instanciated `tqdm` object) to write messages without overlapping on bars (which would effectively overwrite any message the user would be trying to write). This PR also adds two instance methods: `clear()` and `refresh()`.

How it does that: it simply clears up all bars, then print the messages at position 0, and then force refresh the display of all bars, below the printed messages. All this is done by the class, so it has full control on all instances.

Canonical example (the sleeps are there just to have the time to see what happens):

```
from tqdm import tqdm
from time import sleep

t1 = tqdm(total=10, desc='pos0 bar')
t2 = tqdm(total=10, desc='pos1 bar')
t3 = tqdm(total=10, desc='pos2 bar')
sleep(1)
tqdm.write("Hello world")
sleep(1)
t1.update()
t3.update()
t2.update()
sleep(1)
t3.write("Bye world")
sleep(2)
```

NOTE: This PR builds up on `positioned-tqdm` branch, so we should first finish it and then after we should rebase and merge this PR.

TODO:
- [x] Add to readme
- [x] Check that it works with iterable tqdm
- [x] Add unit tests
- [x] Rebase on final `positioned-tqdm` branch
- [ ] Bump version