### PR TITLE
disable automatically on non-TTY

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -450,7 +450,7 @@ class tqdm(object):
 
     def __init__(self, iterable=None, desc=None, total=None, leave=True,
                  file=sys.stderr, ncols=None, mininterval=0.1,
-                 maxinterval=10.0, miniters=None, ascii=None, disable=None,
+                 maxinterval=10.0, miniters=None, ascii=None, disable=False,
                  unit='it', unit_scale=False, dynamic_ncols=False,
                  smoothing=0.3, bar_format=None, initial=0, position=None,
                  gui=False, **kwargs):
@@ -492,9 +492,9 @@ class tqdm(object):
         ascii  : bool, optional
             If unspecified or False, use unicode (smooth blocks) to fill
             the meter. The fallback is to use ASCII characters `1-9 #`.
-        disable  : bool, optional
-            Whether to disable the entire progressbar wrapper. If not set,
-            disable on non-TTY.
+        disable  : bool or None, optional
+            Whether to disable the entire progressbar wrapper
+            [default: False]. If set to None, disable on non-TTY.
         unit  : str, optional
             String that will be used to define the unit of each iteration
             [default: it].

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -450,7 +450,7 @@ class tqdm(object):
 
     def __init__(self, iterable=None, desc=None, total=None, leave=True,
                  file=sys.stderr, ncols=None, mininterval=0.1,
-                 maxinterval=10.0, miniters=None, ascii=None, disable=False,
+                 maxinterval=10.0, miniters=None, ascii=None, disable=None,
                  unit='it', unit_scale=False, dynamic_ncols=False,
                  smoothing=0.3, bar_format=None, initial=0, position=None,
                  gui=False, **kwargs):
@@ -493,8 +493,8 @@ class tqdm(object):
             If unspecified or False, use unicode (smooth blocks) to fill
             the meter. The fallback is to use ASCII characters `1-9 #`.
         disable  : bool, optional
-            Whether to disable the entire progressbar wrapper
-            [default: False].
+            Whether to disable the entire progressbar wrapper. If not set,
+            disable on non-TTY.
         unit  : str, optional
             String that will be used to define the unit of each iteration
             [default: it].
@@ -533,6 +533,10 @@ class tqdm(object):
         -------
         out  : decorated iterator.
         """
+
+        if disable is None and hasattr(file, "isatty") and not file.isatty():
+            disable = True
+
         if disable:
             self.iterable = iterable
             self.disable = disable

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1233,3 +1233,22 @@ def test_len():
     with closing(StringIO()) as f:
         with tqdm(np.zeros((3, 4)), file=f) as t:
             assert len(t) == 3
+
+
+@with_setup(pretest, posttest)
+def test_autodisable_disable():
+    """Test autodisable will disable on non-TTY"""
+    with closing(StringIO()) as our_file:
+        with tqdm(total=10, disable=None, file=our_file) as t:
+            pass
+        assert our_file.getvalue() == ''
+
+
+@with_setup(pretest, posttest)
+def test_autodisable_enable():
+    """Test autodisable will not disable on TTY"""
+    with closing(StringIO()) as our_file:
+        setattr(our_file, "isatty", lambda: True)
+        with tqdm(total=10, disable=None, file=our_file) as t:
+            pass
+        assert our_file.getvalue() != ''


### PR DESCRIPTION
When running python scripts that use tqdm in cron jobs; i noticed that the output of tqdm is also redirected. I changed the `disable` parameter, so if it is not set explicitly, the output will be disabled automatically if the output file is not a TTY (i.e. is some sort of redirection).
