### PR TITLE
Parallelism safety (thread, multiprocessing)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # IMPORTANT: for compatibility with `python setup.py make [alias]`, ensure:
 # 1. Every alias is preceded by @[+]make (eg: @make alias)
 # 2. A maximum of one @make alias or command per line
+# 3. Only use tabs, not spaces to indent (compatibility with linux make)
 #
 # Sample makefile compatible with `python setup.py make`:
 #```
@@ -64,17 +65,21 @@ testcoverage:
 	@make coverclean
 	nosetests tqdm --with-coverage --cover-package=tqdm --cover-erase --cover-min-percentage=80 --ignore-files="tests_perf\.py" -d -v
 
-testperf:  # do not use coverage (which is extremely slow)
+testperf:
+	# do not use coverage (which is extremely slow)
 	nosetests tqdm/tests/tests_perf.py -d -v
 
 testtimer:
 	nosetests tqdm --with-timer -d -v
 
+# another performance test, to check evolution across commits
 testasv:
+	# Test only the last 3 commits (quick test)
 	asv run -j 8 HEAD~3..HEAD
 	@make viewasv
 
 testasvfull:
+	# Test all the commits since the beginning (full test)
 	asv run -j 8 v1.0.0..master
 	@make testasv
 

--- a/README.rst
+++ b/README.rst
@@ -657,10 +657,8 @@ A reusable canonical example is given below:
 .. code:: python
 
     from time import sleep
-
     import contextlib
     import sys
-
     from tqdm import tqdm
 
     class DummyTqdmFile(object):
@@ -673,6 +671,9 @@ A reusable canonical example is given below:
             # Avoid print() second call (useless \n)
             if len(x.rstrip()) > 0:
                 tqdm.write(x, file=self.file)
+
+        def flush(self):
+            return getattr(self.file, "flush", lambda: None)()
 
     @contextlib.contextmanager
     def stdout_redirect_to_tqdm():
@@ -692,11 +693,11 @@ A reusable canonical example is given below:
 
     # Redirect stdout to tqdm.write() (don't forget the `as save_stdout`)
     with stdout_redirect_to_tqdm() as save_stdout:
-        # tqdm call need to specify sys.stdout, not sys.stderr (default)
+        # tqdm needs the original sys.stdout
         # and dynamic_ncols=True to autodetect console width
         for _ in tqdm(range(3), file=save_stdout, dynamic_ncols=True):
-            blabla()
             sleep(.5)
+            blabla()
 
     # After the `with`, printing is restored
     print('Done!')

--- a/README.rst
+++ b/README.rst
@@ -511,7 +511,30 @@ available to keep nested bars on their respective lines.
 
 For manual control over positioning (e.g. for multi-threaded use),
 you may specify ``position=n`` where ``n=0`` for the outermost bar,
-``n=1`` for the next, and so on.
+``n=1`` for the next, and so on:
+
+.. code:: python
+
+    from time import sleep
+    from tqdm import trange
+    from multiprocessing import Pool, freeze_support, Lock
+
+    L = list(range(9))
+
+    def progresser(n):
+        interval = 0.001 / (n + 2)
+        total = 5000
+        text = "#{}, est. {:<04.2}s".format(n, interval * total)
+        for i in trange(total, desc=text, position=n):
+            sleep(interval)
+
+    if __name__ == '__main__':
+        freeze_support()  # for Windows support
+        p = Pool(len(L),
+                 # again, for Windows support
+                 initializer=tqdm.set_lock, initargs=(Lock(),))
+        p.map(progresser, L)
+        print("\n" * (len(L) - 2))
 
 Hooks and callbacks
 ~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -676,31 +676,31 @@ A reusable canonical example is given below:
             return getattr(self.file, "flush", lambda: None)()
 
     @contextlib.contextmanager
-    def stdout_redirect_to_tqdm():
-        save_stdout = sys.stdout
+    def std_out_err_redirect_tqdm():
+        orig_out_err = sys.stdout, sys.stderr
         try:
-            sys.stdout = DummyTqdmFile(sys.stdout)
-            yield save_stdout
+            sys.stdout, sys.stderr = map(DummyTqdmFile, orig_out_err)
+            yield orig_out_err[0]
         # Relay exceptions
         except Exception as exc:
             raise exc
-        # Always restore sys.stdout if necessary
+        # Always restore sys.stdout/err if necessary
         finally:
-            sys.stdout = save_stdout
+            sys.stdout, sys.stderr = orig_out_err
 
-    def blabla():
-        print("Foo blabla")
+    def some_fun(i):
+        print("Fee, fi, fo,".split()[i])
 
     # Redirect stdout to tqdm.write() (don't forget the `as save_stdout`)
-    with stdout_redirect_to_tqdm() as save_stdout:
-        # tqdm needs the original sys.stdout
+    with std_out_err_redirect_tqdm() as orig_stdout:
+        # tqdm needs the original stdout
         # and dynamic_ncols=True to autodetect console width
-        for _ in tqdm(range(3), file=save_stdout, dynamic_ncols=True):
+        for i in tqdm(range(3), file=orig_stdout, dynamic_ncols=True):
             sleep(.5)
-            blabla()
+            some_fun(i)
 
     # After the `with`, printing is restored
-    print('Done!')
+    print("Done!")
 
 Monitoring thread, intervals and miniters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/parallel_bars.py
+++ b/examples/parallel_bars.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+from time import sleep
+from tqdm import tqdm
+from multiprocessing import Pool, freeze_support, Lock
+
+
+L = list(range(9))
+
+
+def progresser(n):
+    interval = 0.001 / (n + 2)
+    total = 5000
+    text = "#{}, est. {:<04.2}s".format(n, interval * total)
+    for _ in tqdm(range(total), desc=text, position=n):
+        sleep(interval)
+
+
+if __name__ == '__main__':
+    freeze_support()  # for Windows support
+    p = Pool(len(L),
+             initializer=tqdm.set_lock,
+             initargs=(Lock(),))
+    p.map(progresser, L)
+    print("\n" * (len(L) - 2))
+
+    # alternatively, on UNIX, just use the default internal lock
+    p = Pool(len(L))
+    p.map(progresser, L)
+    print("\n" * (len(L) - 2))

--- a/examples/redirect_print.py
+++ b/examples/redirect_print.py
@@ -34,30 +34,31 @@ class DummyTqdmFile(object):
 
 
 @contextlib.contextmanager
-def stdout_redirect_to_tqdm():
-    save_stdout = sys.stdout
+def std_out_err_redirect_tqdm():
+    orig_out_err = sys.stdout, sys.stderr
     try:
-        sys.stdout = DummyTqdmFile(sys.stdout)
-        yield save_stdout
+        # sys.stdout = sys.stderr = DummyTqdmFile(orig_out_err[0])
+        sys.stdout, sys.stderr = map(DummyTqdmFile, orig_out_err)
+        yield orig_out_err[0]
     # Relay exceptions
     except Exception as exc:
         raise exc
-    # Always restore sys.stdout if necessary
+    # Always restore sys.stdout/err if necessary
     finally:
-        sys.stdout = save_stdout
+        sys.stdout, sys.stderr = orig_out_err
 
 
-def blabla():
-    print("Foo blabla")
+def some_fun(i):
+    print("Fee, fi, fo,".split()[i])
 
 
-# Redirect stdout to tqdm.write() (don't forget the `as save_stdout`)
-with stdout_redirect_to_tqdm() as save_stdout:
-    # tqdm needs the original sys.stdout
+# Redirect stdout to tqdm.write()
+with std_out_err_redirect_tqdm() as orig_stdout:
+    # tqdm needs the original stdout
     # and dynamic_ncols=True to autodetect console width
-    for _ in tqdm(range(3), file=save_stdout, dynamic_ncols=True):
+    for i in tqdm(range(3), file=orig_stdout, dynamic_ncols=True):
         sleep(.5)
-        blabla()
+        some_fun(i)
 
 # After the `with`, printing is restored
-print('Done!')
+print("Done!")

--- a/examples/redirect_print.py
+++ b/examples/redirect_print.py
@@ -29,6 +29,9 @@ class DummyTqdmFile(object):
         if len(x.rstrip()) > 0:
             tqdm.write(x, file=self.file)
 
+    def flush(self):
+        return getattr(self.file, "flush", lambda: None)()
+
 
 @contextlib.contextmanager
 def stdout_redirect_to_tqdm():
@@ -50,11 +53,11 @@ def blabla():
 
 # Redirect stdout to tqdm.write() (don't forget the `as save_stdout`)
 with stdout_redirect_to_tqdm() as save_stdout:
-    # tqdm call need to specify sys.stdout, not sys.stderr (default)
+    # tqdm needs the original sys.stdout
     # and dynamic_ncols=True to autodetect console width
     for _ in tqdm(range(3), file=save_stdout, dynamic_ncols=True):
-        blabla()
         sleep(.5)
+        blabla()
 
 # After the `with`, printing is restored
 print('Done!')

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ commands =
 [testenv:flake8]
 deps = flake8
 commands =
-    flake8 --max-line-length=80 --count --statistics --exit-zero -j 8 --exclude .asv .
+    flake8 --max-line-length=80 --count --statistics --exit-zero -j 8 --exclude .tox,.asv .
 
 [testenv:setup.py]
 deps =

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -476,10 +476,14 @@ class tqdm(object):
                 for inst in cls._instances:
                     if inst.pos > instance.pos:
                         inst.pos -= 1
-                # Kill monitor if no instances are left
-                if not cls._instances and cls.monitor:
+            # Kill monitor if no instances are left
+            if not cls._instances and cls.monitor:
+                try:
                     cls.monitor.exit()
                     del cls.monitor
+                except AttributeError:  # pragma: nocover
+                    pass
+                else:
                     cls.monitor = None
         except KeyError:
             pass

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -344,11 +344,11 @@ class tqdm(object):
 
             # format the stats displayed to the left and right sides of the bar
             if prefix:
-              # old prefix setup work around
-              bool_prefix_colon_already = (prefix[-2:] == ": ")
-              l_bar = prefix if bool_prefix_colon_already else prefix + ": "
+                # old prefix setup work around
+                bool_prefix_colon_already = (prefix[-2:] == ": ")
+                l_bar = prefix if bool_prefix_colon_already else prefix + ": "
             else:
-              l_bar = ''
+                l_bar = ''
             l_bar += '{0:3.0f}%|'.format(percentage)
             r_bar = '| {0}/{1} [{2}<{3}, {4}{5}]'.format(
                 n_fmt, total_fmt, elapsed_str, remaining_str, rate_fmt,

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -78,7 +78,7 @@ class TqdmDefaultWriteLock(object):
             lock.release()
     def __enter__(self):
         self.acquire()
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, *exc):
         self.release()
 
 

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1125,27 +1125,27 @@ def test_position():
 
 @with_setup(pretest, posttest)
 def test_set_description():
-   """Test set description"""
-   with closing(StringIO()) as our_file:
-       with tqdm(desc='Hello', file=our_file) as t:
-           assert t.desc == 'Hello'
-           t.set_description_str('World')
-           assert t.desc == 'World'
-           t.set_description()
-           assert t.desc == ''
-           t.set_description('Bye')
-           assert t.desc == 'Bye: '
-       assert "World" in our_file.getvalue()
+    """Test set description"""
+    with closing(StringIO()) as our_file:
+        with tqdm(desc='Hello', file=our_file) as t:
+            assert t.desc == 'Hello'
+            t.set_description_str('World')
+            assert t.desc == 'World'
+            t.set_description()
+            assert t.desc == ''
+            t.set_description('Bye')
+            assert t.desc == 'Bye: '
+        assert "World" in our_file.getvalue()
 
-   # without refresh
-   with closing(StringIO()) as our_file:
-       with tqdm(desc='Hello', file=our_file) as t:
-           assert t.desc == 'Hello'
-           t.set_description_str('World', False)
-           assert t.desc == 'World'
-           t.set_description(None, False)
-           assert t.desc == ''
-       assert "World" not in our_file.getvalue()
+    # without refresh
+    with closing(StringIO()) as our_file:
+        with tqdm(desc='Hello', file=our_file) as t:
+            assert t.desc == 'Hello'
+            t.set_description_str('World', False)
+            assert t.desc == 'World'
+            t.set_description(None, False)
+            assert t.desc == ''
+        assert "World" not in our_file.getvalue()
 
 
 @with_setup(pretest, posttest)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1605,20 +1605,17 @@ class DummyTqdmFile(object):
 
 
 @contextmanager
-def stdout_stderr_redirect_to_tqdm(tqdm_file=sys.stderr):
-    save_stdout = sys.stdout
-    save_stderr = sys.stderr
+def std_out_err_redirect_tqdm(tqdm_file=sys.stderr):
+    orig_out_err = sys.stdout, sys.stderr
     try:
-        sys.stdout = DummyTqdmFile(tqdm_file)
-        sys.stderr = DummyTqdmFile(tqdm_file)
-        yield save_stdout, save_stderr
+        sys.stdout = sys.stderr = DummyTqdmFile(tqdm_file)
+        yield orig_out_err[0]
     # Relay exceptions
     except Exception as exc:
         raise exc
-    # Always restore sys.stdout if necessary
+    # Always restore sys.stdout/err if necessary
     finally:
-        sys.stdout = save_stdout
-        sys.stderr = save_stderr
+        sys.stdout, sys.stderr = orig_out_err
 
 
 @with_setup(pretest, posttest)
@@ -1626,8 +1623,7 @@ def test_file_redirection():
     """Test redirection of output"""
     with closing(StringIO()) as our_file:
         # Redirect stdout to tqdm.write()
-        with stdout_stderr_redirect_to_tqdm(tqdm_file=our_file):
-            # as (stdout, stderr)
+        with std_out_err_redirect_tqdm(tqdm_file=our_file):
             for _ in trange(3):
                 print("Such fun")
         res = our_file.getvalue()

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1137,7 +1137,6 @@ def test_set_description():
            assert t.desc == 'Bye: '
        assert "World" in our_file.getvalue()
 
-
    # without refresh
    with closing(StringIO()) as our_file:
        with tqdm(desc='Hello', file=our_file) as t:


### PR DESCRIPTION
Implement parallelism safety in `tqdm` by providing a new `set_lock()` class method. This is a follow-up on #291.

For Linux (and any platform supporting `fork`), no action is required from the user.

For Windows, here is the canonical example usage:

```
from time import sleep
from tqdm import tqdm
from multiprocessing import Pool, freeze_support, Lock

def progresser(n):         
    text = "bar{}".format(n)
    for i in tqdm(range(5000), desc=text, position=n, leave=True):
        sleep(0.001)

def init_child(write_lock):
    """
    Provide tqdm with the lock from the parent app.
    This is necessary on Windows to avoid racing conditions.
    """
    tqdm.set_lock(write_lock)

if __name__ == '__main__':
    freeze_support()
    write_lock = Lock()
    L = list(range(10))
    Pool(len(L), initializer=init_child, initargs=(write_lock,)).map(progresser, L)
```

Todo:

- [ ] Unit test (using squash_ctrl and a fake IO, just check that there are 10 lines at the end, each with a different number, just like the example case provided) with the sample code above as a unit test + with `mp.set_start_method('spawn')` to force mimicking Windows "no-fork" spawning of processes. Else it's impossible to test on Linux.
- [x] Flake8
- [x] add in the documentation how to use tqdm with locks on Windows (as it should be transparent on Linux)
- [ ] LIMITATION: `tqdm.write()` won't work, because there is no way to implement it without a centralized manager that is aware of all bars. See #143 for a possible solution. Or maybe we can change `_instances` type to a `multiprocessing.Queue()` (or another type that is shareable across multiprocesses)?
- [x] update documentation (e.g. #439)