### PR TITLE
Add no rate inversion option in bar_format

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -234,7 +234,12 @@ class tqdm(object):
                             'total': total,
                             'total_fmt': total_fmt,
                             'percentage': percentage,
-                            'rate': rate,
+                            'rate': rate if inv_rate is None else inv_rate,
+                            'rate_noinv': rate,
+                            'rate_noinv_fmt': ((format_sizeof(rate)
+                                                    if unit_scale else
+                                                    '{0:5.2f}'.format(rate))
+                                                    if rate else '?') + 'it/s',
                             'rate_fmt': rate_fmt,
                             'elapsed': elapsed_str,
                             'remaining': remaining_str,


### PR DESCRIPTION
Fix issue #144 by providing two variables `rate_noinv` and `rate_noinv_fmt` in `bar_format` to always display the "not inversed" rate.

Also, this PR fix the issue that the `rate` in `bar_format` was always non inversed, whereas it should be inversed when `rate < 1`.