### PR TITLE
Fix bar_format breaking console display

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -222,7 +222,7 @@ class tqdm(object):
                     # Format left/right sides of the bar, and format the bar
                     # later in the remaining space (avoid breaking display)
                     l_bar_user, r_bar_user = bar_format.split('{bar}')
-                    l_bar, r_bar = l_bar.format(**bar_args), r_bar.format(**bar_args)
+                    l_bar, r_bar = l_bar_user.format(**bar_args), r_bar_user.format(**bar_args)
                 else:
                     # Else no progress bar, we can just format and return
                     return bar_format.format(**bar_args)

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -207,7 +207,7 @@ class tqdm(object):
                             'rate_noinv_fmt': ((format_sizeof(rate)
                                                     if unit_scale else
                                                     '{0:5.2f}'.format(rate))
-                                                    if rate else '?') + 'it/s',
+                                                    if rate else '?') + unit + '/s',
                             'rate_fmt': rate_fmt,
                             'elapsed': elapsed_str,
                             'remaining': remaining_str,

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -194,6 +194,40 @@ class tqdm(object):
             if ncols == 0:
                 return l_bar[:-1] + r_bar[1:]
 
+            if bar_format:
+                # Custom bar formatting
+                # Populate a dict with all available progress indicators
+                bar_args = {'n': n,
+                            'n_fmt': n_fmt,
+                            'total': total,
+                            'total_fmt': total_fmt,
+                            'percentage': percentage,
+                            'rate': rate if inv_rate is None else inv_rate,
+                            'rate_noinv': rate,
+                            'rate_noinv_fmt': ((format_sizeof(rate)
+                                                    if unit_scale else
+                                                    '{0:5.2f}'.format(rate))
+                                                    if rate else '?') + 'it/s',
+                            'rate_fmt': rate_fmt,
+                            'elapsed': elapsed_str,
+                            'remaining': remaining_str,
+                            'l_bar': l_bar,
+                            'r_bar': r_bar,
+                            'desc': prefix if prefix else '',
+                            # 'bar': full_bar  # replaced by procedure below
+                            }
+
+                # Interpolate supplied bar format with the dict
+                if '{bar}' in bar_format:
+                    # Format left/right sides of the bar, and format the bar
+                    # later in the remaining space (avoid breaking display)
+                    l_bar_user, r_bar_user = bar_format.split('{bar}')
+                    l_bar, r_bar = l_bar.format(**bar_args), r_bar.format(**bar_args)
+                else:
+                    # Else no progress bar, we can just format and return
+                    return bar_format.format(**bar_args)
+
+            # Formatting progress bar
             # space available for bar's display
             N_BARS = max(1, ncols - len(l_bar) - len(r_bar)) if ncols \
                 else 10
@@ -222,28 +256,8 @@ class tqdm(object):
                 full_bar = bar + \
                     ' ' * max(N_BARS - bar_length, 0)
 
-            if bar_format is None:
-                # Default bar format = fast display
-                return l_bar + full_bar + r_bar
-            else:
-                # Custom bar formatting
-                # Populate a dict with all available progress indicators
-                bar_args = {'bar': full_bar,
-                            'n': n,
-                            'n_fmt': n_fmt,
-                            'total': total,
-                            'total_fmt': total_fmt,
-                            'percentage': percentage,
-                            'rate': rate,
-                            'rate_fmt': rate_fmt,
-                            'elapsed': elapsed_str,
-                            'remaining': remaining_str,
-                            'l_bar': l_bar,
-                            'r_bar': r_bar,
-                            'desc': prefix if prefix else ''
-                            }
-                # Interpolate supplied bar format with the dict
-                return bar_format.format(**bar_args)
+            # Piece together the bar parts
+            return l_bar + full_bar + r_bar
 
         # no total: no progressbar, ETA, just progress stats
         else:

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -214,9 +214,13 @@ def test_format_meter():
         "100KiB [00:13, 7.69KiB/s]"
     assert format_meter(100, 1000, 12, ncols=0, rate=7.33) == \
         " 10% 100/1000 [00:12<02:02,  7.33it/s]"
-    assert format_meter(20, 100, 12, ncols=30, rate=8.1,
+    # Check that bar_format correctly adapts {bar} size to the rest
+    assert format_meter(20, 100, 12, ncols=13, rate=8.1,
                         bar_format=r'{l_bar}{bar}|{n_fmt}/{total_fmt}') == \
         " 20%|" + unich(0x258f) + "|20/100"
+    assert format_meter(20, 100, 12, ncols=14, rate=8.1,
+                        bar_format=r'{l_bar}{bar}|{n_fmt}/{total_fmt}') == \
+        " 20%|" + unich(0x258d) + " |20/100"
 
 
 def test_si_format():

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -221,6 +221,16 @@ def test_format_meter():
     assert format_meter(20, 100, 12, ncols=14, rate=8.1,
                         bar_format=r'{l_bar}{bar}|{n_fmt}/{total_fmt}') == \
         " 20%|" + unich(0x258d) + " |20/100"
+    # Check that bar_format can print only {bar} or just one side
+    assert format_meter(20, 100, 12, ncols=2, rate=8.1,
+                        bar_format=r'{bar}') == \
+        unich(0x258d) + " "
+    assert format_meter(20, 100, 12, ncols=7, rate=8.1,
+                        bar_format=r'{l_bar}{bar}') == \
+        " 20%|" + unich(0x258d) + " "
+    assert format_meter(20, 100, 12, ncols=6, rate=8.1,
+                        bar_format=r'{bar}|test') == \
+        unich(0x258f) + "|test"
 
 
 def test_si_format():


### PR DESCRIPTION
Apply the fix proposed by #149 to avoid breaking display when using `bar_format`.

This change does not add any additional computation when not using `bar_format`.

In addition, `bar_format` is now much more efficient when not using `{bar}` since it will return directly, skipping the unnecessary computations.

PS: this PR includes the changes in branch `inv-option`, sorry for that. Will clean up if `inv-option` does not get merged.

- [x] Test if it works in all cases
- [x] Coverage?