### PR TITLE
update docs about `leave` parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,7 @@ Parameters
     True and this parameter needs subsequent updating, specify an
     initial arbitrary large positive integer, e.g. int(9e9).
 * leave  : bool, optional  
-    If [default: True], removes all traces of the progressbar
+    If [default: True], keeps all traces of the progressbar
     upon termination of iteration.
 * file  : `io.TextIOWrapper` or `io.StringIO`, optional  
     Specifies where to output the progress messages

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -303,7 +303,7 @@ class tqdm(object):
             True and this parameter needs subsequent updating, specify an
             initial arbitrary large positive integer, e.g. int(9e9).
         leave  : bool, optional
-            If [default: True], removes all traces of the progressbar
+            If [default: True], keeps all traces of the progressbar
             upon termination of iteration.
         file  : `io.TextIOWrapper` or `io.StringIO`, optional
             Specifies where to output the progress messages


### PR DESCRIPTION
It seems that `leave == True` means keep, but old docs say it means remove