### PR TITLE
Fix maxinterval to adjust miniters to mininterval + fix dynamic_miniters when smoothing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -276,8 +276,9 @@ Parameters
     Minimum progress display update interval, in seconds [default: 0.1].
 * maxinterval  : float, optional  
     Maximum progress display update interval, in seconds [default: 10].
-    Automatically adjusts miniters to mininterval after a too long
-    update. Only works if ``dynamic_miniters`` or monitor thread enabled.
+    Automatically adjusts ``miniters`` to correspond to ``mininterval``
+    after long display update lag. Only works if ``dynamic_miniters``
+    or monitor thread is enabled.
 * miniters  : int, optional  
     Minimum progress display update interval, in iterations.
     If 0 and ``dynamic_miniters``, will automatically adjust to equal

--- a/README.rst
+++ b/README.rst
@@ -273,12 +273,19 @@ Parameters
     fallback is a meter width of 10 and no limit for the counter and
     statistics. If 0, will not print any meter (only stats).
 * mininterval  : float, optional  
-    Minimum progress update interval, in seconds [default: 0.1].
+    Minimum progress display update interval, in seconds [default: 0.1].
 * maxinterval  : float, optional  
-    Maximum progress update interval, in seconds [default: 10.0].
+    Maximum progress display update interval, in seconds [default: 10].
+    Automatically adjusts miniters to mininterval after a too long
+    update. Only works if ``dynamic_miniters`` or monitor thread enabled.
 * miniters  : int, optional  
-    Minimum progress update interval, in iterations.
-    If specified, will set ``mininterval`` to 0.
+    Minimum progress display update interval, in iterations.
+    If 0 and ``dynamic_miniters``, will automatically adjust to equal
+    ``mininterval`` (more CPU efficient, good for tight loops).
+    If > 0, will skip display of specified number of iterations.
+    Tweak this and ``mininterval`` to get very efficient loops.
+    If your progress is erratic with both fast and slow iterations
+    (network, skipping items, etc) you should set miniters=1.
 * ascii  : bool, optional  
     If unspecified or False, use unicode (smooth blocks) to fill
     the meter. The fallback is to use ASCII characters ``1-9 #``.

--- a/examples/simple_examples.py
+++ b/examples/simple_examples.py
@@ -28,8 +28,22 @@ for i in tqdm.tgrange(int(1e8)):
     pass
 
 # Comparison to https://code.google.com/p/python-progressbar/
-from progressbar.progressbar import ProgressBar
-for i in ProgressBar()(_range(int(1e8))):
+try:
+    from progressbar.progressbar import ProgressBar
+except ImportError:
+    pass
+else:
+    for i in ProgressBar()(_range(int(1e8))):
+        pass
+
+# Dynamic miniters benchmark
+from tqdm import trange
+for i in trange(int(1e8), miniters=None, mininterval=0.1, smoothing=0):
+    pass
+
+# Fixed miniters benchmark
+from tqdm import trange
+for i in trange(int(1e8), miniters=4500000, mininterval=0.1, smoothing=0):
     pass
 """
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -573,8 +573,9 @@ class tqdm(object):
             Minimum progress display update interval, in seconds [default: 0.1].
         maxinterval  : float, optional
             Maximum progress display update interval, in seconds [default: 10].
-            Automatically adjusts miniters to mininterval after a too long
-            update. Only works if `dynamic_miniters` or monitor thread enabled.
+            Automatically adjusts `miniters` to correspond to `mininterval`
+            after long display update lag. Only works if `dynamic_miniters`
+            or monitor thread is enabled.
         miniters  : int, optional
             Minimum progress display update interval, in iterations.
             If 0 and `dynamic_miniters`, will automatically adjust to equal
@@ -846,8 +847,8 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                         if self.pos:
                             self.moveto(-self.pos)
 
-                        # If no miniters was specified, adjust automatically to
-                        # the max iteration rate seen so far between 2 prints.
+                        # If no `miniters` was specified, adjust automatically
+                        # to the max iteration rate seen so far between 2 prints
                         if dynamic_miniters:
                             if maxinterval and delta_t >= maxinterval:
                                 # Adjust miniters to time interval by rule of 3

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -789,6 +789,7 @@ class tqdm(object):
             ncols = self.ncols
             mininterval = self.mininterval
             maxinterval = self.maxinterval
+            miniters = self.miniters
             dynamic_miniters = self.dynamic_miniters
             unit = self.unit
             unit_scale = self.unit_scale

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -480,7 +480,7 @@ def test_max_interval():
                                (total/2)*maxinterval/(maxinterval*2)
                                ]
 
-    # Same with iteratable based tqdm
+    # Same with iterable based tqdm
     timer1 = DiscreteTimer()  # need 2 timers for each bar because zip not work
     timer2 = DiscreteTimer()
     total = 100

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -382,9 +382,9 @@ def test_max_interval():
     total = 100
     bigstep = 10
     smallstep = 5
-    timer = DiscreteTimer()
 
     # Test without maxinterval
+    timer = DiscreteTimer()
     with closing(StringIO()) as our_file:
         with closing(StringIO()) as our_file2:
             # with maxinterval but higher than loop sleep time
@@ -417,6 +417,7 @@ def test_max_interval():
         assert "25%" not in our_file.read()
 
     # Test with maxinterval effect
+    timer = DiscreteTimer()
     with closing(StringIO()) as our_file:
         with tqdm(total=total, file=our_file, miniters=None, mininterval=0,
                   smoothing=1, maxinterval=1e-4) as t:
@@ -433,6 +434,7 @@ def test_max_interval():
             assert "25%" in our_file.read()
 
     # Test iteration based tqdm with maxinterval effect
+    timer = DiscreteTimer()
     with closing(StringIO()) as our_file:
         with tqdm(_range(total), file=our_file, miniters=None,
                   mininterval=1e-5, smoothing=1, maxinterval=1e-4) as t2:
@@ -447,6 +449,69 @@ def test_max_interval():
 
         our_file.seek(0)
         assert "15%" in our_file.read()
+
+    # Test different behavior with and without mininterval
+    timer = DiscreteTimer()
+    total = 1000
+    mininterval = 0.1
+    maxinterval = 10
+    with closing(StringIO()) as our_file:
+        with tqdm(total=total, file=our_file, miniters=None, smoothing=1,
+                  mininterval=mininterval, maxinterval=maxinterval) as tm1:
+            with tqdm(total=total, file=our_file, miniters=None, smoothing=1,
+                      mininterval=0, maxinterval=maxinterval) as tm2:
+
+                cpu_timify(tm1, timer)
+                cpu_timify(tm2, timer)
+
+                # Fast iterations, check if dynamic_miniters triggers
+                timer.sleep(mininterval)  # to force update for t1
+                tm1.update(total/2)
+                tm2.update(total/2)
+                assert int(tm1.miniters) == tm2.miniters == total/2
+
+                # Slow iterations, check different miniters if mininterval
+                timer.sleep(maxinterval*2)
+                tm1.update(total/2)
+                tm2.update(total/2)
+                res = [tm1.miniters, tm2.miniters]
+                assert res == [
+                               (total/2)*mininterval/(maxinterval*2),
+                               (total/2)*maxinterval/(maxinterval*2)
+                               ]
+
+    # Same with iteratable based tqdm
+    timer1 = DiscreteTimer()  # need 2 timers for each bar because zip not work
+    timer2 = DiscreteTimer()
+    total = 100
+    mininterval = 0.1
+    maxinterval = 10
+    with closing(StringIO()) as our_file:
+        t1 = tqdm(_range(total), file=our_file, miniters=None, smoothing=1,
+                  mininterval=mininterval, maxinterval=maxinterval)
+        t2 = tqdm(_range(total), file=our_file, miniters=None, smoothing=1,
+                  mininterval=0, maxinterval=maxinterval)
+
+        cpu_timify(t1, timer1)
+        cpu_timify(t2, timer2)
+
+        for i in t1:
+            if i == ((total/2)-2):
+                timer1.sleep(mininterval)
+            if i == (total-1):
+                timer1.sleep(maxinterval*2)
+
+        for i in t2:
+            if i == ((total/2)-2):
+                timer2.sleep(mininterval)
+            if i == (total-1):
+                timer2.sleep(maxinterval*2)
+
+        assert t1.miniters == 0.255
+        assert t2.miniters == 0.5
+
+        t1.close()
+        t2.close()
 
 
 @with_setup(pretest, posttest)


### PR DESCRIPTION
... + Deprecation warning test to get 100% coverage again + Update readme and docstrings to provide more details about these parameters.

Fix regressions spotted in #249 (maxinterval fixing miniters too high) and in #258 (smoothing=0 breaks dynamic_miniters, also old calculation made tqdm faster, so it was reinstated).

Maxinterval would sometimes fix miniters to a value higher than it should, because it was adjusting miniters according to maxinterval instead of mininterval (the other conditions for dynamic_miniters are ok and adjusted better than maxinterval).

Also updated the readme and docstring to give more details on the various interval parameters (mininterval, maxinterval, miniters). They are critical for lots of people and define most of the somewhat weird behaviors of tqdm, so I think they ought to have extensive documentation both in the readme and the docstring.

TODO:
- [x] Fix miniters calculation by maxinterval
- [x] Fix unit test
- [x] Flake8
- [x] Add coverage unit test for deprecation exception (100% unit test again for tqdm core)
