### PR TITLE
Flush in refresh() and clean()

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -62,10 +62,7 @@ class TMonitor(Thread):
     _sleep = None
 
     def __init__(self, tqdm_cls, sleep_interval):
-        if hasattr(sys, 'setswitchinterval'):
-            sys.setswitchinterval(100) # new
-        else:
-            sys.setcheckinterval(100) # deprecated
+        sys.setswitchinterval(100)
         Thread.__init__(self)
         self.daemon = True  # kill thread when main killed (KeyboardInterrupt)
         self.was_killed = False

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -63,9 +63,9 @@ class TMonitor(Thread):
 
     def __init__(self, tqdm_cls, sleep_interval):
         if hasattr(sys, 'setswitchinterval'):
-          sys.setswitchinterval(100) # new
+            sys.setswitchinterval(100) # new
         else:
-          sys.setcheckinterval(100) # deprecated
+            sys.setcheckinterval(100) # deprecated
         Thread.__init__(self)
         self.daemon = True  # kill thread when main killed (KeyboardInterrupt)
         self.was_killed = False

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1068,6 +1068,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         # Print current/last bar state
         self.fp.write(self.__repr__())
         self.moveto(-self.pos)
+        self.fp.flush()
 
 
 def trange(*args, **kwargs):

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -62,7 +62,10 @@ class TMonitor(Thread):
     _sleep = None
 
     def __init__(self, tqdm_cls, sleep_interval):
-        sys.setcheckinterval(100)
+        if hasattr(sys, 'setswitchinterval'):
+          sys.setswitchinterval(100) # new
+        else:
+          sys.setcheckinterval(100) # deprecated
         Thread.__init__(self)
         self.daemon = True  # kill thread when main killed (KeyboardInterrupt)
         self.was_killed = False

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -62,7 +62,7 @@ class TMonitor(Thread):
     _sleep = None
 
     def __init__(self, tqdm_cls, sleep_interval):
-        sys.setswitchinterval(100)
+        sys.setcheckinterval(100)
         Thread.__init__(self)
         self.daemon = True  # kill thread when main killed (KeyboardInterrupt)
         self.was_killed = False


### PR DESCRIPTION
for me, without `self.fp.flush()`, refresh always fails in Python 3.5 (but not in 2.7), even with the most mimal test code.  added `flush` at the end of `refresh`.