### PR TITLE
Add set_postfix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -332,7 +332,7 @@ Parameters
     Specify the line offset to print this bar (starting from 0)
     Automatic if unspecified.
     Useful to manage multiple bars at once (eg, from threads).
-* postfix  : dict, optional
+* postfix  : dict, optional  
     Specify additional stats to display at the end of the bar.
 
 Extra CLI Options
@@ -444,9 +444,9 @@ Examples and Advanced Usage
 
 Description and additional stats
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Custom information can easily be displayed on ``tqdm`` bars by using the
-``desc`` and ``postfix`` arguments. They can also be updated dynamically
-inside your loops:
+
+Custom information can be displayed and updated dynamically on ``tqdm`` bars
+with the ``desc`` and ``postfix`` arguments:
 
 .. code:: python
 
@@ -456,10 +456,10 @@ inside your loops:
 
     t = trange(100)
     for i in t:
-        # Description will be displayed at the left
+        # Description will be displayed on the left
         t.set_description('GEN %i' % i)
-        # Postfix will choose the formatting based on argument's datatype
-        # and will display them as additional info at the right
+        # Postfix will be displayed on the right, and will format automatically 
+        # based on argument's datatype
         t.set_postfix(loss=random(), gen=randint(1,999), str='h', lst=[1, 2])
         sleep(0.1)
 

--- a/README.rst
+++ b/README.rst
@@ -251,7 +251,8 @@ Documentation
                    file=sys.stderr, ncols=None, mininterval=0.1,
                    maxinterval=10.0, miniters=None, ascii=None, disable=False,
                    unit='it', unit_scale=False, dynamic_ncols=False,
-                   smoothing=0.3, bar_format=None, initial=0, position=None):
+                   smoothing=0.3, bar_format=None, initial=0, position=None,
+                   postfix=None):
 
 Parameters
 ~~~~~~~~~~
@@ -331,6 +332,8 @@ Parameters
     Specify the line offset to print this bar (starting from 0)
     Automatic if unspecified.
     Useful to manage multiple bars at once (eg, from threads).
+* postfix  : dict, optional
+    Specify additional stats to display at the end of the bar.
 
 Extra CLI Options
 ~~~~~~~~~~~~~~~~~
@@ -392,6 +395,17 @@ Returns
           Print a message via tqdm (without overlap with bars)
           """
 
+      def set_description(self, desc=None):
+          """
+          Set/modify description of the progress bar.
+          """
+
+      def set_postfix(self, **kwargs):
+          """
+          Set/modify postfix (additional stats)
+          with automatic formatting based on datatype.
+          """
+
     def trange(*args, **kwargs):
         """
         A shortcut for tqdm(xrange(*args), **kwargs).
@@ -427,6 +441,27 @@ Examples and Advanced Usage
 - import the module and run ``help()``, or
 - consult the `wiki <https://github.com/tqdm/tqdm/wiki>`__.
     - this has an `excellent article <https://github.com/tqdm/tqdm/wiki/How-to-make-a-great-Progress-Bar>`__ on how to make a **great** progressbar.
+
+Description and additional stats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Custom information can easily be displayed on ``tqdm`` bars by using the
+``desc`` and ``postfix`` arguments. They can also be updated dynamically
+inside your loops:
+
+.. code:: python
+
+    from tqdm import trange
+    from random import random, randint
+    from time import sleep
+
+    t = trange(100)
+    for i in t:
+        # Description will be displayed at the left
+        t.set_description('GEN %i' % i)
+        # Postfix will choose the formatting based on argument's datatype
+        # and will display them as additional info at the right
+        t.set_postfix(loss=random(), gen=randint(1,999), str='h', lst=[1, 2])
+        sleep(0.1)
 
 Nested progress bars
 ~~~~~~~~~~~~~~~~~~~~

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -717,7 +717,8 @@ class tqdm(object):
         self._time = time
         self.bar_format = bar_format
         self.postfix = None
-        if postfix: self.set_postfix(**postfix)
+        if postfix:
+            self.set_postfix(**postfix)
 
         # Init the iterations counters
         self.last_print_n = initial
@@ -1063,8 +1064,10 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
             # Else for any other type, try to get the string conversion
             elif not isinstance(kwargs[key], basestring):
                 kwargs[key] = str(kwargs[key])
+            # Else if it's a string, don't need to preprocess anything
         # Stitch together to get the final postfix
-        self.postfix = ', '.join('%s=%s' % (key, kwargs[key]) for key in kwargs.keys())
+        self.postfix = ', '.join('%s=%s' % (key, kwargs[key])
+                                 for key in kwargs.keys())
 
     def moveto(self, n):
         self.fp.write(_unicode('\n' * n + _term_move_up() * -n))

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -15,6 +15,7 @@ from __future__ import division
 from ._utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet
 import sys
+from numbers import Number
 from threading import Thread
 from time import time
 from time import sleep
@@ -199,7 +200,7 @@ class tqdm(object):
     @staticmethod
     def format_meter(n, total, elapsed, ncols=None, prefix='',
                      ascii=False, unit='it', unit_scale=False, rate=None,
-                     bar_format=None):
+                     bar_format=None, postfix=None):
         """
         Return a string-based progress bar given some parameters
 
@@ -240,6 +241,8 @@ class tqdm(object):
             '| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]'
             Possible vars: bar, n, n_fmt, total, total_fmt, percentage,
             rate, rate_fmt, elapsed, remaining, l_bar, r_bar, desc.
+        postfix  : str, optional
+            Same as prefix but will be placed at the end as additional stats.
 
         Returns
         -------
@@ -284,8 +287,9 @@ class tqdm(object):
             # format the stats displayed to the left and right sides of the bar
             l_bar = (prefix if prefix else '') + \
                 '{0:3.0f}%|'.format(percentage)
-            r_bar = '| {0}/{1} [{2}<{3}, {4}]'.format(
-                    n_fmt, total_fmt, elapsed_str, remaining_str, rate_fmt)
+            r_bar = '| {0}/{1} [{2}<{3}, {4}{5}]'.format(
+                    n_fmt, total_fmt, elapsed_str, remaining_str, rate_fmt,
+                    ', '+postfix if postfix else '')
 
             if ncols == 0:
                 return l_bar[:-1] + r_bar[1:]
@@ -310,6 +314,7 @@ class tqdm(object):
                             'l_bar': l_bar,
                             'r_bar': r_bar,
                             'desc': prefix if prefix else '',
+                            'postfix': ', '+postfix if postfix else '',
                             # 'bar': full_bar  # replaced by procedure below
                             }
 
@@ -358,8 +363,9 @@ class tqdm(object):
 
         # no total: no progressbar, ETA, just progress stats
         else:
-            return (prefix if prefix else '') + '{0}{1} [{2}, {3}]'.format(
-                n_fmt, unit, elapsed_str, rate_fmt)
+            return (prefix if prefix else '') + '{0}{1} [{2}, {3}{4}]'.format(
+                n_fmt, unit, elapsed_str, rate_fmt,
+                ', '+postfix if postfix else '')
 
     def __new__(cls, *args, **kwargs):
         # Create a new instance
@@ -540,6 +546,7 @@ class tqdm(object):
                  maxinterval=10.0, miniters=None, ascii=None, disable=False,
                  unit='it', unit_scale=False, dynamic_ncols=False,
                  smoothing=0.3, bar_format=None, initial=0, position=None,
+                 postfix=None,
                  gui=False, **kwargs):
         """
         Parameters
@@ -619,6 +626,8 @@ class tqdm(object):
             Specify the line offset to print this bar (starting from 0)
             Automatic if unspecified.
             Useful to manage multiple bars at once (eg, from threads).
+        postfix  : dict, optional
+            Specify additional stats to display at the end of the bar.
         gui  : bool, optional
             WARNING: internal parameter - do not use.
             Use tqdm_gui(...) instead. If set, will attempt to use
@@ -707,6 +716,8 @@ class tqdm(object):
         self.avg_time = None
         self._time = time
         self.bar_format = bar_format
+        self.postfix = None
+        if postfix: self.set_postfix(**postfix)
 
         # Init the iterations counters
         self.last_print_n = initial
@@ -723,7 +734,8 @@ class tqdm(object):
                 self.moveto(self.pos)
             self.sp(self.format_meter(self.n, total, 0,
                     (dynamic_ncols(file) if dynamic_ncols else ncols),
-                    self.desc, ascii, unit, unit_scale, None, bar_format))
+                    self.desc, ascii, unit, unit_scale, None, bar_format,
+                    self.postfix))
             if self.pos:
                 self.moveto(-self.pos)
 
@@ -752,7 +764,8 @@ class tqdm(object):
                                  self._time() - self.start_t,
                                  self.ncols, self.desc, self.ascii, self.unit,
                                  self.unit_scale, 1 / self.avg_time
-                                 if self.avg_time else None, self.bar_format)
+                                 if self.avg_time else None, self.bar_format,
+                                 self.postfix)
 
     def __lt__(self, other):
         return self.pos < other.pos
@@ -842,7 +855,8 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                             (dynamic_ncols(self.fp) if dynamic_ncols
                              else ncols),
                             self.desc, ascii, unit, unit_scale,
-                            1 / avg_time if avg_time else None, bar_format))
+                            1 / avg_time if avg_time else None, bar_format,
+                            self.postfix))
 
                         if self.pos:
                             self.moveto(-self.pos)
@@ -938,7 +952,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                      else self.ncols),
                     self.desc, self.ascii, self.unit, self.unit_scale,
                     1 / self.avg_time if self.avg_time else None,
-                    self.bar_format))
+                    self.bar_format, self.postfix))
 
                 if self.pos:
                     self.moveto(-self.pos)
@@ -1010,7 +1024,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                     (self.dynamic_ncols(self.fp) if self.dynamic_ncols
                      else self.ncols),
                     self.desc, self.ascii, self.unit, self.unit_scale, None,
-                    self.bar_format))
+                    self.bar_format, self.postfix))
             if pos:
                 self.moveto(-pos)
             else:
@@ -1035,6 +1049,22 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         Set/modify description of the progress bar.
         """
         self.desc = desc + ': ' if desc else ''
+
+    def set_postfix(self, **kwargs):
+        """
+        Set/modify postfix (additional stats)
+        with automatic formatting based on datatype.
+        """
+        # Preprocess stats according to datatype
+        for key in kwargs.keys():
+            # Number: limit the length of the string
+            if isinstance(kwargs[key], Number):
+                kwargs[key] = '{0:2.3g}'.format(kwargs[key])
+            # Else for any other type, try to get the string conversion
+            elif not isinstance(kwargs[key], basestring):
+                kwargs[key] = str(kwargs[key])
+        # Stitch together to get the final postfix
+        self.postfix = ', '.join('%s=%s' % (key, kwargs[key]) for key in kwargs.keys())
 
     def moveto(self, n):
         self.fp.write(_unicode('\n' * n + _term_move_up() * -n))

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -8,13 +8,12 @@ Usage:
   ...     ...
 """
 from __future__ import absolute_import
-# future division is important to divide integers and get as
-# a result precise floating numbers (instead of truncated int)
+# integer division / : float, // : int
 from __future__ import division
-# import compatibility functions and utilities
+# compatibility functions and utilities
 from ._utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict
-# import native libraries
+# native libraries
 import sys
 from numbers import Number
 from threading import Thread
@@ -1071,7 +1070,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                 postfix[key] = str(postfix[key])
             # Else if it's a string, don't need to preprocess anything
         # Stitch together to get the final postfix
-        self.postfix = ', '.join('%s=%s' % (key, postfix[key].strip())
+        self.postfix = ', '.join(key + '=' + postfix[key].strip()
                                  for key in postfix.keys())
 
     def moveto(self, n):

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -13,10 +13,9 @@ from __future__ import absolute_import
 from __future__ import division
 # import compatibility functions and utilities
 from ._utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
-    _term_move_up, _unicode, WeakSet, _basestring
+    _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict
 # import native libraries
 import sys
-from collections import OrderedDict
 from numbers import Number
 from threading import Thread
 from time import time
@@ -1059,7 +1058,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         with automatic formatting based on datatype.
         """
         # Sort in alphabetical order to be more deterministic
-        postfix = OrderedDict([] if ordered_dict is None else ordered_dict)
+        postfix = _OrderedDict([] if ordered_dict is None else ordered_dict)
         for key in sorted(kwargs.keys()):
             postfix[key] = kwargs[key]
         # Preprocess stats according to datatype

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import
 from __future__ import division
 # import compatibility functions and utilities
 from ._utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
-    _term_move_up, _unicode, WeakSet
+    _term_move_up, _unicode, WeakSet, _basestring
 import sys
 from numbers import Number
 from threading import Thread
@@ -1062,7 +1062,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
             if isinstance(kwargs[key], Number):
                 kwargs[key] = '{0:2.3g}'.format(kwargs[key])
             # Else for any other type, try to get the string conversion
-            elif not isinstance(kwargs[key], basestring):
+            elif not isinstance(kwargs[key], _basestring):
                 kwargs[key] = str(kwargs[key])
             # Else if it's a string, don't need to preprocess anything
         # Stitch together to get the final postfix

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -8,7 +8,7 @@ IS_NIX = (not IS_WIN) and any(
     ['CYGWIN', 'MSYS', 'Linux', 'Darwin', 'SunOS', 'FreeBSD'])
 
 
-# Py2/3 compatiibility code is inside an empty conditional to avoid coverage
+# Py2/3 compat. Empty conditional to avoid coverage
 if True:  # pragma: no cover
     try:
         _range = xrange
@@ -44,13 +44,13 @@ if True:  # pragma: no cover
     except NameError:
         _basestring = str
 
-    try:  # >= Py2.7 or >= Py3.1
+    try:  # py>=2.7,>=3.1
         from collections import OrderedDict as _OrderedDict
     except ImportError:
         try:  # older Python versions with backported ordereddict lib
             from ordereddict import OrderedDict as _OrderedDict
         except ImportError:  # older Python versions without ordereddict lib
-            # Py2.6 and 3.0 compatible code, from PEP 372
+            # Py2.6,3.0 compat, from PEP 372
             from collections import MutableMapping
             class _OrderedDict(dict, MutableMapping):
                 # Methods with direct access to underlying attributes
@@ -94,7 +94,6 @@ if True:  # pragma: no cover
                     return (self.__class__, (items,), inst_dict)
 
                 # Methods with indirect access via the above methods
-
                 setdefault = MutableMapping.setdefault
                 update = MutableMapping.update
                 pop = MutableMapping.pop

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -44,6 +44,78 @@ if True:  # pragma: no cover
     except NameError:
         _basestring = str
 
+    try:  # >= Py2.7 or >= Py3.1
+        from collections import OrderedDict as _OrderedDict
+    except ImportError:
+        try:  # older Python versions with backported ordereddict lib
+            from ordereddict import OrderedDict as _OrderedDict
+        except ImportError:  # older Python versions without ordereddict lib
+            # Py2.6 and 3.0 compatible code, from PEP 372
+            from collections import MutableMapping
+            class _OrderedDict(dict, MutableMapping):
+                # Methods with direct access to underlying attributes
+                def __init__(self, *args, **kwds):
+                    if len(args) > 1:
+                        raise TypeError('expected at 1 argument, got %d', len(args))
+                    if not hasattr(self, '_keys'):
+                        self._keys = []
+                    self.update(*args, **kwds)
+
+                def clear(self):
+                    del self._keys[:]
+                    dict.clear(self)
+
+                def __setitem__(self, key, value):
+                    if key not in self:
+                        self._keys.append(key)
+                    dict.__setitem__(self, key, value)
+
+                def __delitem__(self, key):
+                    dict.__delitem__(self, key)
+                    self._keys.remove(key)
+
+                def __iter__(self):
+                    return iter(self._keys)
+
+                def __reversed__(self):
+                    return reversed(self._keys)
+
+                def popitem(self):
+                    if not self:
+                        raise KeyError
+                    key = self._keys.pop()
+                    value = dict.pop(self, key)
+                    return key, value
+
+                def __reduce__(self):
+                    items = [[k, self[k]] for k in self]
+                    inst_dict = vars(self).copy()
+                    inst_dict.pop('_keys', None)
+                    return (self.__class__, (items,), inst_dict)
+
+                # Methods with indirect access via the above methods
+
+                setdefault = MutableMapping.setdefault
+                update = MutableMapping.update
+                pop = MutableMapping.pop
+                keys = MutableMapping.keys
+                values = MutableMapping.values
+                items = MutableMapping.items
+
+                def __repr__(self):
+                    pairs = ', '.join(map('%r: %r'.__mod__, self.items()))
+                    return '%s({%s})' % (self.__class__.__name__, pairs)
+
+                def copy(self):
+                    return self.__class__(self)
+
+                @classmethod
+                def fromkeys(cls, iterable, value=None):
+                    d = cls()
+                    for key in iterable:
+                        d[key] = value
+                    return d
+
 
 def _is_utf(encoding):
     return encoding.lower().startswith('utf-') or ('U8' == encoding)

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -8,6 +8,7 @@ IS_NIX = (not IS_WIN) and any(
     ['CYGWIN', 'MSYS', 'Linux', 'Darwin', 'SunOS', 'FreeBSD'])
 
 
+# Py2/3 compatiibility code is inside an empty conditional to avoid coverage
 if True:  # pragma: no cover
     try:
         _range = xrange
@@ -37,6 +38,11 @@ if True:  # pragma: no cover
         from weakref import WeakSet
     except ImportError:
         WeakSet = set
+
+    try:
+        _basestring = basestring
+    except NameError:
+        _basestring = str
 
 
 def _is_utf(encoding):

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -7,7 +7,6 @@ import sys
 import csv
 import re
 import os
-from collections import OrderedDict
 from nose import with_setup
 from nose.plugins.skip import SkipTest
 from nose.tools import assert_raises
@@ -1516,7 +1515,7 @@ def test_monitoring_thread():
 def test_postfix():
     """ Test postfix """
     postfix = {'float': 0.321034, 'gen': 543, 'str': 'h', 'lst': [2]}
-    postfix_order = OrderedDict((('w', 'w'), ('a', 0)))
+    postfix_order = (('w', 'w'), ('a', 0))  # no need for a OrderedDict, set is OK
     expected = ['float=0.321', 'gen=543', 'lst=[2]', 'str=h']
     expected_order = ['w=w', 'a=0', 'float=0.321', 'gen=543', 'lst=[2]', 'str=h']
 

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -7,6 +7,7 @@ import sys
 import csv
 import re
 import os
+from collections import OrderedDict
 from nose import with_setup
 from nose.plugins.skip import SkipTest
 from nose.tools import assert_raises
@@ -1514,8 +1515,10 @@ def test_monitoring_thread():
 @with_setup(pretest, posttest)
 def test_postfix():
     """ Test postfix """
-    postfix = {'float': 0.321034, 'gen': 543, 'str': 'h', 'lst': [1, 2]}
-    expected = ['lst=[1, 2]', 'float=0.321', 'gen=543', 'str=h']
+    postfix = {'float': 0.321034, 'gen': 543, 'str': 'h', 'lst': [2]}
+    postfix_order = OrderedDict((('w', 'w'), ('a', 0)))
+    expected = ['float=0.321', 'gen=543', 'lst=[2]', 'str=h']
+    expected_order = ['w=w', 'a=0', 'float=0.321', 'gen=543', 'lst=[2]', 'str=h']
 
     # Test postfix set at init
     with closing(StringIO()) as our_file:
@@ -1536,3 +1539,14 @@ def test_postfix():
     for res in expected:
         assert res in out
         assert res in out2
+
+    # Test postfix set after init and with ordered dict
+    with closing(StringIO()) as our_file:
+        with trange(10, file=our_file, desc='pos2 bar',
+                    bar_format='{r_bar}', postfix=None) as t3:
+            t3.set_postfix(postfix_order, **postfix)
+            t3.refresh()
+            out3 = our_file.getvalue()
+
+    out3 = out3[1:-1].split(', ')[3:]
+    assert out3 == expected_order

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1509,3 +1509,30 @@ def test_monitoring_thread():
                     sleep(0.000001)
                 assert t1.miniters == 1  # check that monitor corrected miniters
                 assert t2.miniters == 500  # check that t2 was not adjusted
+
+
+@with_setup(pretest, posttest)
+def test_postfix():
+    """ Test postfix """
+    postfix = {'float': 0.321034, 'gen': 543, 'str': 'h', 'lst': [1, 2]}
+    expected = ['lst=[1, 2]', 'float=0.321', 'gen=543', 'str=h']
+
+    # Test postfix set at init
+    with closing(StringIO()) as our_file:
+        t1 = tqdm(total=10, file=our_file, desc='pos0 bar',
+                  bar_format='{r_bar}', postfix=postfix)
+        t1.refresh()
+        out = our_file.getvalue()
+
+    # Test postfix set after init
+    with closing(StringIO()) as our_file:
+        t2 = trange(10, file=our_file, desc='pos1 bar',
+                    bar_format='{r_bar}', postfix=None)
+        t2.set_postfix(**postfix)
+        t2.refresh()
+        out2 = our_file.getvalue()
+
+    # Order of items in dict may change, so need a loop to check per item
+    for res in expected:
+        assert res in out
+        assert res in out2

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1513,7 +1513,7 @@ def test_monitoring_thread():
 
 @with_setup(pretest, posttest)
 def test_postfix():
-    """ Test postfix """
+    """Test postfix"""
     postfix = {'float': 0.321034, 'gen': 543, 'str': 'h', 'lst': [2]}
     postfix_order = (('w', 'w'), ('a', 0))  # no need for a OrderedDict, set is OK
     expected = ['float=0.321', 'gen=543', 'lst=[2]', 'str=h']

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1519,18 +1519,18 @@ def test_postfix():
 
     # Test postfix set at init
     with closing(StringIO()) as our_file:
-        t1 = tqdm(total=10, file=our_file, desc='pos0 bar',
-                  bar_format='{r_bar}', postfix=postfix)
-        t1.refresh()
-        out = our_file.getvalue()
+        with tqdm(total=10, file=our_file, desc='pos0 bar',
+                  bar_format='{r_bar}', postfix=postfix) as t1:
+            t1.refresh()
+            out = our_file.getvalue()
 
     # Test postfix set after init
     with closing(StringIO()) as our_file:
-        t2 = trange(10, file=our_file, desc='pos1 bar',
-                    bar_format='{r_bar}', postfix=None)
-        t2.set_postfix(**postfix)
-        t2.refresh()
-        out2 = our_file.getvalue()
+        with trange(10, file=our_file, desc='pos1 bar',
+                    bar_format='{r_bar}', postfix=None) as t2:
+            t2.set_postfix(**postfix)
+            t2.refresh()
+            out2 = our_file.getvalue()
 
     # Order of items in dict may change, so need a loop to check per item
     for res in expected:


### PR DESCRIPTION
Add a `postfix` argument and `set_postfix()` method to supply additional stats to display on the bar, as suggested in #266. The method automatically formats the inputs depending on their datatype. This could be useful for machine learning and for data scientists.

This is an alternative to `set_description()` which asks the user to format themselves the whole description.

Example:

```
from tqdm import trange
from random import random, randint
from time import sleep

t = trange(100)
for i in t:
    t.set_postfix(loss=random(), gen=randint(1,999), str='h', lst=[1, 2])
    sleep(0.1)
```

Output:

```
 98%|9| 98/100 [00:09<00:00,  9.90it/s, loss=0.0419, lst=[1, 2], gen=677, str=h]
```

TODO:
- [x] Test perf using examples/simple_examples.py to see if impact negligible or significative when not using postfix (because of `self.postfix` access in `__iter__()`, just like `self.desc`) -> no difference, the impact is negligible.
- [x] Add unit tests
- [x] Fix flake8 warning
- [x] Add to readme
- [x] Add support in tqdm_notebook and potentially other submodules (already works, no change needed, as long as `r_bar` is managed, the postfix is also handled implicitly).
- [x] Support for ordered arguments.
- [x] Rebased.
