### PR TITLE
Fix `file` default value (ease redirection)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -250,7 +250,7 @@ Documentation
       """
 
       def __init__(self, iterable=None, desc=None, total=None, leave=True,
-                   file=sys.stderr, ncols=None, mininterval=0.1,
+                   file=None, ncols=None, mininterval=0.1,
                    maxinterval=10.0, miniters=None, ascii=None, disable=False,
                    unit='it', unit_scale=False, dynamic_ncols=False,
                    smoothing=0.3, bar_format=None, initial=0, position=None,
@@ -276,7 +276,7 @@ Parameters
     upon termination of iteration.
 * file  : ``io.TextIOWrapper`` or ``io.StringIO``, optional  
     Specifies where to output the progress messages
-    [default: sys.stderr]. Uses ``file.write(str)`` and ``file.flush()``
+    (default: sys.stderr). Uses ``file.write(str)`` and ``file.flush()``
     methods.
 * ncols  : int, optional  
     The width of the entire output message. If specified,

--- a/examples/redirect_print.py
+++ b/examples/redirect_print.py
@@ -1,0 +1,60 @@
+"""Redirecting writing
+
+If using a library that can print messages to the console, editing the library
+by  replacing `print()` with `tqdm.write()` may not be desirable.
+In that case, redirecting `sys.stdout` to `tqdm.write()` is an option.
+
+To redirect `sys.stdout`, create a file-like class that will write
+any input string to `tqdm.write()`, and supply the arguments
+`file=sys.stdout, dynamic_ncols=True`.
+
+A reusable canonical example is given below:
+"""
+from __future__ import print_function
+from time import sleep
+import contextlib
+import sys
+from tqdm import tqdm
+
+
+class DummyTqdmFile(object):
+    """Dummy file-like that will write to tqdm"""
+    file = None
+
+    def __init__(self, file):
+        self.file = file
+
+    def write(self, x):
+        # Avoid print() second call (useless \n)
+        if len(x.rstrip()) > 0:
+            tqdm.write(x, file=self.file)
+
+
+@contextlib.contextmanager
+def stdout_redirect_to_tqdm():
+    save_stdout = sys.stdout
+    try:
+        sys.stdout = DummyTqdmFile(sys.stdout)
+        yield save_stdout
+    # Relay exceptions
+    except Exception as exc:
+        raise exc
+    # Always restore sys.stdout if necessary
+    finally:
+        sys.stdout = save_stdout
+
+
+def blabla():
+    print("Foo blabla")
+
+
+# Redirect stdout to tqdm.write() (don't forget the `as save_stdout`)
+with stdout_redirect_to_tqdm() as save_stdout:
+    # tqdm call need to specify sys.stdout, not sys.stderr (default)
+    # and dynamic_ncols=True to autodetect console width
+    for _ in tqdm(range(3), file=save_stdout, dynamic_ncols=True):
+        blabla()
+        sleep(.5)
+
+# After the `with`, printing is restored
+print('Done!')

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -418,11 +418,11 @@ class tqdm(object):
             pass
 
     @classmethod
-    def write(cls, s, file=sys.stdout, end="\n"):
+    def write(cls, s, file=None, end="\n"):
         """
         Print a message via tqdm (without overlap with bars)
         """
-        fp = file
+        fp = file if file is not None else sys.stdout
 
         # Clear all bars
         inst_cleared = []
@@ -548,7 +548,7 @@ class tqdm(object):
         GroupBy.progress_transform = inner_generator('transform')
 
     def __init__(self, iterable=None, desc=None, total=None, leave=True,
-                 file=sys.stderr, ncols=None, mininterval=0.1,
+                 file=None, ncols=None, mininterval=0.1,
                  maxinterval=10.0, miniters=None, ascii=None, disable=False,
                  unit='it', unit_scale=False, dynamic_ncols=False,
                  smoothing=0.3, bar_format=None, initial=0, position=None,
@@ -653,6 +653,11 @@ class tqdm(object):
             self.pos = self._get_free_pos(self)
             self._instances.remove(self)
             return
+
+        # Define file default value at instanciation rather than class import
+        # (ease file redirection)
+        if file is None:
+            file = sys.stderr
 
         if kwargs:
             self.disable = True

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -574,7 +574,7 @@ class tqdm(object):
             upon termination of iteration.
         file  : `io.TextIOWrapper` or `io.StringIO`, optional
             Specifies where to output the progress messages
-            [default: sys.stderr]. Uses `file.write(str)` and `file.flush()`
+            (default: sys.stderr). Uses `file.write(str)` and `file.flush()`
             methods.
         ncols  : int, optional
             The width of the entire output message. If specified,
@@ -600,7 +600,7 @@ class tqdm(object):
         ascii  : bool, optional
             If unspecified or False, use unicode (smooth blocks) to fill
             the meter. The fallback is to use ASCII characters `1-9 #`.
-        disable  : bool or None, optional
+        disable  : bool, optional
             Whether to disable the entire progressbar wrapper
             [default: False]. If set to None, disable on non-TTY.
         unit  : str, optional
@@ -654,8 +654,6 @@ class tqdm(object):
             self._instances.remove(self)
             return
 
-        # Define file default value at instanciation rather than class import
-        # (ease file redirection)
         if file is None:
             file = sys.stderr
 

--- a/tqdm/_tqdm_gui.py
+++ b/tqdm/_tqdm_gui.py
@@ -28,10 +28,12 @@ class tqdm_gui(tqdm):  # pragma: no cover
     """
 
     @classmethod
-    def write(cls, s, file=sys.stdout, end="\n"):
+    def write(cls, s, file=None, end="\n"):
         """
         Print a message via tqdm_gui (just an alias for print)
         """
+        if file is None:
+            file = sys.stdout
         # TODO: print text on GUI?
         file.write(s)
         file.write(end)

--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -148,10 +148,12 @@ class tqdm_notebook(tqdm):
         return print_status
 
     @classmethod
-    def write(cls, s, file=sys.stdout, end="\n"):
+    def write(cls, s, file=None, end="\n"):
         """
         Print a message via tqdm_notebook (just an alias for print)
         """
+        if file is None:
+            file = sys.stdout
         # Just an alias for print because overlap is impossible with ipywidgets
         file.write(s)
         file.write(end)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -467,19 +467,17 @@ def test_max_interval():
 
                 # Fast iterations, check if dynamic_miniters triggers
                 timer.sleep(mininterval)  # to force update for t1
-                tm1.update(total/2)
-                tm2.update(total/2)
-                assert int(tm1.miniters) == tm2.miniters == total/2
+                tm1.update(total / 2)
+                tm2.update(total / 2)
+                assert int(tm1.miniters) == tm2.miniters == total / 2
 
                 # Slow iterations, check different miniters if mininterval
-                timer.sleep(maxinterval*2)
-                tm1.update(total/2)
-                tm2.update(total/2)
+                timer.sleep(maxinterval * 2)
+                tm1.update(total / 2)
+                tm2.update(total / 2)
                 res = [tm1.miniters, tm2.miniters]
-                assert res == [
-                               (total/2)*mininterval/(maxinterval*2),
-                               (total/2)*maxinterval/(maxinterval*2)
-                               ]
+                assert res == [(total / 2) * mininterval / (maxinterval * 2),
+                               (total / 2) * maxinterval / (maxinterval * 2)]
 
     # Same with iterable based tqdm
     timer1 = DiscreteTimer()  # need 2 timers for each bar because zip not work
@@ -497,16 +495,16 @@ def test_max_interval():
         cpu_timify(t2, timer2)
 
         for i in t1:
-            if i == ((total/2)-2):
+            if i == ((total / 2) - 2):
                 timer1.sleep(mininterval)
-            if i == (total-1):
-                timer1.sleep(maxinterval*2)
+            if i == (total - 1):
+                timer1.sleep(maxinterval * 2)
 
         for i in t2:
-            if i == ((total/2)-2):
+            if i == ((total / 2) - 2):
                 timer2.sleep(mininterval)
-            if i == (total-1):
-                timer2.sleep(maxinterval*2)
+            if i == (total - 1):
+                timer2.sleep(maxinterval * 2)
 
         assert t1.miniters == 0.255
         assert t2.miniters == 0.5
@@ -1423,7 +1421,7 @@ def test_monitoring_thread():
     # Test if alive, then killed
     assert monitor.report()
     monitor.exit()
-    timer.sleep(maxinterval*2)  # need to go out of the sleep to die
+    timer.sleep(maxinterval * 2)  # need to go out of the sleep to die
     assert not monitor.report()
     # assert not monitor.is_alive()  # not working dunno why, thread not killed
     del monitor
@@ -1445,12 +1443,12 @@ def test_monitoring_thread():
             cpu_timify(t, timer)
             # Do a lot of iterations in a small timeframe
             # (smaller than monitor interval)
-            timer.sleep(maxinterval/2)  # monitor won't wake up
+            timer.sleep(maxinterval / 2)  # monitor won't wake up
             t.update(500)
             # check that our fixed miniters is still there
             assert t.miniters == 500
             # Then do 1 it after monitor interval, so that monitor kicks in
-            timer.sleep(maxinterval*2)
+            timer.sleep(maxinterval * 2)
             t.update(1)
             # Wait for the monitor to get out of sleep's loop and update tqdm..
             timeend = timer.time()
@@ -1464,7 +1462,7 @@ def test_monitoring_thread():
             # to ensure that monitor wakes up at some point.
 
             # Try again but already at miniters = 1 so nothing will be done
-            timer.sleep(maxinterval*2)
+            timer.sleep(maxinterval * 2)
             t.update(2)
             timeend = timer.time()
             while not (t.monitor.woken >= timeend):
@@ -1500,7 +1498,7 @@ def test_monitoring_thread():
                 assert t1.miniters == 500
                 assert t2.miniters == 500
                 # Then do 1 it after monitor interval, so that monitor kicks in
-                timer.sleep(maxinterval*2)
+                timer.sleep(maxinterval * 2)
                 t1.update(1)
                 t2.update(1)
                 # Wait for the monitor to get out of sleep and update tqdm


### PR DESCRIPTION
Implements #275.

`file` argument is now set to None and defined at instanciation inside `__init__()` (instead of at class import). This should ease file redirection (as long as `sys.stdout` is redirected before tqdm instanciation, it should be fine).

TODO:
- [x] Use `file=None` and set default `self.fp=sys.stderr` inside init. Same for `tqdm.write()` (and other methods/submodules?). This will allow users to redirect sys.stderr before instanciating tqdm, without needing to supply the new redirection to tqdm.
- [x] Check that it doesn't impact the stdout redirection scheme described in the readme.
- [x] Add unit test for stdout (or a dummy IO) redirection (2 tests: 1- redirect using wrapper like in README, 2- redirect stdout before instanciating tqdm, this is the new redirection scheme provided by this PR).

TODO in a separate PR `resiliency-io-error`:
- [ ] Wrap any `self.fp.write()` (`tqdm.move()` and `status_printer`?) in `try/except` block (this should not impact performances as the except block will only get evaluated if necessary). The `except` block should still display any error but as a non blocking message (using a new `TqdmErrorMessage() class`?). Something like this:

```python
def move(n):
    try:
        #...
    except IOError as exc:
        if not self.resiliency:
            raise(exc)
```