### PR TITLE
Add ncols to specify tqdm_notebook bar width

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -853,7 +853,7 @@ class tqdm(object):
         return self.total if self.iterable is None else \
             (self.iterable.shape[0] if hasattr(self.iterable, "shape")
              else len(self.iterable) if hasattr(self.iterable, "__len__")
-             else self.total)
+             else getattr(self, "total", None))
 
     def __enter__(self):
         return self

--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -105,9 +105,9 @@ class tqdm_notebook(tqdm):
         # Only way to place text to the right of the bar is to use a container
         container = HBox(children=[pbar, ptext])
         # Prepare layout
-        if ncols is not None: # if ncols is None, use default style of ipywidgets
+        if ncols is not None:  # use default style of ipywidgets
             # ncols could be 100, "100px", "100%"
-            ncols = str(ncols) # ipywidgets only accepts string,
+            ncols = str(ncols)  # ipywidgets only accepts string
             if ncols[-1].isnumeric():
                 # if last value is digit, assume the value is digit
                 ncols += 'px'
@@ -185,12 +185,11 @@ class tqdm_notebook(tqdm):
         # self.sp('', close=True)
 
         # Get bar width
-        self.ncols = kwargs.get('ncols', None)
-        if self.dynamic_ncols:
-            self.ncols = '100%'
+        self.ncols = '100%' if self.dynamic_ncols else kwargs.get("ncols", None)
 
         # Replace with IPython progress bar display (with correct total)
-        self.sp = self.status_printer(self.fp, self.total, self.desc, self.ncols)
+        self.sp = self.status_printer(
+            self.fp, self.total, self.desc, self.ncols)
         self.desc = None  # trick to place description before the bar
 
         # Print initial bar state
@@ -203,7 +202,7 @@ class tqdm_notebook(tqdm):
                 # return super(tqdm...) will not catch exception
                 yield obj
         # NB: except ... [ as ...] breaks IPython async KeyboardInterrupt
-        except:
+        except:  # NOQA
             self.sp(bar_style='danger')
             raise
 

--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -104,17 +104,17 @@ class tqdm_notebook(tqdm):
         ptext = HTML()
         # Only way to place text to the right of the bar is to use a container
         container = HBox(children=[pbar, ptext])
-        # Prepare layout (if available in ipywidgets version)
-        #try:  # commented until it works, ease debugging
-        if not ncols:
-            ncols = '100%'
-        pbar.layout.width = ncols
-        container.layout.width = ncols
-        container.layout.display = 'inline-flex'
-        container.layout.flex_flow = 'row wrap'
-        #except Exception:
-            #pass
-        # Display!
+        # Prepare layout
+        if ncols is not None: # if ncols is None, use default style of ipywidgets
+            # ncols could be 100, "100px", "100%"
+            ncols = str(ncols) # ipywidgets only accepts string,
+            if ncols[-1].isnumeric():
+                # if last value is digit, assume the value is digit
+                ncols += 'px'
+            pbar.layout.flex = '2'
+            container.layout.width = ncols
+            container.layout.display = 'inline-flex'
+            container.layout.flex_flow = 'row wrap'
         display(container)
 
         def print_status(s='', close=False, bar_style=None, desc=None):
@@ -185,8 +185,8 @@ class tqdm_notebook(tqdm):
         # self.sp('', close=True)
 
         # Get bar width
-        ncols = kwargs.get('ncols', None)
-        if ncols is None or self.dynamic_ncols:
+        self.ncols = kwargs.get('ncols', None)
+        if self.dynamic_ncols:
             self.ncols = '100%'
 
         # Replace with IPython progress bar display (with correct total)

--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -80,7 +80,7 @@ class tqdm_notebook(tqdm):
     """
 
     @staticmethod
-    def status_printer(_, total=None, desc=None):
+    def status_printer(_, total=None, desc=None, ncols=None):
         """
         Manage the printing of an IPython/Jupyter Notebook progress bar widget.
         """
@@ -104,6 +104,17 @@ class tqdm_notebook(tqdm):
         ptext = HTML()
         # Only way to place text to the right of the bar is to use a container
         container = HBox(children=[pbar, ptext])
+        # Prepare layout (if available in ipywidgets version)
+        #try:  # commented until it works, ease debugging
+        if not ncols:
+            ncols = '100%'
+        pbar.layout.width = ncols
+        container.layout.width = ncols
+        container.layout.display = 'inline-flex'
+        container.layout.flex_flow = 'row wrap'
+        #except Exception:
+            #pass
+        # Display!
         display(container)
 
         def print_status(s='', close=False, bar_style=None, desc=None):
@@ -172,8 +183,14 @@ class tqdm_notebook(tqdm):
         # Delete first pbar generated from super() (wrong total and text)
         # DEPRECATED by using gui=True
         # self.sp('', close=True)
+
+        # Get bar width
+        ncols = kwargs.get('ncols', None)
+        if ncols is None or self.dynamic_ncols:
+            self.ncols = '100%'
+
         # Replace with IPython progress bar display (with correct total)
-        self.sp = self.status_printer(self.fp, self.total, self.desc)
+        self.sp = self.status_printer(self.fp, self.total, self.desc, self.ncols)
         self.desc = None  # trick to place description before the bar
 
         # Print initial bar state

--- a/tqdm/tests/tests_synchronisation.py
+++ b/tqdm/tests/tests_synchronisation.py
@@ -1,11 +1,11 @@
 from __future__ import division
-from tqdm import tqdm
-from tests_tqdm import with_setup, pretest, posttest, StringIO, closing
+from tqdm import tqdm, TMonitor
+from tests_tqdm import with_setup, pretest, posttest, SkipTest, \
+    StringIO, closing
 from tests_tqdm import DiscreteTimer, cpu_timify
 
 from time import sleep
 from threading import Event
-from tqdm import TMonitor
 
 
 class FakeSleep(object):
@@ -35,6 +35,10 @@ def make_create_fake_sleep_event(sleep):
         return event
 
     return create_fake_sleep_event
+
+
+def incr(x):
+    return x + 1
 
 
 @with_setup(pretest, posttest)
@@ -162,3 +166,16 @@ def test_monitoring_multi():
     # Check that class var monitor is deleted if no instance left
     tqdm.monitor_interval = 10
     assert tqdm.monitor is None
+
+
+@with_setup(pretest, posttest)
+def test_imap():
+    """Test multiprocessing.Pool"""
+    try:
+        from multiprocessing import Pool
+    except ImportError:
+        raise SkipTest
+
+    pool = Pool()
+    res = list(tqdm(pool.imap(incr, range(100)), disable=True))
+    assert res[-1] == 100


### PR DESCRIPTION
Fixes #276 but does not work yet as layout seems to be broken in current ipywidgets (see https://github.com/ipython/ipywidgets/issues/773).

I tried using either `widget.layout.width = 100%` and `Layout(width='100%')`, and in either case `ipywidgets` raises an error saying that both are unknown property/can't import Layout class...
