### PR TITLE
Ignore coverall failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     coveralls
 commands =
     nosetests --with-coverage --with-timer --cover-package=tqdm --ignore-files="tests_perf\.py" -d -v tqdm/
-    coveralls
+    - coveralls
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
When running locally, I get:

```
$ make test
...
ERROR: InvocationError: '/Users/peter/PROJECTS/tqdm/.tox/py26/bin/coveralls'
...
ERROR:   py26: commands failed
...

$ /Users/peter/PROJECTS/tqdm/.tox/py35/bin/coveralls
You have to provide either repo_token in .coveralls.yml, or launch via Travis or CircleCI
```

This fixes that issue.
