### PR TITLE
Add stepsize + autodetection of initial, total and stepsize in trange()

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -562,11 +562,11 @@ class tqdm(object):
         elif total is not None and iterable is not None and stepsize is None:
             try:
                 iterable_total = len(iterable)
-                stepsize = max(int(iterable / iterable_total), 1)
+                stepsize = max(int(total / iterable_total), 1)
             except (TypeError, AttributeError):
                 pass
 
-        if stepsize is None:
+        if stepsize is None or stepsize <= 0:
             stepsize = 1
 
         if ((ncols is None) and (file in (sys.stderr, sys.stdout))) or \
@@ -810,7 +810,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         if self.disable:
             return
 
-        if n < 0:
+        if n is not None and n < 0:
             raise ValueError("n ({0}) cannot be negative".format(n))
         self.n += n if n else self.stepsize
 


### PR DESCRIPTION
Implement #265 with 2 strategies: autodetection of stepsize if `len(iterable) != total` (total is explicitly specified) + autodetection in `trange()` of `range()` arguments to feed `tqdm()` (using a new function `trange_preprocess()` -- I wanted to turn `trange()` into a class but then the wrapper did not work anymore, it cannot just return a wrapped range under tqdm without wrapping in trange also).

TODO:
- [ ] Call `trange_preprocess()` in all `trange()`-like of submodules.
- [x] Test impact on performance (`examples/simple_tests.py`) -> significative difference: 15% in manual mode and 5-10% in iterable mode. All because of `tqdm.stepsize`. If we remove `tqdm.stepsize` but keep `trange_preprocess()`, we would remove all performance impact, but iterable mode tqdm won't be able to account for `range()`'s stepsize (only `initial` and `total`, which is already good but not perfect). What should we do @casperdcl ?
- [ ] Add unit test
