### PR TITLE
RF: delay imports of ipython until necessary through adapter functions

### DIFF
--- a/tqdm/__init__.py
+++ b/tqdm/__init__.py
@@ -3,8 +3,6 @@ from ._tqdm import trange
 from ._tqdm_gui import tqdm_gui
 from ._tqdm_gui import tgrange
 from ._tqdm_pandas import tqdm_pandas
-from ._tqdm_notebook import tqdm_notebook
-from ._tqdm_notebook import tnrange
 from ._main import main
 from ._main import TqdmKeyError
 from ._main import TqdmTypeError
@@ -13,3 +11,21 @@ from ._version import __version__  # NOQA
 __all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_pandas',
            'tqdm_notebook', 'tnrange', 'main', 'TqdmKeyError', 'TqdmTypeError',
            '__version__']
+
+
+def tqdm_notebook(*args, **kwargs):
+    """See tqdm._tqdm_notebook.tqdm_notebook for full documentation
+
+    This is just an adapter to delay imports
+    """
+    from ._tqdm_notebook import tqdm_notebook as _tqdm_notebook
+    return _tqdm_notebook(*args, **kwargs)
+
+
+def tnrange(*args, **kwargs):
+    """See tqdm._tqdm_notebook.tnrange for full documentation
+
+    This is just an adapter to delay imports
+    """
+    from ._tqdm_notebook import tnrange as _tnrange
+    return _tnrange(*args, **kwargs)


### PR DESCRIPTION
Partially addresses #176 
More of a proof of concept:  compare

```
$> /usr/bin/time python -c 'import tqdm' 
0.15user 0.02system 0:00.18elapsed 94%CPU (0avgtext+0avgdata 30772maxresident)k

$> git co enh-delayed-imports           
Previous HEAD position was af1d7c5... readme updates, removed broken pypi download count
Switched to branch 'enh-delayed-imports'
Your branch is up-to-date with 'gh-yarikoptic/enh-delayed-imports'.

$> /usr/bin/time python -c 'import tqdm'
0.01user 0.00system 0:00.02elapsed 72%CPU (0avgtext+0avgdata 7684maxresident)k
```