### PR TITLE
Disable coveralls because of duplicate comments on github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,15 +42,16 @@ install:
   # https://docs.travis-ci.com/user/caching/#Clearing-Caches
   - pip install pandas
   # Coverage install
-  - pip install tox 'coverage<4' coveralls
+  # - pip install tox 'coverage<4' coveralls
+  - pip install tox 'coverage<4'
   # install this package (tqdm) into the environment
   - python setup.py install
 
 # run tests
 script:
   - tox
-# submit coverage
 
+# submit coverage
 after_success:
-  - coveralls
+  # - coveralls
   - codecov


### PR DESCRIPTION
Coveralls is currently spamming our PR everytime we commit with duplicate comments containing the exact same info. This seems to have started when we merged #232, more exactly when we started caching pip packages like pandas. The error was reported by @CrazyPython to coveralls devs (https://github.com/lemurheavy/coveralls-public/issues/838) but it was closed and their fix doesn't seem to work.

Plus it reduces build time (~5 sec per python version) plus coveralls sometimes fails and makes the build fail.

Anyway, we use codecov since a while as our main coverage report because it is more stringent (branch coverage for codecov instead of statement coverage for coveralls). So we can safely disable it without losing anything.