### PR TITLE
cleaner tqdm_notebook exit when not run in a notebook

### DIFF
--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -203,15 +203,17 @@ class tqdm_notebook(tqdm):
 
     def close(self, *args, **kwargs):
         super(tqdm_notebook, self).close(*args, **kwargs)
-        # Try to detect if there was an error or KeyboardInterrupt
-        # in manual mode: if n < total, things probably got wrong
-        if self.total and self.n < self.total:
-            self.sp(bar_style='danger')
-        else:
-            if self.leave:
-                self.sp(bar_style='success')
+        # If it was not run in a notebook, sp is not assigned, check for it
+        if hasattr(self, 'sp'):
+            # Try to detect if there was an error or KeyboardInterrupt
+            # in manual mode: if n < total, things probably got wrong
+            if self.total and self.n < self.total:
+                self.sp(bar_style='danger')
             else:
-                self.sp(close=True)
+                if self.leave:
+                    self.sp(bar_style='success')
+                else:
+                    self.sp(close=True)
 
     def moveto(*args, **kwargs):
         # void -> avoid extraneous `\n` in IPython output cell


### PR DESCRIPTION
When not run in a notebook, the `sp` is not set. This checks if it is set, and exits cleanly.

The idea is to be able to do something like this (with appropriate catching if interested..):

```python
from tqdm import tqdm, tqdm_notebook

def progressbar(*args, **kwargs):
    try:
        return tqdm_notebook(*args, **kwargs)
    except:
        return tqdm(*args, **kwargs)
```

This is a temporary workaround I found useful while waiting for https://github.com/tqdm/tqdm/issues/234