### PR TITLE
Fix temporary bar displaying with tqdm_notebook

### DIFF
--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -174,10 +174,12 @@ class tqdm_notebook(tqdm):  # pragma: no cover
         if not kwargs.get('bar_format', None):
             kwargs['bar_format'] = r'{n}/|/{l_bar}{r_bar}'
 
-        super(tqdm_notebook, self).__init__(*args, **kwargs)
+        # Initialize parent class + avoid printing by using gui=True
+        super(tqdm_notebook, self).__init__(*args, gui=True, **kwargs)
 
         # Delete first pbar generated from super() (wrong total and text)
-        self.sp('', close=True)
+        # DEPRECATED by using gui=True
+        # self.sp('', close=True)
         # Replace with IPython progress bar display (with correct total)
         self.sp = self.status_printer(self.fp, self.total, self.desc)
         self.desc = None  # trick to place description before the bar


### PR DESCRIPTION
Should fix issue reported by @wernight in issue #170.

BTW, I noticed a weird issue about old widgets bars reappearing after reloading the notebook, but we can't do anything about it because it seems it's ipywidgets fault. I reported it at https://github.com/ipython/ipywidgets/issues/624.