### PR TITLE
initial benchmark framework to visualise regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ nosetests.xml
 
 # PyCharm
 .idea
+
+# asv
+.asv/
+benchmarks/*.pyc

--- a/CONTRIBUTE
+++ b/CONTRIBUTE
@@ -249,6 +249,32 @@ cannot re-upload another with the same version number
 updating just the metadata is possible: `[python setup.py] make pypimeta`
 
 
+UPDATING GH-PAGES
+-----------------
+
+The most important file is README.rst, which sould always be kept up-to-date
+and in sync with the in-line source documentation. This will affect all of the
+following:
+
+- The [main repository site](https://github.com/tqdm/tqdm) which automatically
+  serves the latest README.rst as well as links to all of github's features.
+  This is the preferred online referral link for tqdm.
+- The [PyPi mirror](https://pypi.python.org/pypi/tqdm) which automatically
+  serves the latest release built from README.rst as well as links to past
+  releases.
+- Many external web crawlers.
+
+
+Additionally (less maintained), there exists:
+
+- A [wiki](https://github.com/tqdm/tqdm/wiki) which is publicly editable.
+- The [gh-pages project](https://tqdm.github.io/tqdm/) which is built from the
+  [gh-pages branch](https://github.com/tqdm/tqdm/tree/gh-pages), which is
+  built using [asv](https://github.com/spacetelescope/asv/).
+- The [gh-pages root](https://tqdm.github.io/) which is built from a separate
+  outdated [github.io repo](https://github.com/tqdm/tqdm.github.io).
+
+
 QUICK DEV SUMMARY
 -----------------
 

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,18 @@ testperf:  # do not use coverage (which is extremely slow)
 testtimer:
 	nosetests tqdm --with-timer -d -v
 
+testasv:
+	asv run -j 8 HEAD~3..HEAD
+	@make viewasv
+
+testasvfull:
+	asv run -j 8 v1.0.0..master
+	@make testasv
+
+viewasv:
+	asv publish
+	asv preview
+
 distclean:
 	@+make coverclean
 	@+make prebuildclean

--- a/README.rst
+++ b/README.rst
@@ -3,14 +3,15 @@
 tqdm
 ====
 
-|PyPI-Status| |PyPI-Versions|
+|PyPI-Status| |PyPI-Versions| |Conda-Forge-Status|
 
 |Build-Status| |Coverage-Status| |Branch-Coverage-Status| |Codacy-Grade|
 
 |DOI-URI| |LICENCE|
 
 
-``tqdm`` (read taqadum, تقدّم) means "progress" in arabic.
+``tqdm`` means "progress" in Arabic (taqadum, تقدّم)
+and an abbreviation for "I love you so much" in Spanish (te quiero demasiado).
 
 Instantly make your loops show a smart progress meter - just wrap any
 iterable with ``tqdm(iterable)``, and you're done!
@@ -85,6 +86,15 @@ Pull and install in the current directory:
 .. code:: sh
 
     pip install -e git+https://github.com/tqdm/tqdm.git@master#egg=tqdm
+
+Latest Conda release
+~~~~~~~~~~~~~~~~~~~~
+
+|Conda-Forge-Status|
+
+.. code:: sh
+
+    conda install -c conda-forge tqdm
 
 
 Changelog
@@ -714,6 +724,8 @@ Ranked by contributions.
    :target: https://pypi.python.org/pypi/tqdm
 .. |PyPI-Versions| image:: https://img.shields.io/pypi/pyversions/tqdm.svg
    :target: https://pypi.python.org/pypi/tqdm
+.. |Conda-Forge-Status| image:: https://anaconda.org/conda-forge/tqdm/badges/version.svg
+   :target: https://anaconda.org/conda-forge/tqdm
 .. |LICENCE| image:: https://img.shields.io/pypi/l/tqdm.svg
    :target: https://raw.githubusercontent.com/tqdm/tqdm/master/LICENCE
 .. |DOI-URI| image:: https://zenodo.org/badge/21637/tqdm/tqdm.svg

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,28 @@
+{
+    "version": 1,
+    "project": "tqdm",
+    "project_url": "https://github.com/tqdm/tqdm/",
+    "repo": ".",
+    "environment_type": "virtualenv",
+    "show_commit_url": "http://github.com/tqdm/tqdm/commit/",
+    // "pythons": ["2.7", "3.3"],
+    // "matrix": {
+    //     "numpy": ["1.6", "1.7"],
+    //     "six": ["", null],        // test with and without six installed
+    //     "pip+emcee": [""],   // emcee is only available for install with pip.
+    // },
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    // ],
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "numpy": "1.8"},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    // ],
+    "benchmark_dir": "benchmarks",
+    "env_dir": ".asv/env",
+    "results_dir": ".asv/results",
+    "html_dir": ".asv/html",
+}

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,13 +1,20 @@
 # Write the benchmarking functions here.
 # See "Writing benchmarks" in the asv docs for more information.
+from __future__ import division
 
 
-class TimeSuite:
+class FractionalOverheadSuite:
     """
     An example benchmark that times the performance of various kinds
     of iterating over dictionaries in Python.
     """
     def setup(self):
+        try:
+            from time import process_time
+            self.time = process_time
+        except ImportError:
+            from time import clock
+            self.time = clock
         from tqdm import tqdm
         self.tqdm = tqdm
         try:
@@ -15,11 +22,14 @@ class TimeSuite:
         except:
             self.iterable = range(int(6e6))
 
-    def time_tqdm(self):
+        t0 = self.time()
+        [0 for _ in self.iterable]
+        t1 = self.time()
+        self.t = t1 - t0
+
+
+    def track_tqdm(self):
+        t0 = self.time()
         [0 for _ in self.tqdm(self.iterable)]
-
-
-class MemSuite:
-    # def mem_list(self):
-    #     return [0] * 256
-    pass
+        t1 = self.time()
+        return (t1 - t0 - self.t) / self.t  # fractional overhead

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -19,7 +19,7 @@ class FractionalOverheadSuite:
         self.tqdm = tqdm
         try:
             self.iterable = xrange(int(6e6))
-        except:
+        except NameError:
             self.iterable = range(int(6e6))
 
         t0 = self.time()
@@ -27,9 +27,16 @@ class FractionalOverheadSuite:
         t1 = self.time()
         self.t = t1 - t0
 
-
     def track_tqdm(self):
         t0 = self.time()
         [0 for _ in self.tqdm(self.iterable)]
         t1 = self.time()
-        return (t1 - t0 - self.t) / self.t  # fractional overhead
+        return (t1 - t0 - self.t) / self.t
+
+    def track_optimsed(self):
+        t0 = self.time()
+        [0 for _ in self.tqdm(self.iterable,
+                              miniters=6e5, smoothing=0)]
+        # TODO: miniters=None, mininterval=0.1, smoothing=0)]
+        t1 = self.time()
+        return (t1 - t0 - self.t) / self.t

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,0 +1,25 @@
+# Write the benchmarking functions here.
+# See "Writing benchmarks" in the asv docs for more information.
+
+
+class TimeSuite:
+    """
+    An example benchmark that times the performance of various kinds
+    of iterating over dictionaries in Python.
+    """
+    def setup(self):
+        from tqdm import tqdm
+        self.tqdm = tqdm
+        try:
+            self.iterable = xrange(int(6e6))
+        except:
+            self.iterable = range(int(6e6))
+
+    def time_tqdm(self):
+        [0 for _ in self.tqdm(self.iterable)]
+
+
+class MemSuite:
+    # def mem_list(self):
+    #     return [0] * 256
+    pass

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -721,7 +721,7 @@ class tqdm(object):
 
         # Init the time counter
         # NB: Avoid race conditions by setting this at the very end of init
-        self.start_t = self.last_print_t = self._time()
+        self.last_print_t = self.start_t = self._time()
 
     def __len__(self):
         return (self.iterable.shape[0] if hasattr(self.iterable, 'shape')

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -427,8 +427,8 @@ class tqdm(object):
         fp.write(end)
         # Force refresh display of bars we cleared
         for inst in inst_cleared:
-            # Avoid racing conditions by checking that the instance started
-            if hasattr(inst, 'started') and inst.started:
+            # Avoid race conditions by checking that the instance started
+            if hasattr(inst, 'start_t'):
                 inst.refresh()
         # TODO: make list of all instances incl. absolutely positioned ones?
 
@@ -720,10 +720,8 @@ class tqdm(object):
                 self.moveto(-self.pos)
 
         # Init the time counter
+        # NB: Avoid race conditions by setting this at the very end of init
         self.start_t = self.last_print_t = self._time()
-
-        # Avoid race conditions by setting a flag at the very end of init
-        self.started = True
 
     def __len__(self):
         return (self.iterable.shape[0] if hasattr(self.iterable, 'shape')


### PR DESCRIPTION
Requires the `asv` python package as suggested in #298 (installable via `pip`) and either `conda` or `virtualenv`.

``` sh
~/tqdm$ asv run v1.0.0..master  # all commits from tag v1.0.0 to current master
~/tqdm$ asv publish  # builds html
~/tqdm$ asv preview  # serves to http://127.0.0.1:8080/
```

Takes about 30min to run first time. Pushable to https://github.com/tqdm/tqdm/tree/gh-pages using `asv gh-pages`. See the result here: https://tqdm.github.io/tqdm/ (note: not the same as https://tqdm.github.io/).
