### PR TITLE
Update test to run with python3 executable

### DIFF
--- a/tqdm/tests/tests_main.py
+++ b/tqdm/tests/tests_main.py
@@ -19,7 +19,7 @@ def test_main():
     ls = subprocess.Popen(('ls'),
                           stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT)
-    res = _sh('python', '-c', 'from tqdm import main; main()',
+    res = _sh(sys.executable, '-c', 'from tqdm import main; main()',
               stdin=ls.stdout,
               stderr=subprocess.STDOUT)
     ls.wait()


### PR DESCRIPTION
Use sys.executable to run with the same python as the tests are run. Needed for installations with different python installed, e.g. python2 and python3 instead of plain python.