### PR TITLE
Add callable support for bar_format argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -290,8 +290,9 @@ Parameters
     Exponential moving average smoothing factor for speed estimates
     (ignored in GUI mode). Ranges from 0 (average speed) to 1
     (current/instantaneous speed) [default: 0.3].
-* bar_format  : str, optional  
+* bar_format  : str or callable, optional  
     Specify a custom bar string formatting. May impact performance.
+    Can be a callable that will handle bar display.
     If unspecified, will use '{l_bar}{bar}{r_bar}', where l_bar is
     '{desc}{percentage:3.0f}%|' and r_bar is
     '| {n_fmt}/{total_fmt} [{elapsed_str}<{remaining_str}, {rate_fmt}]'
@@ -483,6 +484,34 @@ Here's an example with ``urllib``:
 It is recommend to use ``miniters=1`` whenever there is potentially
 large differences in iteration speed (e.g. downloading a file over
 a patchy connection).
+
+Integration in a GUI
+~~~~~~~~~~~~~~~~~~~~
+``tqdm`` can easily be integrated in your own GUI by providing ``bar_format`` with
+a callback function that will update your GUI bar display:
+
+.. code:: python
+
+    from tqdm import tqdm
+    from time import sleep
+    from awesome import GUI
+    
+    class my_gui_bar(object):
+        '''Toy GUI bar'''
+        def __init__(self):
+            self.gui_bar = GUI()
+            self.gui_bar.init()
+            # etc.
+
+        def update(self, bar_args={}):
+            '''Callback for tqdm to update the bar display'''
+            self.gui_bar.set_text = "{n_fmt}/{n_total} [{elapsed}>{remaining}]".format(bar_args)
+            self.gui_bar.set_progress = bar_args['n']
+
+    gbar = my_gui_bar()
+    for i in tqdm(range(100), bar_format=gbar.update):
+        sleep(0.1)
+
 
 Pandas Integration
 ~~~~~~~~~~~~~~~~~~

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -155,8 +155,9 @@ class tqdm(object):
         rate  : float, optional
             Manual override for iteration rate.
             If [default: None], uses n/elapsed.
-        bar_format  : str, optional
+        bar_format  : str or callable, optional
             Specify a custom bar string formatting. May impact performance.
+            Can be a callable that will handle bar display.
             [default: '{l_bar}{bar}{r_bar}'], where l_bar is
             '{desc}{percentage:3.0f}%|' and r_bar is
             '| {n_fmt}/{total_fmt} [{elapsed_str}<{remaining_str}, {rate_fmt}]'
@@ -236,7 +237,10 @@ class tqdm(object):
                             }
 
                 # Interpolate supplied bar format with the dict
-                if '{bar}' in bar_format:
+                if hasattr(bar_format, '__call__'):
+                    # Callback user provided function/method to handle display
+                    bar_format(bar_args)
+                elif '{bar}' in bar_format:
                     # Format left/right sides of the bar, and format the bar
                     # later in the remaining space (avoid breaking display)
                     l_bar_user, r_bar_user = bar_format.split('{bar}')
@@ -508,8 +512,9 @@ class tqdm(object):
             Exponential moving average smoothing factor for speed estimates
             (ignored in GUI mode). Ranges from 0 (average speed) to 1
             (current/instantaneous speed) [default: 0.3].
-        bar_format  : str, optional
+        bar_format  : str or callable, optional
             Specify a custom bar string formatting. May impact performance.
+            Can be a callable that will handle bar display.
             If unspecified, will use '{l_bar}{bar}{r_bar}', where l_bar is
             '{desc}{percentage:3.0f}%|' and r_bar is
             '| {n_fmt}/{total_fmt} [{elapsed_str}<{remaining_str}, {rate_fmt}]'


### PR DESCRIPTION
The main goal is to allow the parent application to manage the progress bar display itself. For example, if an application with a GUI (such as [moviepy](https://github.com/Zulko/moviepy/issues/128)?) wants to use `tqdm` on both its console and GUI displays without having to make a dedicated module (that won't be reusable for any other module but theirs). This is way easier than subclassing `tqdm` and should be pretty much as fast performance-wise.

Todo:
- [ ] test on real cases (not yet tested at all, beware!)
- [ ] unit test