### PR TITLE
Modularize tqdm.pandas -> tqdm_pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ install:
   # install big packages (they are cached to minimize build time)
   # if issues, clear cache
   # https://docs.travis-ci.com/user/caching/#Clearing-Caches
+  - pip install numpy
   - pip install pandas
   # Coverage install
   # - pip install tox 'coverage<4' coveralls

--- a/README.rst
+++ b/README.rst
@@ -494,19 +494,36 @@ for ``DataFrame.progress_apply`` and ``DataFrameGroupBy.progress_apply``:
 
     import pandas as pd
     import numpy as np
-    from tqdm import tqdm
+    from tqdm import tqdm, tqdm_pandas
 
-    df = pd.DataFrame(np.random.randint(0, 100, (100000, 6)))
+    df = pd.DataFrame(np.random.randint(0, 100, (6, 100000)))
 
-    # Register `pandas.progress_apply` and `pandas.Series.map_apply` with `tqdm`
+    # Register `tqdm` callbacks in `pandas`
+    # This monkeypatch `pandas` to add methods that will callback `tqdm`
     # (can use `tqdm_gui`, `tqdm_notebook`, optional kwargs, etc.)
-    tqdm.pandas(desc="my bar!")
+    # You need to do this only once, all `pandas` calls will have `tqdm`.
+    tqdm_pandas(tqdm, desc="my bar!")
 
     # Now you can use `progress_apply` instead of `apply`
     # and `progress_map` instead of `map`
     df.progress_apply(lambda x: x**2)
     # can also groupby:
     # df.groupby(0).progress_apply(lambda x: x**2)
+
+Here is the list of `tqdm` callbacks in `pandas`:
+
+* `progress_apply`
+* `progress_map`
+* `progress_applymap`
+* `progress_aggregate` (for GroupBy)
+* `progress_transform` (for GroupBy)
+
+List of supported `pandas` datatypes:
+
+* `Series` and `SeriesGroupBy`
+* `DataFrame` and `DataFrameGroupBy`
+* `Panels` (partially)
+* `GroupBy`
 
 In case you're interested in how this works (and how to modify it for your
 own callbacks), see the

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -347,106 +347,11 @@ class tqdm(object):
 
     @classmethod
     def pandas(tclass, *targs, **tkwargs):
-        """
-        Registers the given `tqdm` class with
-            pandas.core.
-            ( frame.DataFrame
-            | series.Series
-            | groupby.DataFrameGroupBy
-            | groupby.SeriesGroupBy
-            ).progress_apply
-
-        A new instance will be create every time `progress_apply` is called,
-        and each instance will automatically close() upon completion.
-
-        Parameters
-        ----------
-        targs, tkwargs  : arguments for the tqdm instance
-
-        Examples
-        --------
-        >>> import pandas as pd
-        >>> import numpy as np
-        >>> from tqdm import tqdm, tqdm_gui
-        >>>
-        >>> df = pd.DataFrame(np.random.randint(0, 100, (100000, 6)))
-        >>> tqdm.pandas(ncols=50)  # can use tqdm_gui, optional kwargs, etc
-        >>> # Now you can use `progress_apply` instead of `apply`
-        >>> df.groupby(0).progress_apply(lambda x: x**2)
-
-        References
-        ----------
-        https://stackoverflow.com/questions/18603270/
-        progress-indicator-during-pandas-operations-python
-        """
-        from pandas.core.frame import DataFrame
-        from pandas.core.series import Series
-        from pandas.core.groupby import DataFrameGroupBy
-        from pandas.core.groupby import SeriesGroupBy
-        from pandas.core.groupby import GroupBy
-        from pandas.core.groupby import PanelGroupBy
-        from pandas import Panel
-
-        deprecated_t = [tkwargs.pop('deprecated_t', None)]
-
-        def inner_generator(df_function='apply'):
-            def inner(df, func, *args, **kwargs):
-                """
-                Parameters
-                ----------
-                df  : (DataFrame|Series)[GroupBy]
-                    Data (may be grouped).
-                func  : function
-                    To be applied on the (grouped) data.
-                *args, *kwargs  : optional
-                    Transmitted to `df.apply()`.
-                """
-                # Precompute total iterations
-                total = getattr(df, 'ngroups', None)
-                if total is None:  # not grouped
-                    total = len(df) if isinstance(df, Series) \
-                        else df.size // len(df)
-                else:
-                    total += 1  # pandas calls update once too many
-
-                # Init bar
-                if deprecated_t[0] is not None:
-                    t = deprecated_t[0]
-                    deprecated_t[0] = None
-                else:
-                    t = tclass(*targs, total=total, **tkwargs)
-
-                # Define bar updating wrapper
-                def wrapper(*args, **kwargs):
-                    t.update()
-                    return func(*args, **kwargs)
-
-                # Apply the provided function (in *args and **kwargs)
-                # on the df using our wrapper (which provides bar updating)
-                result = getattr(df, df_function)(wrapper, *args, **kwargs)
-
-                # Close bar and return pandas calculation result
-                t.close()
-                return result
-            return inner
-
-        # Monkeypatch pandas to provide easy methods
-        # Enable custom tqdm progress in pandas!
-        Series.progress_apply = inner_generator()
-        SeriesGroupBy.progress_apply = inner_generator()
-        Series.progress_map = inner_generator('map')
-        SeriesGroupBy.progress_map = inner_generator('map')
-
-        DataFrame.progress_apply = inner_generator()
-        DataFrameGroupBy.progress_apply = inner_generator()
-        DataFrame.progress_applymap = inner_generator('applymap')
-
-        Panel.progress_apply = inner_generator()
-        PanelGroupBy.progress_apply = inner_generator()
-
-        GroupBy.progress_apply = inner_generator()
-        GroupBy.progress_aggregate = inner_generator('aggregate')
-        GroupBy.progress_transform = inner_generator('transform')
+        TqdmDeprecationWarning("""\
+            Please use `tqdm_pandas(tqdm, ...)` instead of `tqdm.pandas(...)`.
+            """, fp_write=getattr(tkwargs.get('file', None), 'write', sys.stderr.write))
+        from ._tqdm_pandas import tqdm_pandas
+        tqdm_pandas(tclass, *targs, **tkwargs)
 
     def __init__(self, iterable=None, desc=None, total=None, leave=True,
                  file=sys.stderr, ncols=None, mininterval=0.1,

--- a/tqdm/_tqdm_pandas.py
+++ b/tqdm/_tqdm_pandas.py
@@ -26,6 +26,7 @@ def tqdm_pandas(tclass, *targs, **tkwargs):
 
     Parameters
     ----------
+    tclass  : tqdm class you want to use (eg, tqdm, tqdm_notebook, etc)
     *targs, **tkwargs  : arguments for the tqdm instance
 
     Examples

--- a/tqdm/_tqdm_pandas.py
+++ b/tqdm/_tqdm_pandas.py
@@ -1,3 +1,10 @@
+# future division is important to divide integers and get as
+# a result precise floating numbers (instead of truncated int)
+from __future__ import absolute_import
+from __future__ import division
+
+from ._tqdm import TqdmDeprecationWarning
+
 import sys
 
 __author__ = "github.com/casperdcl"
@@ -6,14 +13,20 @@ __all__ = ['tqdm_pandas']
 
 def tqdm_pandas(tclass, *targs, **tkwargs):
     """
-    Registers the given `tqdm` instance with
-    `pandas.core.groupby.DataFrameGroupBy.progress_apply`.
-    It will even close() the `tqdm` instance upon completion.
+    Registers the given `tqdm` class with
+        pandas.core.
+        ( frame.DataFrame
+        | series.Series
+        | groupby.DataFrameGroupBy
+        | groupby.SeriesGroupBy
+        ).progress_apply
+
+    A new instance will be create every time `progress_apply` is called,
+    and each instance will automatically close() upon completion.
 
     Parameters
     ----------
-    tclass  : tqdm class you want to use (eg, tqdm, tqdm_notebook, etc)
-    targs and tkwargs  : arguments for the tqdm instance
+    *targs, **tkwargs  : arguments for the tqdm instance
 
     Examples
     --------
@@ -22,7 +35,7 @@ def tqdm_pandas(tclass, *targs, **tkwargs):
     >>> from tqdm import tqdm, tqdm_pandas
     >>>
     >>> df = pd.DataFrame(np.random.randint(0, 100, (100000, 6)))
-    >>> tqdm_pandas(tqdm, leave=True)  # can use tqdm_gui, optional kwargs, etc
+    >>> tqdm_pandas(tqdm, ncols=50)  # can use submodule, optional kwargs, etc
     >>> # Now you can use `progress_apply` instead of `apply`
     >>> df.groupby(0).progress_apply(lambda x: x**2)
 
@@ -31,16 +44,76 @@ def tqdm_pandas(tclass, *targs, **tkwargs):
     https://stackoverflow.com/questions/18603270/
     progress-indicator-during-pandas-operations-python
     """
-    from tqdm import TqdmDeprecationWarning
+    from pandas.core.frame import DataFrame
+    from pandas.core.series import Series
+    from pandas.core.groupby import DataFrameGroupBy
+    from pandas.core.groupby import SeriesGroupBy
+    from pandas.core.groupby import GroupBy
+    from pandas.core.groupby import PanelGroupBy
+    from pandas import Panel
 
-    if isinstance(tclass, type) or (getattr(tclass, '__name__', '').startswith(
-            'tqdm_')):  # delayed adapter case
-        TqdmDeprecationWarning("""\
-Please use `tqdm.pandas(...)` instead of `tqdm_pandas(tqdm, ...)`.
-""", fp_write=getattr(tkwargs.get('file', None), 'write', sys.stderr.write))
-        tclass.pandas(*targs, **tkwargs)
-    else:
-        TqdmDeprecationWarning("""\
-Please use `tqdm.pandas(...)` instead of `tqdm_pandas(tqdm(...))`.
-""", fp_write=getattr(tclass.fp, 'write', sys.stderr.write))
-        type(tclass).pandas(deprecated_t=tclass)
+    def inner_generator(df_function='apply'):
+        def inner(df, func, *args, **kwargs):
+            """
+            Parameters
+            ----------
+            df  : (DataFrame|Series)[GroupBy]
+                Data (may be grouped).
+            func  : function
+                To be applied on the (grouped) data.
+            *args, **kwargs  : optional
+                Transmitted to `df.apply()`.
+            """
+            # Precompute total iterations
+            total = getattr(df, 'ngroups', None)
+            if total is None:  # not grouped
+                total = len(df) if isinstance(df, Series) \
+                    else df.size // len(df)
+            else:
+                total += 1  # pandas calls update once too many
+
+            # Init bar
+            # Check if tclass is indeed a class
+            if isinstance(tclass, type) or \
+                (hasattr(tclass, '__name__') and
+                 tclass.__name__.startswith('tqdm_')):  # delayed adapter case
+                t = tclass(*targs, total=total, **tkwargs)
+            # Else it's an instance, it's wrong but let's still accept it
+            else:
+                t = tclass
+                t.total = total
+                TqdmDeprecationWarning("""\
+                    Please use `tqdm_pandas(tqdm, ...)` instead of `tqdm_pandas(tqdm(...))`.
+                    """, fp_write=getattr(t.fp, 'write', sys.stderr.write))
+
+            # Define bar updating wrapper
+            def wrapper(*args, **kwargs):
+                t.update()
+                return func(*args, **kwargs)
+
+            # Apply the provided function (in *args and **kwargs)
+            # on the df using our wrapper (which provides bar updating)
+            result = getattr(df, df_function)(wrapper, *args, **kwargs)
+
+            # Close bar and return pandas calculation result
+            t.close()
+            return result
+        return inner
+
+    # Monkeypatch pandas to provide easy methods
+    # Enable custom tqdm progress in pandas!
+    Series.progress_apply = inner_generator()
+    SeriesGroupBy.progress_apply = inner_generator()
+    Series.progress_map = inner_generator('map')
+    SeriesGroupBy.progress_map = inner_generator('map')
+
+    DataFrame.progress_apply = inner_generator()
+    DataFrameGroupBy.progress_apply = inner_generator()
+    DataFrame.progress_applymap = inner_generator('applymap')
+
+    Panel.progress_apply = inner_generator()
+    PanelGroupBy.progress_apply = inner_generator()
+
+    GroupBy.progress_apply = inner_generator()
+    GroupBy.progress_aggregate = inner_generator('aggregate')
+    GroupBy.progress_transform = inner_generator('transform')

--- a/tqdm/tests/tests_pandas.py
+++ b/tqdm/tests/tests_pandas.py
@@ -1,6 +1,6 @@
 from nose.plugins.skip import SkipTest
 
-from tqdm import tqdm
+from tqdm import tqdm, tqdm_pandas
 from tests_tqdm import with_setup, pretest, posttest, StringIO, closing
 
 
@@ -14,7 +14,7 @@ def test_pandas_groupby_apply():
         raise SkipTest
 
     with closing(StringIO()) as our_file:
-        tqdm.pandas(file=our_file, leave=False, ascii=True)
+        tqdm_pandas(tqdm, file=our_file, leave=False, ascii=True)
 
         df = pd.DataFrame(randint(0, 50, (500, 3)))
         df.groupby(0).progress_apply(lambda x: None)
@@ -44,7 +44,7 @@ def test_pandas_apply():
         raise SkipTest
 
     with closing(StringIO()) as our_file:
-        tqdm.pandas(file=our_file, leave=True, ascii=True)
+        tqdm_pandas(tqdm, file=our_file, leave=True, ascii=True)
         df = pd.DataFrame(randint(0, 50, (500, 3)))
         df.progress_apply(lambda x: None)
 
@@ -70,7 +70,7 @@ def test_pandas_map():
         raise SkipTest
 
     with closing(StringIO()) as our_file:
-        tqdm.pandas(file=our_file, leave=True, ascii=True)
+        tqdm_pandas(tqdm, file=our_file, leave=True, ascii=True)
         dfs = pd.DataFrame(randint(0, 50, (500, 3)),
                            columns=list('abc'))
         dfs.a.progress_map(lambda x: None)
@@ -91,7 +91,7 @@ def test_pandas_leave():
 
     with closing(StringIO()) as our_file:
         df = pd.DataFrame(randint(0, 100, (1000, 6)))
-        tqdm.pandas(file=our_file, leave=True, ascii=True)
+        tqdm_pandas(tqdm, file=our_file, leave=True, ascii=True)
         df.groupby(0).progress_apply(lambda x: None)
 
         our_file.seek(0)
@@ -105,7 +105,7 @@ def test_pandas_leave():
 
 @with_setup(pretest, posttest)
 def test_pandas_deprecation():
-    """ Test bar object instance as argument deprecation """
+    """ Test pandas bar object instance as argument deprecation """
     try:
         from numpy.random import randint
         from tqdm import tqdm_pandas
@@ -122,9 +122,9 @@ def test_pandas_deprecation():
         assert "instead of `tqdm_pandas(tqdm(...))`" in our_file.getvalue()
 
     with closing(StringIO()) as our_file:
-        tqdm_pandas(tqdm, file=our_file, leave=False, ascii=True, ncols=20)
+        tqdm.pandas(tqdm, file=our_file, leave=False, ascii=True, ncols=20)
         df = pd.DataFrame(randint(0, 50, (500, 3)))
         df.groupby(0).progress_apply(lambda x: None)
         # Check deprecation message
         assert "TqdmDeprecationWarning" in our_file.getvalue()
-        assert "instead of `tqdm_pandas(tqdm, ...)`" in our_file.getvalue()
+        assert "instead of `tqdm.pandas(...)`" in our_file.getvalue()


### PR DESCRIPTION
Modularize tqdm.pandas() back to tqdm_pandas submodule for these reasons:
- Uses external library (plus it's still in alpha stages, not stable, bad for core tqdm)
- In core `tqdm`, this decreased the coverage in Travis.
- Standardize usage with submodules with delayed interface such as `tqdm_notebook` (see #245).

Don't worry about codecov's test not passing the threshold, see #272 for more info on this issue.
