### PR TITLE
Custom bar symbols formatting + bar_format callback and dict return

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -290,8 +290,9 @@ Parameters
     Exponential moving average smoothing factor for speed estimates
     (ignored in GUI mode). Ranges from 0 (average speed) to 1
     (current/instantaneous speed) [default: 0.3].
-* bar_format  : str, optional  
+* bar_format  : str or callable, optional  
     Specify a custom bar string formatting. May impact performance.
+    Can be a callable that will handle bar display.
     If unspecified, will use '{l_bar}{bar}{r_bar}', where l_bar is
     '{desc}{percentage:3.0f}%|' and r_bar is
     '| {n_fmt}/{total_fmt} [{elapsed_str}<{remaining_str}, {rate_fmt}]'
@@ -483,6 +484,34 @@ Here's an example with ``urllib``:
 It is recommend to use ``miniters=1`` whenever there is potentially
 large differences in iteration speed (e.g. downloading a file over
 a patchy connection).
+
+Integration in a GUI
+~~~~~~~~~~~~~~~~~~~~
+``tqdm`` can easily be integrated in your own GUI by providing ``bar_format`` with
+a callback function that will update your GUI bar display:
+
+.. code:: python
+
+    from tqdm import tqdm
+    from time import sleep
+    from awesome import GUI
+    
+    class my_gui_bar(object):
+        '''Toy GUI bar'''
+        def __init__(self):
+            self.gui_bar = GUI()
+            self.gui_bar.init()
+            # etc.
+
+        def update(self, bar_args={}):
+            '''Callback for tqdm to update the bar display'''
+            self.gui_bar.set_text = "{n_fmt}/{n_total} [{elapsed}>{remaining}]".format(bar_args)
+            self.gui_bar.set_progress = bar_args['n']
+
+    gbar = my_gui_bar()
+    for i in tqdm(range(100), bar_format=gbar.update):
+        sleep(0.1)
+
 
 Pandas Integration
 ~~~~~~~~~~~~~~~~~~

--- a/tqdm/__init__.py
+++ b/tqdm/__init__.py
@@ -2,13 +2,15 @@ from ._tqdm import tqdm
 from ._tqdm import trange
 from ._tqdm_gui import tqdm_gui
 from ._tqdm_gui import tgrange
+from ._tqdm_custom import tqdm_custom
+from ._tqdm_custom import tcrange
 from ._tqdm_pandas import tqdm_pandas
 from ._main import main
 from ._version import __version__  # NOQA
 from ._tqdm import TqdmTypeError, TqdmKeyError, TqdmDeprecationWarning
 
 __all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_pandas',
-           'tqdm_notebook', 'tnrange', 'main',
+           'tqdm_notebook', 'tnrange', 'tqdm_custom', 'tcrange', 'main',
            'TqdmTypeError', 'TqdmKeyError', 'TqdmDeprecationWarning',
            '__version__']
 

--- a/tqdm/__init__.py
+++ b/tqdm/__init__.py
@@ -4,13 +4,17 @@ from ._tqdm_gui import tqdm_gui
 from ._tqdm_gui import tgrange
 from ._tqdm_custom import tqdm_custom
 from ._tqdm_custom import tcrange
+from ._tqdm_custommulti import tqdm_custommulti
+from ._tqdm_custommulti import tcmrange
 from ._tqdm_pandas import tqdm_pandas
 from ._main import main
 from ._version import __version__  # NOQA
 from ._tqdm import TqdmTypeError, TqdmKeyError, TqdmDeprecationWarning
 
 __all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_pandas',
-           'tqdm_notebook', 'tnrange', 'tqdm_custom', 'tcrange', 'main',
+           'tqdm_notebook', 'tnrange',
+           'tqdm_custom', 'tcrange', 'tqdm_custommulti', 'tcmrange',
+           'main',
            'TqdmTypeError', 'TqdmKeyError', 'TqdmDeprecationWarning',
            '__version__']
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -317,11 +317,13 @@ class tqdm(object):
                 # normal progress symbols
                 else:
                     bar_length, frac_bar_length = divmod(
-                        int(frac * N_BARS * len(c_symbols)), len(c_symbols))
+                        int((frac/len(c_symbols[-1])) * N_BARS * len(c_symbols)), len(c_symbols))
 
                     bar = c_symbols[-1] * bar_length  # last symbol is always the filler
                     frac_bar = c_symbols[frac_bar_length] if frac_bar_length \
                         else ' '
+                    # update real bar length (if symbols > 1 char) for correct filler
+                    bar_length = bar_length * len(c_symbols[-1])
 
             # ascii format
             elif ascii:
@@ -345,7 +347,7 @@ class tqdm(object):
             # whitespace padding
             if bar_length < N_BARS:
                 full_bar = bar + frac_bar + \
-                    ' ' * max(N_BARS - bar_length - 1, 0)
+                    ' ' * max(N_BARS - bar_length - len(frac_bar), 0)
             else:
                 full_bar = bar + \
                     ' ' * max(N_BARS - bar_length, 0)

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -121,7 +121,7 @@ class tqdm(object):
     @staticmethod
     def format_meter(n, total, elapsed, ncols=None, prefix='',
                      ascii=False, unit='it', unit_scale=False, rate=None,
-                     bar_format=None):
+                     bar_format=None, custom_symbols=None):
         """
         Return a string-based progress bar given some parameters
 
@@ -168,27 +168,6 @@ class tqdm(object):
         -------
         out  : Formatted meter and stats, ready to display.
         """
-        
-        def extract_symbols(s, start_tag, end_tag):
-            """
-            Extract custom symbols enclosed by tags, with the first character being the separator.
-            Eg, extract_symbols('before{start},1,2,3,4,#{end}after', '{start}', '{end}')
-            
-            Returns
-            -------
-            out, out2  : list of symbols, input string without tagged part
-            """
-            start = s.find(start_tag)
-            start_content = start+len(start_tag)
-            end_content = s.find(end_tag)
-            end = end_content+len(end_tag)
-
-            sep = s[start_content:start_content+1]
-            return s[start_content+1:end_content].split(sep), s[:start] + s[end:]
-
-        # Custom symbols variables
-        c_symbols = None
-        looping = False
 
         # sanity check: total
         if total and n > total:
@@ -261,22 +240,6 @@ class tqdm(object):
                             # 'bar': full_bar  # replaced by procedure below
                             }
 
-                # Custom symbols extraction
-                for tag in ['bar_symbols', 'bar_symbols_ascii', 'bar_symbols_loop', 'bar_symbols_loop_ascii']:
-                    start_tag = '{' + tag + '}'
-                    end_tag = '{/' + tag + '}'
-                    # Check if tag is found in the template
-                    if start_tag in bar_format and end_tag in bar_format:
-                        # Get ascii symbols if ascii env, else unicode
-                        if (ascii and 'ascii' in tag) or (not ascii and not 'ascii' in tag):
-                            c_symbols, bar_format = extract_symbols(bar_format, start_tag, end_tag)
-                            # Looping symbol?
-                            if 'loop' in tag:
-                                looping = True
-                        # Need to clean all tags from template
-                        else:
-                            _, bar_format = extract_symbols(bar_format, start_tag, end_tag)
-
                 # Interpolate supplied bar format with the dict
                 if hasattr(bar_format, '__call__'):
                     # Callback user provided function/method to handle display
@@ -302,28 +265,33 @@ class tqdm(object):
                 return l_bar + r_bar
 
             # custom symbols format
-            # need to provide both ascii and unicode versions of custom symbols,
-            # eg, if ascii env but user provided only unicode symbols, then
-            # will revert to default ascii bar.
-            if c_symbols:
+            # need to provide both ascii and unicode versions of custom symbols
+            if custom_symbols:
+                # get ascii or unicode template
+                if ascii:
+                    c_symb = custom_symbols[1]
+                else:
+                    c_symb = custom_symbols[2]
                 # looping symbols: just update the symbol animation at each iteration
-                if looping:
+                if custom_symbols[0] == 'loop':
                     # increment one step in the animation at each step
-                    bar = c_symbols[divmod(n, len(c_symbols))[1]]
+                    bar = c_symb[divmod(n, len(c_symb))[1]]
                     frac_bar = ''
 
                     bar_length = N_BARS  # avoid the filling
                     frac_bar_length = len(frac_bar)
                 # normal progress symbols
                 else:
+                    nb_symb = len(c_symb)
+                    len_filler = len(c_symb[-1])
                     bar_length, frac_bar_length = divmod(
-                        int((frac/len(c_symbols[-1])) * N_BARS * len(c_symbols)), len(c_symbols))
+                        int((frac/len_filler) * N_BARS * nb_symb), nb_symb)
 
-                    bar = c_symbols[-1] * bar_length  # last symbol is always the filler
-                    frac_bar = c_symbols[frac_bar_length] if frac_bar_length \
+                    bar = c_symb[-1] * bar_length  # last symbol is always the filler
+                    frac_bar = c_symb[frac_bar_length] if frac_bar_length \
                         else ' '
                     # update real bar length (if symbols > 1 char) for correct filler
-                    bar_length = bar_length * len(c_symbols[-1])
+                    bar_length = bar_length * len_filler
 
             # ascii format
             elif ascii:
@@ -705,6 +673,46 @@ class tqdm(object):
         if ascii is None:
             ascii = not _supports_unicode(file)
 
+
+        # Custom symbols extraction
+        custom_symbols = None
+        if bar_format:
+            looping = None
+            c_symbols_ascii = None
+            c_symbols_unicode = None
+            found_tag = False
+            for tag in ['bar_symbols', 'bar_symbols_ascii', 'bar_symbols_loop', 'bar_symbols_loop_ascii']:
+                start_tag = '{' + tag + '}'
+                end_tag = '{/' + tag + '}'
+                # Check if tag is found in the template
+                if start_tag in bar_format and end_tag in bar_format:
+                    found_tag = True
+                    # Extract custom symbols enclosed by tags, with the first character being the separator.
+                    # Eg, extract_symbols('before{start},1,2,3,4,#{end}after', '{start}', '{end}')
+                    start = bar_format.find(start_tag)
+                    start_content = start+len(start_tag)
+                    end_content = bar_format.find(end_tag)
+                    end = end_content+len(end_tag)
+                    sep = bar_format[start_content:start_content+1]
+                    c_symbols = bar_format[start_content+1:end_content].split(sep)
+                    # Cleanup all weird tags from bar_format else .format() crash
+                    bar_format = bar_format[:start] + bar_format[end:]
+
+                    if 'ascii' in tag:
+                        c_symbols_ascii = c_symbols
+                    else:
+                        c_symbols_unicode = c_symbols
+
+                    # Looping symbol?
+                    if 'loop' in tag:
+                        looping = True
+                    else:
+                        looping = False
+
+            # Compile the ascii/unicode bars in a nice argument for format_meter
+            if found_tag:
+                custom_symbols = ['loop' if looping else 'bar', c_symbols_ascii, c_symbols_unicode]
+
         if bar_format and not ascii:
             # Convert bar format into unicode since terminal uses unicode
             bar_format = _unicode(bar_format)
@@ -733,6 +741,7 @@ class tqdm(object):
         self.avg_time = None
         self._time = time
         self.bar_format = bar_format
+        self.custom_symbols = custom_symbols
 
         # Init the iterations counters
         self.last_print_n = initial
@@ -749,7 +758,8 @@ class tqdm(object):
                 self.moveto(self.pos)
             self.sp(self.format_meter(self.n, total, 0,
                     (dynamic_ncols(file) if dynamic_ncols else ncols),
-                    self.desc, ascii, unit, unit_scale, None, bar_format))
+                    self.desc, ascii, unit, unit_scale, None,
+                    bar_format, custom_symbols))
             if self.pos:
                 self.moveto(-self.pos)
 
@@ -776,7 +786,8 @@ class tqdm(object):
                                  time() - self.last_print_t,
                                  self.ncols, self.desc, self.ascii, self.unit,
                                  self.unit_scale, 1 / self.avg_time
-                                 if self.avg_time else None, self.bar_format)
+                                 if self.avg_time else None,
+                                 self.bar_format, self.custom_symbols)
 
     def __lt__(self, other):
         return self.pos < other.pos
@@ -827,6 +838,7 @@ class tqdm(object):
             smoothing = self.smoothing
             avg_time = self.avg_time
             bar_format = self.bar_format
+            custom_symbols = self.custom_symbols
             _time = self._time
             format_meter = self.format_meter
 
@@ -865,7 +877,8 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                             (dynamic_ncols(self.fp) if dynamic_ncols
                              else ncols),
                             self.desc, ascii, unit, unit_scale,
-                            1 / avg_time if avg_time else None, bar_format))
+                            1 / avg_time if avg_time else None,
+                            bar_format, custom_symbols))
 
                         if self.pos:
                             self.moveto(-self.pos)
@@ -951,7 +964,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                      else self.ncols),
                     self.desc, self.ascii, self.unit, self.unit_scale,
                     1 / self.avg_time if self.avg_time else None,
-                    self.bar_format))
+                    self.bar_format, self.custom_symbols))
 
                 if self.pos:
                     self.moveto(-self.pos)
@@ -1018,7 +1031,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                     (self.dynamic_ncols(self.fp) if self.dynamic_ncols
                      else self.ncols),
                     self.desc, self.ascii, self.unit, self.unit_scale, None,
-                    self.bar_format))
+                    self.bar_format, self.custom_symbols))
             if pos:
                 self.moveto(-pos)
             else:

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -155,8 +155,9 @@ class tqdm(object):
         rate  : float, optional
             Manual override for iteration rate.
             If [default: None], uses n/elapsed.
-        bar_format  : str, optional
+        bar_format  : str or callable, optional
             Specify a custom bar string formatting. May impact performance.
+            Can be a callable that will handle bar display.
             [default: '{l_bar}{bar}{r_bar}'], where l_bar is
             '{desc}{percentage:3.0f}%|' and r_bar is
             '| {n_fmt}/{total_fmt} [{elapsed_str}<{remaining_str}, {rate_fmt}]'
@@ -236,7 +237,10 @@ class tqdm(object):
                             }
 
                 # Interpolate supplied bar format with the dict
-                if '{bar}' in bar_format:
+                if hasattr(bar_format, '__call__'):
+                    # Callback user provided function/method to handle display
+                    bar_format(bar_args)
+                elif '{bar}' in bar_format:
                     # Format left/right sides of the bar, and format the bar
                     # later in the remaining space (avoid breaking display)
                     l_bar_user, r_bar_user = bar_format.split('{bar}')
@@ -508,8 +512,9 @@ class tqdm(object):
             Exponential moving average smoothing factor for speed estimates
             (ignored in GUI mode). Ranges from 0 (average speed) to 1
             (current/instantaneous speed) [default: 0.3].
-        bar_format  : str, optional
+        bar_format  : str or callable, optional
             Specify a custom bar string formatting. May impact performance.
+            Can be a callable that will handle bar display.
             If unspecified, will use '{l_bar}{bar}{r_bar}', where l_bar is
             '{desc}{percentage:3.0f}%|' and r_bar is
             '| {n_fmt}/{total_fmt} [{elapsed_str}<{remaining_str}, {rate_fmt}]'

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -234,9 +234,10 @@ class tqdm(object):
                             'remaining': remaining_str,
                             'l_bar': l_bar,
                             'r_bar': r_bar,
-                            'n_bars': n_bars,
+                            'n_bars': N_BARS,
                             'desc': prefix if prefix else '',
                             'ncols': ncols,
+                            'frac': frac,
                             # 'bar': full_bar  # replaced by procedure below
                             }
 
@@ -297,7 +298,7 @@ class tqdm(object):
             if bar_format:
                 l_bar = (prefix if prefix else '') + \
                             '{0}{1}'.format(n_fmt, unit)
-                r_bar = '[{2}, {3}]'.format(elapsed_str, rate_fmt)
+                r_bar = '[{0}, {1}]'.format(elapsed_str, rate_fmt)
                 N_BARS = max(1, ncols - len(l_bar) - len(r_bar)) if ncols \
                     else 10
                 # Populate dict with nototal appropriate values
@@ -318,9 +319,10 @@ class tqdm(object):
                             'remaining': '?',
                             'l_bar': l_bar,
                             'r_bar': r_bar,
-                            'n_bars': n_bars,
+                            'n_bars': N_BARS,
                             'desc': prefix if prefix else '',
                             'ncols': ncols,
+                            'frac': None,
                             }
 
                 # Interpolate supplied bar format with the dict

--- a/tqdm/_tqdm_custom.py
+++ b/tqdm/_tqdm_custom.py
@@ -43,34 +43,8 @@ class tqdm_custom(tqdm):
 
         Parameters
         ----------
-        n  : int
-            Number of finished iterations.
-        total  : int
-            The expected total number of iterations. If meaningless (), only
-            basic progress statistics are displayed (no ETA).
-        elapsed  : float
-            Number of seconds passed since start.
-        ncols  : int, optional
-            The width of the entire output message. If specified,
-            dynamically resizes the progress meter to stay within this bound
-            [default: None]. The fallback meter width is 10 for the progress
-            bar + no limit for the iterations counter and statistics. If 0,
-            will not print any meter (only stats).
-        prefix  : str, optional
-            Prefix message (included in total width) [default: ''].
-        ascii  : bool, optional
-            If not set, use unicode (smooth blocks) to fill the meter
-            [default: False]. The fallback is to use ASCII characters
-            (1-9 #).
-        unit  : str, optional
-            The iteration unit [default: 'it'].
-        unit_scale  : bool, optional
-            If set, the number of iterations will printed with an
-            appropriate SI metric prefix (K = 10^3, M = 10^6, etc.)
-            [default: False].
-        rate  : float, optional
-            Manual override for iteration rate.
-            If [default: None], uses n/elapsed.
+        same as core tqdm.
+
         bar_format  : str/list, optional
             Specify a custom bar string formatting. May impact performance.
             [default: '{l_bar}{bar}{r_bar}'], where l_bar is
@@ -84,170 +58,110 @@ class tqdm_custom(tqdm):
         out  : Formatted meter and stats, ready to display.
         """
 
-        custom_symbols = None
+        # No custom symbol (bar_format is not a dict), just call super
+        if not bar_format or \
+         bar_format and isinstance(bar_format, basestring):
+            return super(tqdm_custom, self).format_meter(n, total, elapsed, ncols,
+                     prefix, ascii, unit, unit_scale, rate, bar_format)
 
-        # sanity check: total
-        if total and n > total:
-            total = None
-
-        format_interval = tqdm.format_interval
-        elapsed_str = format_interval(elapsed)
-
-        # if unspecified, attempt to use rate = average speed
-        # (we allow manual override since predicting time is an arcane art)
-        if rate is None and elapsed:
-            rate = n / elapsed
-        inv_rate = 1 / rate if (rate and (rate < 1)) else None
-        format_sizeof = tqdm.format_sizeof
-        rate_fmt = ((format_sizeof(inv_rate if inv_rate else rate)
-                    if unit_scale else
-                    '{0:5.2f}'.format(inv_rate if inv_rate else rate))
-                    if rate else '?') \
-            + ('s' if inv_rate else unit) + '/' + (unit if inv_rate else 's')
-
-        if unit_scale:
-            n_fmt = format_sizeof(n)
-            total_fmt = format_sizeof(total) if total else None
+        # Custom symbols!
         else:
-            n_fmt = str(n)
-            total_fmt = str(total)
+            # Unpack variables if it's a list
+            if isinstance(bar_format, dict):
+                bar_template = bar_format.get('template', None)
+            else:
+                bar_template = bar_format
 
-        # total is known: we can predict some stats
-        if total:
-            # fractional and percentage progress
-            frac = n / total
-            percentage = frac * 100
+            # Preprocess and generate bar arguments using super
+            bar_args = super(tqdm_custom, self).format_meter(n, total, elapsed,
+                         ncols, prefix, ascii, unit, unit_scale, rate,
+                         bar_format=True)
 
-            remaining_str = format_interval((total - n) / rate) \
-                if rate else '?'
+            # Format bar using the template
+            if bar_template:
+                bar_args['bar'] = '{bar}'  # trick to format all except bar
+                full_bar = bar_template.format(**bar_args)
+                l_bar, r_bar = full_bar.split('{bar}')
+            else:
+                l_bar, r_bar = bar_args['l_bar'], bar_args['r_bar']
 
-            # format the stats displayed to the left and right sides of the bar
-            l_bar = (prefix if prefix else '') + \
-                '{0:3.0f}%|'.format(percentage)
-            r_bar = '| {0}/{1} [{2}<{3}, {4}]'.format(
-                    n_fmt, total_fmt, elapsed_str, remaining_str, rate_fmt)
+            custom_symbols = None
 
-            if ncols == 0:
-                return l_bar[:-1] + r_bar[1:]
+            # total is known: we can predict some stats
+            if total:
+                frac = bar_args['frac']
+                percentage = bar_args['percentage']
 
-            if bar_format:
-                # Unpack variables if it's a list
-                if isinstance(bar_format, dict):
-                    bar_format_template = bar_format.get('template', None)
-                else:
-                    bar_format_template = bar_format
+                remaining_str = bar_args['remaining']
 
-                if bar_format_template:
-                    # Custom bar formatting
-                    # Populate a dict with all available progress indicators
-                    bar_args = {'n': n,
-                                'n_fmt': n_fmt,
-                                'total': total,
-                                'total_fmt': total_fmt,
-                                'percentage': percentage,
-                                'rate': rate if inv_rate is None else inv_rate,
-                                'rate_noinv': rate,
-                                'rate_noinv_fmt': ((format_sizeof(rate)
-                                                   if unit_scale else
-                                                   '{0:5.2f}'.format(rate))
-                                                   if rate else '?') + unit + '/s',
-                                'rate_fmt': rate_fmt,
-                                'elapsed': elapsed_str,
-                                'remaining': remaining_str,
-                                'l_bar': l_bar,
-                                'r_bar': r_bar,
-                                'desc': prefix if prefix else '',
-                                # 'bar': full_bar  # replaced by procedure below
-                                }
+                N_BARS = bar_args['n_bars']
 
-                    # Interpolate supplied bar format with the dict
-                    if '{bar}' in bar_format_template:
-                        # Format left/right sides of the bar, and format the bar
-                        # later in the remaining space (avoid breaking display)
-                        l_bar_user, r_bar_user = bar_format_template.split('{bar}')
-                        l_bar = l_bar_user.format(**bar_args)
-                        r_bar = r_bar_user.format(**bar_args)
+                # custom symbols format
+                # need to provide both ascii and unicode versions of custom symbols
+                if bar_format and isinstance(bar_format, dict):
+                    # get ascii or unicode template
+                    if ascii:
+                        c_symb = bar_format['symbols'].get('ascii', list("123456789#"))
                     else:
-                        # Else no progress bar, we can just format and return
-                        return bar_format_template.format(**bar_args)
+                        c_symb = bar_format['symbols'].get('unicode', map(_unich, range(0x258F, 0x2587, -1)))
+                    # looping symbols: just update the symbol animation at each iteration
+                    if bar_format['symbols'].get('loop', False):
+                        # increment one step in the animation for each display
+                        self.n_anim += 1
+                        # get the symbol for current animation step
+                        bar = c_symb[divmod(self.n_anim, len(c_symb))[1]]
+                        frac_bar = ''
 
-            # Formatting progress bar
-            # space available for bar's display
-            N_BARS = max(1, ncols - len(l_bar) - len(r_bar)) if ncols \
-                else 10
+                        bar_length = N_BARS  # avoid the filling
+                        frac_bar_length = len(frac_bar)
+                    # normal progress symbols
+                    else:
+                        nb_symb = len(c_symb)
+                        len_filler = len(c_symb[-1])
+                        bar_length, frac_bar_length = divmod(
+                            int((frac/len_filler) * N_BARS * nb_symb), nb_symb)
 
-            # custom symbols format
-            # need to provide both ascii and unicode versions of custom symbols
-            if bar_format and isinstance(bar_format, dict):
-                # get ascii or unicode template
-                if ascii:
-                    c_symb = bar_format['symbols'].get('ascii', list("123456789#"))
-                else:
-                    c_symb = bar_format['symbols'].get('unicode', map(_unich, range(0x258F, 0x2587, -1)))
-                # looping symbols: just update the symbol animation at each iteration
-                if bar_format['symbols'].get('loop', False):
-                    # increment one step in the animation for each display
-                    self.n_anim += 1
-                    # get the symbol for current animation step
-                    bar = c_symb[divmod(self.n_anim, len(c_symb))[1]]
-                    frac_bar = ''
+                        bar = c_symb[-1] * bar_length  # last symbol is always the filler
+                        frac_bar = c_symb[frac_bar_length] if frac_bar_length \
+                            else ' '
+                        # update real bar length (if symbols > 1 char) for correct filler
+                        bar_length = bar_length * len_filler
 
-                    bar_length = N_BARS  # avoid the filling
-                    frac_bar_length = len(frac_bar)
-                # normal progress symbols
-                else:
-                    nb_symb = len(c_symb)
-                    len_filler = len(c_symb[-1])
+                # ascii format
+                elif ascii:
+                    # get the remainder of the division of current fraction with number of symbols
+                    # this will tell us which symbol we should pick
                     bar_length, frac_bar_length = divmod(
-                        int((frac/len_filler) * N_BARS * nb_symb), nb_symb)
+                        int(frac * N_BARS * 10), 10)
 
-                    bar = c_symb[-1] * bar_length  # last symbol is always the filler
-                    frac_bar = c_symb[frac_bar_length] if frac_bar_length \
+                    bar = '#' * bar_length
+                    frac_bar = chr(48 + frac_bar_length) if frac_bar_length \
                         else ' '
-                    # update real bar length (if symbols > 1 char) for correct filler
-                    bar_length = bar_length * len_filler
 
-            # ascii format
-            elif ascii:
-                # get the remainder of the division of current fraction with number of symbols
-                # this will tell us which symbol we should pick
-                bar_length, frac_bar_length = divmod(
-                    int(frac * N_BARS * 10), 10)
+                # unicode format (if available)
+                else:
+                    bar_length, frac_bar_length = divmod(int(frac * N_BARS * 8), 8)
 
-                bar = '#' * bar_length
-                frac_bar = chr(48 + frac_bar_length) if frac_bar_length \
-                    else ' '
+                    bar = _unich(0x2588) * bar_length
+                    frac_bar = _unich(0x2590 - frac_bar_length) \
+                        if frac_bar_length else ' '
 
-            # unicode format (if available)
+                # whitespace padding
+                if bar_length < N_BARS:
+                    full_bar = bar + frac_bar + \
+                        ' ' * max(N_BARS - bar_length - len(frac_bar), 0)
+                else:
+                    full_bar = bar + \
+                        ' ' * max(N_BARS - bar_length, 0)
+
+                # Piece together the bar parts
+                return l_bar + full_bar + r_bar
+
+            # no total: no progressbar, ETA, just progress stats
             else:
-                bar_length, frac_bar_length = divmod(int(frac * N_BARS * 8), 8)
+                N_BARS = bar_args['n_bars']
 
-                bar = _unich(0x2588) * bar_length
-                frac_bar = _unich(0x2590 - frac_bar_length) \
-                    if frac_bar_length else ' '
-
-            # whitespace padding
-            if bar_length < N_BARS:
-                full_bar = bar + frac_bar + \
-                    ' ' * max(N_BARS - bar_length - len(frac_bar), 0)
-            else:
-                full_bar = bar + \
-                    ' ' * max(N_BARS - bar_length, 0)
-
-            # Piece together the bar parts
-            return l_bar + full_bar + r_bar
-
-        # no total: no progressbar, ETA, just progress stats
-        else:
-            if bar_format and isinstance(bar_format, dict):
-                # left and right sides
-                l_bar = '{0}{1}|'.format(n_fmt, unit)
-                r_bar = '| {0}/? [{1}, {2}]'.format(n_fmt, elapsed_str, rate_fmt)
-
-                # space available for bar's display
-                N_BARS = max(1, ncols - len(l_bar) - len(r_bar)) if ncols \
-                    else 10
-
+                # Custom symbols!
                 # get ascii or unicode template
                 if ascii:
                     c_symb = bar_format['symbols_indeterminate'].get('ascii', ["====="])
@@ -286,11 +200,6 @@ class tqdm_custom(tqdm):
 
                 # Piece together the bar parts
                 return l_bar + full_bar + r_bar
-
-            # Standard fast no ETA progress status
-            else:
-                return (prefix if prefix else '') + '{0}{1} [{2}, {3}]'.format(
-                        n_fmt, unit, elapsed_str, rate_fmt)
 
     def __init__(self, *args, **kwargs):
         """

--- a/tqdm/_tqdm_custom.py
+++ b/tqdm/_tqdm_custom.py
@@ -1,0 +1,290 @@
+"""
+Customisable progressbar decorator for iterators.
+Includes a default (x)range iterator printing to stderr.
+
+Usage:
+  >>> from tqdm import trange[, tqdm]
+  >>> for i in trange(10): #same as: for i in tqdm(xrange(10))
+  ...     ...
+"""
+from __future__ import absolute_import, division
+# import compatibility functions and utilities
+from ._utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
+    _unicode
+import sys
+
+from ._utils import _range
+# to inherit from the tqdm class
+from ._tqdm import tqdm
+
+
+__author__ = {"github.com/": ["lrq3000"]}
+__all__ = ['tqdm_custom', 'tcrange']
+
+
+class tqdm_custom(tqdm):
+    """
+    tqdm with nice customizable bar symbols!
+    """
+    @staticmethod
+    def format_meter(n, total, elapsed, ncols=None, prefix='',
+                     ascii=False, unit='it', unit_scale=False, rate=None,
+                     bar_format=None):
+        """
+        Return a string-based progress bar given some parameters
+
+        Parameters
+        ----------
+        n  : int
+            Number of finished iterations.
+        total  : int
+            The expected total number of iterations. If meaningless (), only
+            basic progress statistics are displayed (no ETA).
+        elapsed  : float
+            Number of seconds passed since start.
+        ncols  : int, optional
+            The width of the entire output message. If specified,
+            dynamically resizes the progress meter to stay within this bound
+            [default: None]. The fallback meter width is 10 for the progress
+            bar + no limit for the iterations counter and statistics. If 0,
+            will not print any meter (only stats).
+        prefix  : str, optional
+            Prefix message (included in total width) [default: ''].
+        ascii  : bool, optional
+            If not set, use unicode (smooth blocks) to fill the meter
+            [default: False]. The fallback is to use ASCII characters
+            (1-9 #).
+        unit  : str, optional
+            The iteration unit [default: 'it'].
+        unit_scale  : bool, optional
+            If set, the number of iterations will printed with an
+            appropriate SI metric prefix (K = 10^3, M = 10^6, etc.)
+            [default: False].
+        rate  : float, optional
+            Manual override for iteration rate.
+            If [default: None], uses n/elapsed.
+        bar_format  : str/list, optional
+            Specify a custom bar string formatting. May impact performance.
+            [default: '{l_bar}{bar}{r_bar}'], where l_bar is
+            '{desc}{percentage:3.0f}%|' and r_bar is
+            '| {n_fmt}/{total_fmt} [{elapsed_str}<{remaining_str}, {rate_fmt}]'
+            Possible vars: bar, n, n_fmt, total, total_fmt, percentage,
+            rate, rate_fmt, elapsed, remaining, l_bar, r_bar, desc.
+
+        Returns
+        -------
+        out  : Formatted meter and stats, ready to display.
+        """
+
+        custom_symbols = None
+
+        # sanity check: total
+        if total and n > total:
+            total = None
+
+        format_interval = tqdm.format_interval
+        elapsed_str = format_interval(elapsed)
+
+        # if unspecified, attempt to use rate = average speed
+        # (we allow manual override since predicting time is an arcane art)
+        if rate is None and elapsed:
+            rate = n / elapsed
+        inv_rate = 1 / rate if (rate and (rate < 1)) else None
+        format_sizeof = tqdm.format_sizeof
+        rate_fmt = ((format_sizeof(inv_rate if inv_rate else rate)
+                    if unit_scale else
+                    '{0:5.2f}'.format(inv_rate if inv_rate else rate))
+                    if rate else '?') \
+            + ('s' if inv_rate else unit) + '/' + (unit if inv_rate else 's')
+
+        if unit_scale:
+            n_fmt = format_sizeof(n)
+            total_fmt = format_sizeof(total) if total else None
+        else:
+            n_fmt = str(n)
+            total_fmt = str(total)
+
+        # total is known: we can predict some stats
+        if total:
+            # fractional and percentage progress
+            frac = n / total
+            percentage = frac * 100
+
+            remaining_str = format_interval((total - n) / rate) \
+                if rate else '?'
+
+            # format the stats displayed to the left and right sides of the bar
+            l_bar = (prefix if prefix else '') + \
+                '{0:3.0f}%|'.format(percentage)
+            r_bar = '| {0}/{1} [{2}<{3}, {4}]'.format(
+                    n_fmt, total_fmt, elapsed_str, remaining_str, rate_fmt)
+
+            if ncols == 0:
+                return l_bar[:-1] + r_bar[1:]
+
+            if bar_format:
+                # Unpack variables if it's a list
+                if isinstance(bar_format, list):
+                    bar_format, custom_symbols = bar_format
+                # Custom bar formatting
+                # Populate a dict with all available progress indicators
+                bar_args = {'n': n,
+                            'n_fmt': n_fmt,
+                            'total': total,
+                            'total_fmt': total_fmt,
+                            'percentage': percentage,
+                            'rate': rate if inv_rate is None else inv_rate,
+                            'rate_noinv': rate,
+                            'rate_noinv_fmt': ((format_sizeof(rate)
+                                               if unit_scale else
+                                               '{0:5.2f}'.format(rate))
+                                               if rate else '?') + unit + '/s',
+                            'rate_fmt': rate_fmt,
+                            'elapsed': elapsed_str,
+                            'remaining': remaining_str,
+                            'l_bar': l_bar,
+                            'r_bar': r_bar,
+                            'desc': prefix if prefix else '',
+                            # 'bar': full_bar  # replaced by procedure below
+                            }
+
+                # Interpolate supplied bar format with the dict
+                if '{bar}' in bar_format:
+                    # Format left/right sides of the bar, and format the bar
+                    # later in the remaining space (avoid breaking display)
+                    l_bar_user, r_bar_user = bar_format.split('{bar}')
+                    l_bar = l_bar_user.format(**bar_args)
+                    r_bar = r_bar_user.format(**bar_args)
+                else:
+                    # Else no progress bar, we can just format and return
+                    return bar_format.format(**bar_args)
+
+            # Formatting progress bar
+            # space available for bar's display
+            N_BARS = max(1, ncols - len(l_bar) - len(r_bar)) if ncols \
+                else 10
+
+            # custom symbols format
+            # need to provide both ascii and unicode versions of custom symbols
+            if custom_symbols:
+                # get ascii or unicode template
+                if ascii:
+                    c_symb = custom_symbols[1]
+                else:
+                    c_symb = custom_symbols[2]
+                # looping symbols: just update the symbol animation at each iteration
+                if custom_symbols[0] == 'loop':
+                    # increment one step in the animation at each step
+                    bar = c_symb[divmod(n, len(c_symb))[1]]
+                    frac_bar = ''
+
+                    bar_length = N_BARS  # avoid the filling
+                    frac_bar_length = len(frac_bar)
+                # normal progress symbols
+                else:
+                    nb_symb = len(c_symb)
+                    len_filler = len(c_symb[-1])
+                    bar_length, frac_bar_length = divmod(
+                        int((frac/len_filler) * N_BARS * nb_symb), nb_symb)
+
+                    bar = c_symb[-1] * bar_length  # last symbol is always the filler
+                    frac_bar = c_symb[frac_bar_length] if frac_bar_length \
+                        else ' '
+                    # update real bar length (if symbols > 1 char) for correct filler
+                    bar_length = bar_length * len_filler
+
+            # ascii format
+            elif ascii:
+                # get the remainder of the division of current fraction with number of symbols
+                # this will tell us which symbol we should pick
+                bar_length, frac_bar_length = divmod(
+                    int(frac * N_BARS * 10), 10)
+
+                bar = '#' * bar_length
+                frac_bar = chr(48 + frac_bar_length) if frac_bar_length \
+                    else ' '
+
+            # unicode format (if available)
+            else:
+                bar_length, frac_bar_length = divmod(int(frac * N_BARS * 8), 8)
+
+                bar = _unich(0x2588) * bar_length
+                frac_bar = _unich(0x2590 - frac_bar_length) \
+                    if frac_bar_length else ' '
+
+            # whitespace padding
+            if bar_length < N_BARS:
+                full_bar = bar + frac_bar + \
+                    ' ' * max(N_BARS - bar_length - len(frac_bar), 0)
+            else:
+                full_bar = bar + \
+                    ' ' * max(N_BARS - bar_length, 0)
+
+            # Piece together the bar parts
+            return l_bar + full_bar + r_bar
+
+        # no total: no progressbar, ETA, just progress stats
+        else:
+            return (prefix if prefix else '') + '{0}{1} [{2}, {3}]'.format(
+                n_fmt, unit, elapsed_str, rate_fmt)
+
+    def __init__(self, *args, **kwargs):
+        # get bar_format
+        bar_format = kwargs.get('bar_format', None)
+
+        # Custom symbols extraction
+        custom_symbols = None
+        if bar_format:
+            looping = None
+            c_symbols_ascii = None
+            c_symbols_unicode = None
+            found_tag = False
+            for tag in ['bar_symbols', 'bar_symbols_ascii', 'bar_symbols_loop', 'bar_symbols_loop_ascii']:
+                start_tag = '{' + tag + '}'
+                end_tag = '{/' + tag + '}'
+                # Check if tag is found in the template
+                if start_tag in bar_format and end_tag in bar_format:
+                    found_tag = True
+                    # Extract custom symbols enclosed by tags, with the first character being the separator.
+                    # Eg, extract_symbols('before{start},1,2,3,4,#{end}after', '{start}', '{end}')
+                    start = bar_format.find(start_tag)
+                    start_content = start+len(start_tag)
+                    end_content = bar_format.find(end_tag)
+                    end = end_content+len(end_tag)
+                    sep = bar_format[start_content:start_content+1]
+                    c_symbols = bar_format[start_content+1:end_content].split(sep)
+                    # Cleanup all weird tags from bar_format else .format() crash
+                    bar_format = bar_format[:start] + bar_format[end:]
+
+                    if 'ascii' in tag:
+                        c_symbols_ascii = c_symbols
+                    else:
+                        c_symbols_unicode = c_symbols
+
+                    # Looping symbol?
+                    if 'loop' in tag:
+                        looping = True
+                    else:
+                        looping = False
+
+            # Compile the ascii/unicode bars in a nice argument for format_meter
+            if found_tag:
+                custom_symbols = ['loop' if looping else 'bar', c_symbols_ascii, c_symbols_unicode]
+
+        # Do rest of init with cleaned up bar_format
+        kwargs['bar_format'] = bar_format
+        super(tqdm_custom, self).__init__(*args, **kwargs)
+
+        # Store the arguments
+        if custom_symbols is not None:
+            self.bar_format = [bar_format, custom_symbols]
+        else:
+            self.bar_format = bar_format
+
+
+def tcrange(*args, **kwargs):
+    """
+    A shortcut for tqdm_custom(xrange(*args), **kwargs).
+    On Python3+ range is used instead of xrange.
+    """
+    return tqdm_custom(_range(*args), **kwargs)

--- a/tqdm/_tqdm_custom.py
+++ b/tqdm/_tqdm_custom.py
@@ -123,7 +123,7 @@ class tqdm_custom(tqdm):
                         nb_symb = len(c_symb)
                         len_filler = len(c_symb[-1])
                         bar_length, frac_bar_length = divmod(
-                            int((frac/len_filler) * N_BARS * nb_symb), nb_symb)
+                            int(frac * int(N_BARS/len_filler) * nb_symb), nb_symb)
 
                         bar = c_symb[-1] * bar_length  # last symbol is always the filler
                         frac_bar = c_symb[frac_bar_length] if frac_bar_length \
@@ -177,7 +177,7 @@ class tqdm_custom(tqdm):
                 if bar_format['symbols_indeterminate'].get('loop', False):
                     # increment one step in the animation for each display
                     self.n_anim += 1
-                    # Get current bar animation based on current iteration
+                    # Get current bar animation
                     bar = c_symb[divmod(self.n_anim, len(c_symb))[1]]
 
                     bar_length = N_BARS  # avoid the filling
@@ -185,7 +185,7 @@ class tqdm_custom(tqdm):
                 else:
                     # increment one step in the animation for each display
                     self.n_anim += 1
-                    # Get current bar animation based on current iteration
+                    # Get current bar animation
                     symbol_idx = divmod(self.n_anim, len(c_symb))[1]
                     bar = c_symb[symbol_idx]
                     # Get left filling space and animation step (right pass or left?)

--- a/tqdm/_tqdm_custommulti.py
+++ b/tqdm/_tqdm_custommulti.py
@@ -398,6 +398,21 @@ class tqdm_custommulti(tqdm):
                     # And store the reversed symbols
                     self.bar_format[key][type_rev] = p_symb
 
+    def moveto(self, n):
+        """
+        Relative cursor positioning for multiline bars
+        """
+        # In core tqdm, n = self.pos usually, which also = number of lines
+        # Here it's different since it's multiline, so we walk through each
+        # tqdm instance and count the nb of lines of each multiline bar
+        instances = tqdm_custommulti._instances
+        real_n = 0
+        for inst in instances:
+            if inst.pos < abs(n):
+                real_n += inst.last_print_height
+        # We can then call super with the real number of lines
+        super(tqdm_custommulti, self).moveto(real_n if n >= 0 else -real_n)
+
     def close(self):
         """
         Cleanup for multiline bars
@@ -407,7 +422,7 @@ class tqdm_custommulti(tqdm):
             if self.pos:
                 self.moveto(self.pos)
             else:
-                self.moveto(self.last_print_height - 1)
+                self.fp.write('\n' * (self.last_print_height - 1))
 
 
 def tcmrange(*args, **kwargs):

--- a/tqdm/_tqdm_custommulti.py
+++ b/tqdm/_tqdm_custommulti.py
@@ -1,0 +1,341 @@
+"""
+Customisable progressbar decorator for iterators.
+Includes a default (x)range iterator printing to stderr.
+
+Usage:
+  >>> from tqdm import trange[, tqdm]
+  >>> for i in trange(10): #same as: for i in tqdm(xrange(10))
+  ...     ...
+"""
+from __future__ import absolute_import, division
+# import compatibility functions and utilities
+from ._utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
+    _unicode, _term_move_up
+import string
+import sys
+
+from ._utils import _range
+# to inherit from the tqdm class
+from ._tqdm import tqdm
+
+
+__author__ = {"github.com/": ["lrq3000"]}
+__all__ = ['tqdm_custommulti', 'tcmrange']
+
+# Characters mirror translation table
+_mirror_in = '()<>[]\/{}bd'
+_mirror_out = ')(><][/\}{db'
+
+
+def mirror_line(s):
+    """Mirror a line and its characters using translation"""
+    global _mirror_in, _mirror_out
+    s2 = s[::-1]
+    trans = string.maketrans(_mirror_in, _mirror_out)
+    return s2.translate(trans)
+
+def docstring2lines(s):
+    return filter(None, s.split("\n"))
+
+def argmax(iterable):
+    return max(enumerate(iterable), key=lambda x: x[1])
+
+
+class tqdm_custommulti(tqdm):
+    """
+    tqdm with nice customizable bar symbols!
+    """
+
+    @staticmethod
+    def status_printer(file):
+        """
+        Manage the printing and in-place updating of a multiline bar
+        """
+        fp = file
+        fp_flush = getattr(fp, 'flush', lambda: None)  # pragma: no cover
+
+        def fp_write(s):
+            fp.write(_unicode(s))
+            fp_flush()
+
+        def movetomulti(n):
+            fp.write(_unicode('\n' * n + _term_move_up() * -n))
+
+        last_len = [ [0] ]
+        last_height = [1]
+
+        def print_status(s):
+            s_lines = s.splitlines()
+            height = len(s_lines)
+            # If s is multilines, store length of each line in a list
+            if height > 1:
+                len_s = [len(line) for line in s_lines]
+            else:
+                len_s = [len(s)]
+            # For each line, clear line then print line then fill the rest depending on len of last printed line
+            fp_write(
+              '\n'.join(
+                '\r' + line + (' ' * max(last_len_s - len(line), 0)) for last_len_s, line in zip(last_len[0], s_lines)
+              )
+            )
+            # Replace cursor at the first line
+            if height > 1:
+                movetomulti(-height + 1)
+            # Store length of each line
+            last_len[0] = len_s
+        return print_status
+
+    def format_meter(self, n, total, elapsed, ncols=None, prefix='',
+                     ascii=False, unit='it', unit_scale=False, rate=None,
+                     bar_format=None):
+        """
+        Return a string-based progress bar given some parameters
+
+        Parameters
+        ----------
+        Same as core tqdm.
+
+        bar_format  : str/list, optional
+            Specify a custom bar string formatting. May impact performance.
+            [default: '{l_bar}{bar}{r_bar}'], where l_bar is
+            '{desc}{percentage:3.0f}%|' and r_bar is
+            '| {n_fmt}/{total_fmt} [{elapsed_str}<{remaining_str}, {rate_fmt}]'
+            Possible vars: bar, n, n_fmt, total, total_fmt, percentage,
+            rate, rate_fmt, elapsed, remaining, l_bar, r_bar, desc.
+
+        Returns
+        -------
+        out  : Formatted meter and stats, ready to display.
+        """
+
+        # No custom symbol (bar_format is not a dict), just call super
+        if not bar_format or \
+         bar_format and isinstance(bar_format, basestring):
+            return super(tqdm_custommulti, self).format_meter(n, total, elapsed, ncols,
+                     prefix, ascii, unit, unit_scale, rate, bar_format)
+
+        # Custom symbols!
+        else:
+            # Unpack variables if it's a list
+            if isinstance(bar_format, dict):
+                bar_template = bar_format.get('template', None)
+            else:
+                bar_template = bar_format
+
+            # Preprocess and generate bar arguments using super
+            bar_args = super(tqdm_custommulti, self).format_meter(n, total, elapsed,
+                         ncols, prefix, ascii, unit, unit_scale, rate,
+                         bar_format=True)
+
+            # Format bar using the template
+            if bar_template:
+                bar_args['bar'] = '{bar}'  # trick to format all except bar
+                full_bar = bar_template.format(**bar_args)
+                l_bar, r_bar = full_bar.split('{bar}')
+            else:
+                l_bar, r_bar = bar_args['l_bar'], bar_args['r_bar']
+
+            custom_symbols = None
+
+            # total is known: we can predict some stats
+            if total:
+                frac = bar_args['frac']
+                percentage = bar_args['percentage']
+
+                remaining_str = bar_args['remaining']
+
+                N_BARS = bar_args['n_bars']
+
+                # custom symbols format
+                # need to provide both ascii and unicode versions of custom symbols
+                if bar_format and isinstance(bar_format, dict):
+                    # get ascii or unicode template
+                    if ascii:
+                        c_symb = bar_format['symbols'].get('ascii', list("123456789#"))
+                    else:
+                        c_symb = bar_format['symbols'].get('unicode', map(_unich, range(0x258F, 0x2587, -1)))
+                    # looping symbols: just update the symbol animation at each iteration
+                    if bar_format['symbols'].get('loop', False):
+                        # increment one step in the animation for each display
+                        self.n_anim += 1
+                        # get the symbol for current animation step
+                        bar = c_symb[divmod(self.n_anim, len(c_symb))[1]]
+                        frac_bar = ''
+
+                        bar_length = N_BARS  # avoid the filling
+                        frac_bar_length = len(frac_bar)
+                    # normal progress symbols
+                    else:
+                        nb_symb = len(c_symb)
+                        len_filler = len(c_symb[-1])
+                        bar_length, frac_bar_length = divmod(
+                            int((frac/len_filler) * N_BARS * nb_symb), nb_symb)
+
+                        bar = c_symb[-1] * bar_length  # last symbol is always the filler
+                        frac_bar = c_symb[frac_bar_length] if frac_bar_length \
+                            else ' '
+                        # update real bar length (if symbols > 1 char) for correct filler
+                        bar_length = bar_length * len_filler
+
+                # ascii format
+                elif ascii:
+                    # get the remainder of the division of current fraction with number of symbols
+                    # this will tell us which symbol we should pick
+                    bar_length, frac_bar_length = divmod(
+                        int(frac * N_BARS * 10), 10)
+
+                    bar = '#' * bar_length
+                    frac_bar = chr(48 + frac_bar_length) if frac_bar_length \
+                        else ' '
+
+                # unicode format (if available)
+                else:
+                    bar_length, frac_bar_length = divmod(int(frac * N_BARS * 8), 8)
+
+                    bar = _unich(0x2588) * bar_length
+                    frac_bar = _unich(0x2590 - frac_bar_length) \
+                        if frac_bar_length else ' '
+
+                # whitespace padding
+                if bar_length < N_BARS:
+                    full_bar = bar + frac_bar + \
+                        ' ' * max(N_BARS - bar_length - len(frac_bar), 0)
+                else:
+                    full_bar = bar + \
+                        ' ' * max(N_BARS - bar_length, 0)
+
+                # Piece together the bar parts
+                return l_bar + full_bar + r_bar
+
+            # no total: no progressbar, ETA, just progress stats
+            else:
+                N_BARS = bar_args['n_bars']
+
+                # get ascii or unicode template
+                if ascii:
+                    c_symb = bar_format['symbols_indeterminate'].get('ascii', ["====="])
+                    c_symb_rev = bar_format['symbols_indeterminate'].get('ascii_rev', c_symb)
+                else:
+                    c_symb = bar_format['symbols_indeterminate'].get('unicode', ["====="])
+                    c_symb_rev = bar_format['symbols_indeterminate'].get('unicode_rev', c_symb)
+                # looping symbols: just update the symbol animation at each iteration
+                if bar_format['symbols_indeterminate'].get('loop', False):
+                    # increment one step in the animation for each display
+                    self.n_anim += 1
+                    # Get current bar animation based on current iteration
+                    bar = c_symb[divmod(self.n_anim, len(c_symb))[1]]
+
+                    bar_length = N_BARS  # avoid the filling
+                # indeterminate progress bar (cycle from left to right then right to left)
+                else:
+                    # increment one step in the animation for each display
+                    self.n_anim += 1
+                    # Get current bar animation based on current iteration
+                    bar = c_symb[divmod(self.n_anim, len(c_symb))[1]]
+                    bar_lines = bar.splitlines()
+                    c_width = len(bar_lines[0])
+                    # Get left filling space and animation step (right pass or left?)
+                    anim_step, fill_left = divmod(self.n_anim, (N_BARS - c_width))
+                    # If anim_step is odd, then we do left pass (2nd pass)
+                    if divmod(anim_step, 2)[1] == 1:
+                        # Inverse the left filling space (now it's the right space)
+                        fill_left = N_BARS - c_width - fill_left
+                        # Reverse the bar string
+                        bar = '\n'.join(mirror_line(line) for line in bar_lines)
+
+                    # Generate bar with left filling space
+                    l_bar_fill = ' ' * len(l_bar)
+                    r_bar_fill = ' ' * len(r_bar)
+                    l_fill = ' ' * fill_left
+                    bar_lines = bar.splitlines()  # split bar again because it may have been reversed
+                    middle_bar = int(len(bar_lines) / 2)
+                    r_fill = ' ' * max(N_BARS - fill_left - len(bar_lines[middle_bar]), 0)
+
+                    # Construct final bar line by line: print the bar status at the middle, otherwise print only the symbol animation on the other lines and fill with blanks to correctly position the symbol.
+                    full_bar = '\n'.join(l_bar + l_fill + line + r_fill + r_bar if line_nb == middle_bar else
+                                        l_bar_fill + l_fill + line + r_fill + r_bar_fill for line_nb, line in enumerate(bar_lines)
+                                        )
+                    
+                    self.last_print_height = sum(1 for line in full_bar.splitlines())
+
+                # Piece together the bar parts
+                return full_bar
+
+    def __init__(self, *args, **kwargs):
+        """
+        mininterval:  float, optional
+            Controls display refresh rate just like for core tqdm,
+            but in addition also controls looping symbols animation speed
+            (except if miniters is set, then miniters controls the animation).
+        bar_format:  str/dict, optional
+            Can either be a string, or a dict for more complex templating.
+            Format: {'template': '{l_bar}{bar}{r_bar}',
+                         'symbols': {'unicode': ['1', '2', '3', '4', '5', '6'],
+                                         'ascii': ['1', '2', '3'],
+                                         'loop': False}
+                         'symbols_indeterminate': {'unicode': ....
+                         }
+        """
+        # get bar_format
+        bar_format = kwargs.get('bar_format', None)
+        
+        if bar_format and isinstance(bar_format, dict):
+            kwargs['bar_format'] = bar_format.get('template', None)
+
+        # Do rest of init with cleaned up bar_format
+        super(tqdm_custommulti, self).__init__(*args, **kwargs)
+
+        # Store the arguments
+        bar_format['template'] = self.bar_format
+        self.bar_format = bar_format
+        self.n_anim = 0  # animation step for looping symbols
+        self.last_print_height = 1  # number of lines of last printed symbol
+
+        # Preprocess multiline symbols
+        for key in self.bar_format.keys():
+            if not isinstance(self.bar_format[key], dict):
+                continue
+            is_multiline = self.bar_format[key].get('multiline', False)
+            # Padding
+            if is_multiline:
+                for type in ['ascii', 'unicode']:
+                    p_symb = []
+                    # Preprocess each symbol of the animation
+                    for symb in self.bar_format[key].get(type, []):
+                        # Break symbol into list of lines
+                        symb = docstring2lines(symb)
+                        # Find the longest line
+                        _, longest = argmax(len(line) for line in symb)
+                        # Right pad the other lines (because right facing symbol)
+                        symb = [line + ' ' * (longest - len(line)) for line in symb]
+                        # Stitch lines back together
+                        p_symb.append('\n'.join(symb))
+                    # Put the whole animation back into bar_format
+                    if p_symb:
+                        self.bar_format[key][type] = p_symb
+
+            # Precompute reverse strings (if not provided) for loop symbol
+            for type, type_rev in [('ascii','ascii_rev'), ('unicode', 'unicode_rev')]:
+                entry = self.bar_format[key].get(type, None)
+                entry_rev = self.bar_format[key].get(type_rev, None)
+                # If type (ascii or unicode) exists but not the reversed
+                if entry and not entry_rev:
+                    # Then reverse each symbol
+                    p_symb = []
+                    for symb in entry:
+                        # If multiline, reverse line by line each symbol
+                        if is_multiline:
+                            p_symb.append( '\n'.join(mirror_line(line) for line in symb) )
+                        # Else symbol is one line, reverse it directly
+                        else:
+                            p_symb.append( mirror_line(symb) )
+                    # And store the reversed symbols
+                    self.bar_format[key][type_rev] = p_symb
+
+
+def tcmrange(*args, **kwargs):
+    """
+    A shortcut for tqdm_custommulti(xrange(*args), **kwargs).
+    On Python3+ range is used instead of xrange.
+    """
+    return tqdm_custommulti(_range(*args), **kwargs)

--- a/tqdm/_tqdm_custommulti.py
+++ b/tqdm/_tqdm_custommulti.py
@@ -83,11 +83,10 @@ class tqdm_custommulti(tqdm):
                 len_s = [len(s)]
             # For each line, clear line then print line then fill the rest depending on len of last printed line
             # fillvalue must be '' if s_lines is shorter, or 0 if last_len is shorter
-            fp_write(
-              '\n'.join(
-                '\r' + line + (' ' * max(last_len_s - len(line), 0)) for last_len_s, line in _zip_longest(last_len[0], s_lines, fillvalue='' if len(last_len[0]) > len(len_s) else 0)
-              )
-            )
+            out = ['\r' + line + (' ' * max(last_len_s - len(line), 0)) for last_len_s, line in _zip_longest(last_len[0], s_lines, fillvalue='' if len(last_len[0]) > len(len_s) else 0)]
+            fp_write('\n'.join(out))
+            # Update height to what was really printed
+            height = len(out)
             # Replace cursor at the first line
             if height > 1:
                 movetomulti(-height + 1)

--- a/tqdm/_tqdm_custommulti.py
+++ b/tqdm/_tqdm_custommulti.py
@@ -398,6 +398,17 @@ class tqdm_custommulti(tqdm):
                     # And store the reversed symbols
                     self.bar_format[key][type_rev] = p_symb
 
+    def close(self):
+        """
+        Cleanup for multiline bars
+        """
+        super(tqdm_custommulti, self).close()
+        if self.leave:
+            if self.pos:
+                self.moveto(self.pos)
+            else:
+                self.moveto(self.last_print_height - 1)
+
 
 def tcmrange(*args, **kwargs):
     """

--- a/tqdm/_tqdm_custommulti.py
+++ b/tqdm/_tqdm_custommulti.py
@@ -20,6 +20,13 @@ from ._utils import _range
 # to inherit from the tqdm class
 from ._tqdm import tqdm
 
+try:
+    from itertools import zip_longest as _zip_longest
+    from itertools import izip as _zip
+except ImportError:
+    from itertools import izip_longest as _zip_longest
+    _zip = zip
+
 
 __author__ = {"github.com/": ["lrq3000"]}
 __all__ = ['tqdm_custommulti', 'tcmrange']
@@ -75,9 +82,10 @@ class tqdm_custommulti(tqdm):
             else:
                 len_s = [len(s)]
             # For each line, clear line then print line then fill the rest depending on len of last printed line
+            # fillvalue must be '' if s_lines is shorter, or 0 if last_len is shorter
             fp_write(
               '\n'.join(
-                '\r' + line + (' ' * max(last_len_s - len(line), 0)) for last_len_s, line in zip(last_len[0], s_lines)
+                '\r' + line + (' ' * max(last_len_s - len(line), 0)) for last_len_s, line in _zip_longest(last_len[0], s_lines, fillvalue='' if len(last_len[0]) > len(len_s) else 0)
               )
             )
             # Replace cursor at the first line
@@ -233,7 +241,7 @@ class tqdm_custommulti(tqdm):
                         full_bar = '\n'.join(l_bar + filler + frac + r_fill + r_bar \
                             if line_nb == middle_bar else \
                             l_bar_fill + filler + frac + r_fill + r_bar_fill \
-                            for line_nb, filler, frac in zip(count(), filler_lines, frac_lines))
+                            for line_nb, filler, frac in _zip(count(), filler_lines, frac_lines))
 
             # no total: no progressbar, ETA, just progress stats
             else:


### PR DESCRIPTION
Implements also #181 (add callback support for bar_format) + custom bar symbols formatting as a submodule.

Not the most urgent PR, but we missed some more customization (pretty sure someone will ask someday!). So here it is: the ability to set custom bar symbols, just like our fellow [progressbar2](https://github.com/WoLpH/python-progressbar):

```
import time
from tqdm import tcrange, tqdm_custom

bar_format = {'template': '{l_bar}{bar}{r_bar}',
                     'symbols': {'ascii': list('ABCDEO'),
                                      'loop': False},
                     }

bar_format_loop = {
                     'symbols': {'ascii': list('/-\|'),
                                      'loop': True},
                     }

bar_format_ind_loop = {
                    'symbols_indeterminate': {'ascii': list('/-\|'),
                                      'loop': True},
                      }

bar_format_ind = {
                    'symbols_indeterminate': {'ascii': ['----{,_,">', '----{,_,*>'],
                                      'loop': False},
                      }

for i in tcrange(100, ascii=True, bar_format=bar_format):
    time.sleep(0.1)

for i in tcrange(100, ascii=True, bar_format=bar_format_loop):
    time.sleep(0.1)

with tqdm_custom(ascii=True, bar_format=bar_format_ind_loop) as tt1:
    for i in xrange(100):
        time.sleep(0.1)
        tt1.update()

with tqdm_custom(ascii=True, bar_format=bar_format_ind) as tt2:
    for i in xrange(100):
        time.sleep(0.1)
        tt2.update()
```

Respective outputs:

```
  9%|OOOE                                      | 9/100 [00:00<00:09,  9.95it/s]

 12%|/| 12/100 [00:01<00:08, 10.00it/s]

100it|/| 100/? [00:10,  9.91it/s]

100it|                          ----{,_,">           | 100/? [00:10, 10.00it/s]
```

For multiline (work in progress, needs bugfixes):

```
import time
from tqdm import tcmrange, tqdm_custommulti
from copy import deepcopy

bar_format_ind_multi = {
                    'symbols_indeterminate': {'ascii': [
"""
     _
\. _(9>
 \==_)
  -'=
""",
"""
     _
\. _(6>
 \==_)
  -'=
"""
],
                                      'loop': False,
                                      'multiline': True},
                      }


bar_format_ind_loop_multi = {
                    'symbols_indeterminate': {'ascii': [
"""
     _
\. _(9>
 \==_)
  -'=
""",
"""
     _
\. _(6>
 \==_)
  -'=
"""
],
                                      'loop': True,
                                      'multiline': True},
                      }

bar_format_loop_multi = {
                    'symbols': {'ascii': [
"""
     _
\. _(9>
 \==_)
  -'=
""",
"""
     _
\. _(6>
 \==_)
  -'=
"""
],
                                      'loop': True,
                                      'multiline': True},
                      }

bar_format_multi = {
                    'symbols': {'ascii': [
"""
. . . 
 . .
. . .
""",
"""
* * * 
 * *
* * *
""",
"""
= = = 
 = =
= = =
""",
"""
0 0 0 
 0 0
0 0 0
""",
"""
O O O 
 O O
O O O
""",
                                    ],
                                      'loop': False,
                                      'multiline': True},
                      }

bar_format_multi_anim = {
                    'symbols': {'ascii': [
["""
. . . 
 . .
. . .
""",
"""
 . .
. . . 
 . .
"""],
["""
* * * 
 * *
* * *
""",
"""
 * *
* * * 
 * *
"""],
["""
= = = 
 = =
= = =
""",
"""
 = =
= = = 
 = =
"""],
["""
0 0 0 
 0 0
0 0 0
""",
"""
 0 0
0 0 0 
 0 0
"""],
["""
O O O 
 O O
O O O
""",
"""
 O O
O O O 
 O O
"""],
                                    ],
                                      'loop': False,
                                      'multiline': True,
                                      'random': False},
                      }

bar_format_multi_anim_rand = deepcopy(bar_format_multi_anim)
bar_format_multi_anim_rand['symbols']['random'] = True

sleep_step = 0.05
anim_interval = 0.1

for i in tcmrange(100, mininterval=anim_interval, ascii=True, bar_format=bar_format_loop_multi):
    time.sleep(sleep_step)

with tqdm_custommulti(mininterval=anim_interval, ascii=True, bar_format=bar_format_ind_loop_multi) as ttm1:
    for i in xrange(100):
        time.sleep(sleep_step)
        ttm1.update()

with tqdm_custommulti(mininterval=anim_interval, ascii=True, bar_format=bar_format_ind_multi) as ttm1:
    for i in xrange(300):
        time.sleep(sleep_step)
        ttm1.update()

for i in tcmrange(100, mininterval=anim_interval, ascii=True, bar_format=bar_format_multi):
    time.sleep(sleep_step)

for i in tcmrange(100, mininterval=anim_interval, ascii=True, bar_format=bar_format_multi_anim):
    time.sleep(sleep_step)

for i in tcmrange(100, mininterval=anim_interval, ascii=True, bar_format=bar_format_multi_anim_rand):
    time.sleep(sleep_step)
```

User can specify both ascii and unicode versions of the bar, if one isn't provided, then it will fallback to the default tqdm bar.

TODO:
- [x] Add indeterminate progress customization
- [x] Optimize reversing symbol by precomputing in `__init__` and then loading it at the same time as `c_symbol` (eg, `c_symbol_reverse = self.bar_format[key].get('ascii_reverse', None)` ? Would allow manual user reversing BTW).
- [x] Rebase on #181 
- [x] Remove copy/pasted code thank's to #181 
- [x] Multiline symbols support (fish/nyanbar-like, see below)
  - [x] Multiline indeterminate bar
  - [x] Multiline loop (both indeterminate and determinate)
  - [x] Multiline animated progress bar
  - [ ] Fix leave=True (there are more than the required line returns sometimes, I guess it's Windows terminal's fault, it seems it doubles the number of line returns when reaching the terminal's end)
  - [ ] Fix multiline progress bar overflowing ncols when 100%
  - [ ] Fix multiline progress bar frac not reaching filler symbol when 100%
  - [x] Fix multiple parallel/nested multiline bars using `self.last_print_height` (works with leave=False, need to fix leave=True bug)
- [ ] Fix Flake8
- [ ] Add unit tests
- [ ] Update docstrings and readme

About multiline symbols:
We should try to implement multiline animated ascii-art bars like [nyanbar](https://github.com/apg/nyanbar) or [fish](https://github.com/lericson/fish). This shouldn't be too hard to implement, let me explain:

Basically, we have currently 4 different bar displays:
- **progress bar** : standard progress bar with numbers 1 to 9 and then `#` when enough progress, and it gets filled up until it reaches 100% completion.
- **progress loop** : animated symbol that loops in-place, takes minimal space on screen.
- **indeterminate bar** : infinite progress bar with a symbol that goes from left to right, then right to left (because we don't know when it ends).
- **indeterminate loop** : like progress loop.

Then for all these cases, you can add `multiline` support. We can then assimilate `fish` and `nyanbar` to the following cases:
- fish single line = indeterminate bar
- fish multi line = indeterminate bar **multiline**
- nyanbar = progress bar **multiline**

So if we can support multiline, we can essentially support what these two libraries do (somewhat, because for example `nyanbar` would only be simulated since the real one generates random colored blocks, our version would have fixed sprites but if you make enough of them, then you can give the illusion it's random).

Only issue is how to handle multiple concurrent tqdm bars, but this can be managed I think (we can memorize the number of lines of the last printed symbol and get back to original position, just like we currently do with automated nesting, then when we `move_to()` we would compute the correct position to print using `sum([t.s_height for t in tqdm._instances if t.pos < self.pos])`).

---

**The rest of the text here is for the old version of this PR.**

For reference, the old way with bar string templating was like this (but it was scraped to give more flexibility, but maybe it will be reintroduced in the future if people like it):

```
import time
from tqdm import tcrange

for i in tcrange(100, ascii=True, bar_format='{l_bar}{bar}{bar_symbols_ascii},A,B,C,D,E,O{/bar_symbols_ascii}{r_bar}'):
    time.sleep(0.1)

for i in tcrange(100, ascii=True, bar_format='{l_bar}{bar}{bar_symbols_loop_ascii},/,-,\,|{/bar_symbols_loop_ascii}{r_bar}'):
    time.sleep(0.1)
```

There are four different new tags for `bar_format`:
- `{bar_symbols}` and `{bar_symbols_ascii}` set custom progress bar symbols (unicode or ascii respectively)
- `{bar_symbols_loop}` and `{bar_symbols_loop_ascii}` set animated looping symbols (unicode or ascii respectively)

As you can see, I added both unicode and ascii tags, so that the user can provide either one or both. If the user didn't provide custom symbols for the target environment (eg, user provided `{bar_symbols}` but the environment is ascii), then the bar will fallback to the default bar. Why? This is to ensure robustness, so the user has to explicitly provide both a unicode and an ascii bars to work in all envs.

Formatting follow a rule similar to egrep: the first character is the separator, then the rest is compiled in a list of symbols. Eg:
- `{bar_symbols}|1|2|3|#{/bar_symbols}` --> `|` is the separator
- `{bar_symbols_loop},|,/,-,\{/bar_symbols_loop}` --> `,` is the separator

Note that symbols are not necessarily only one character long, they can be longer (can be interesting for animated loops). /EDIT: tested and it works.
