### PR TITLE
Fix security issue in __version__ extra calculation (fix #328)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,5 @@ omit =
     tqdm/tests/*
     tqdm/_tqdm_gui.py
     tqdm/_tqdm_notebook.py
+[report]
+show_missing = True

--- a/examples/7zx.py
+++ b/examples/7zx.py
@@ -107,6 +107,8 @@ def main():
                                 else:
                                     t.write(l)
             ex.wait()
+
+
 main.__doc__ = __doc__
 
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,8 @@ def execute_makefile_commands(commands, alias, verbose=False):
             if verbose:
                 print("Running command: " + cmd)
             # Launch the command and wait to finish (synchronized call)
-            check_call(parsed_cmd, cwd=os.path.dirname(os.path.abspath(__file__)))
+            check_call(parsed_cmd,
+                       cwd=os.path.dirname(os.path.abspath(__file__)))
 
 
 # Main setup.py config #

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -437,7 +437,7 @@ class tqdm(object):
         # Force refresh display of bars we cleared
         for inst in inst_cleared:
             # Avoid race conditions by checking that the instance started
-            if hasattr(inst, 'start_t'):
+            if hasattr(inst, 'start_t'):  # pragma: nocover
                 inst.refresh()
         # TODO: make list of all instances incl. absolutely positioned ones?
 

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -52,11 +52,13 @@ if True:  # pragma: no cover
         except ImportError:  # older Python versions without ordereddict lib
             # Py2.6,3.0 compat, from PEP 372
             from collections import MutableMapping
+
             class _OrderedDict(dict, MutableMapping):
                 # Methods with direct access to underlying attributes
                 def __init__(self, *args, **kwds):
                     if len(args) > 1:
-                        raise TypeError('expected at 1 argument, got %d', len(args))
+                        raise TypeError('expected at 1 argument, got %d',
+                                        len(args))
                     if not hasattr(self, '_keys'):
                         self._keys = []
                     self.update(*args, **kwds)

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -205,8 +205,3 @@ def _environ_cols_linux(fp):  # pragma: no cover
 
 def _term_move_up():  # pragma: no cover
     return '' if (os.name == 'nt') and (colorama is None) else '\x1b[A'
-
-
-def _sh(*cmd, **kwargs):
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                            **kwargs).communicate()[0].decode('utf-8')

--- a/tqdm/_version.py
+++ b/tqdm/_version.py
@@ -11,35 +11,41 @@ __version__ = '.'.join(map(str, version_info))
 
 
 # auto -extra based on commit hash (if not tagged as release)
-res = None
 scriptdir = os.path.dirname(__file__)
 gitdir = os.path.abspath(scriptdir + '/../.git')
 if os.path.isdir(gitdir):
-    # Open the HEAD file
-    with open(os.path.join(gitdir,'HEAD'), 'r') as fh_head:
-        res = fh_head.readline().strip()
-    # If we are in a branch, HEAD will point to a file containing the latest commit
-    if 'ref:' in res:
-        # Get reference file path
-        ref_file = res[5:]
-        # Get branch name
-        branch_name = ref_file.split('/')[-1]
-        # Sanitize path of ref file
-        # get full path to ref file
-        ref_file_path = os.path.abspath(os.path.join(gitdir, ref_file))
-        # check that we are in git folder (by stripping the git folder from the ref file path)
-        if os.path.relpath(ref_file_path, gitdir).replace('\\', '/') != ref_file:
-            # Trying to get out of git folder, not good!
-            res = None
-        else:
-            # Else the file file is inside git, all good
-            # Open the ref file
-            with open(ref_file_path, 'r') as fh_branch:
-                commit_hash = fh_branch.readline().strip()
-                res = commit_hash[:8] + ' (branch: ' + branch_name + ')'
-    # Else we are in detached HEAD mode, we directly have a commit hash
-    else:
-        res = res[:8]
+    extra = None
+    # Open config file to check if we are in tqdm project
+    with open(os.path.join(gitdir, 'config'), 'r') as fh_config:
+        if 'tqdm' in fh_config.read():
+            # Open the HEAD file
+            with open(os.path.join(gitdir, 'HEAD'), 'r') as fh_head:
+                extra = fh_head.readline().strip()
+            # If we are in a branch, HEAD will point to a file containing the latest commit
+            if 'ref:' in extra:
+                # Get reference file path
+                ref_file = extra[5:]
+                # Get branch name
+                branch_name = ref_file.split('/')[-1]
+
+                # Sanitize path of ref file
+                # get full path to ref file
+                ref_file_path = os.path.abspath(os.path.join(gitdir, ref_file))
+                # check that we are in git folder (by stripping the git folder from the ref file path)
+                if os.path.relpath(ref_file_path, gitdir).replace('\\', '/') != ref_file:
+                    # Trying to get out of git folder, not good!
+                    extra = None
+                else:
+                    # Else the file file is inside git, all good
+                    # Open the ref file
+                    with open(ref_file_path, 'r') as fh_branch:
+                        commit_hash = fh_branch.readline().strip()
+                        extra = commit_hash[:8] + ' (branch: ' + branch_name + ')'
+
+            # Else we are in detached HEAD mode, we directly have a commit hash
+            else:
+                extra = extra[:8]  # limit to the first 8 symbols of the hash
+
     # Append to version string
-    if res is not None:
-        __version__ += '-' + res
+    if extra is not None:
+        __version__ += '-' + extra

--- a/tqdm/_version.py
+++ b/tqdm/_version.py
@@ -1,5 +1,6 @@
 # Definition of the version number
 import os
+from io import open as io_open
 
 __all__ = ["__version__"]
 
@@ -12,39 +13,39 @@ __version__ = '.'.join(map(str, version_info))
 
 # auto -extra based on commit hash (if not tagged as release)
 scriptdir = os.path.dirname(__file__)
-gitdir = os.path.abspath(scriptdir + '/../.git')
+gitdir = os.path.abspath(os.path.join(scriptdir, "..", ".git"))
 if os.path.isdir(gitdir):
     extra = None
     # Open config file to check if we are in tqdm project
-    with open(os.path.join(gitdir, 'config'), 'r') as fh_config:
+    with io_open(os.path.join(gitdir, "config"), 'r') as fh_config:
         if 'tqdm' in fh_config.read():
             # Open the HEAD file
-            with open(os.path.join(gitdir, 'HEAD'), 'r') as fh_head:
+            with io_open(os.path.join(gitdir, "HEAD"), 'r') as fh_head:
                 extra = fh_head.readline().strip()
-            # If we are in a branch, HEAD will point to a file containing the latest commit
+            # in a branch => HEAD points to file containing last commit
             if 'ref:' in extra:
-                # Get reference file path
+                # reference file path
                 ref_file = extra[5:]
-                # Get branch name
-                branch_name = ref_file.split('/')[-1]
+                branch_name = ref_file.rsplit('/', 1)[-1]
 
-                # Sanitize path of ref file
-                # get full path to ref file
                 ref_file_path = os.path.abspath(os.path.join(gitdir, ref_file))
-                # check that we are in git folder (by stripping the git folder from the ref file path)
-                if os.path.relpath(ref_file_path, gitdir).replace('\\', '/') != ref_file:
-                    # Trying to get out of git folder, not good!
+                # check that we are in git folder
+                # (by stripping the git folder from the ref file path)
+                if os.path.relpath(
+                        ref_file_path, gitdir).replace('\\', '/') != ref_file:
+                    # out of git folder
                     extra = None
                 else:
-                    # Else the file file is inside git, all good
-                    # Open the ref file
-                    with open(ref_file_path, 'r') as fh_branch:
+                    # open the ref file
+                    with io_open(ref_file_path, 'r') as fh_branch:
                         commit_hash = fh_branch.readline().strip()
-                        extra = commit_hash[:8] + ' (branch: ' + branch_name + ')'
+                        extra = commit_hash[:8]
+                        if branch_name != "master":
+                            extra += '.' + branch_name
 
-            # Else we are in detached HEAD mode, we directly have a commit hash
+            # detached HEAD mode, already have commit hash
             else:
-                extra = extra[:8]  # limit to the first 8 symbols of the hash
+                extra = extra[:8]
 
     # Append to version string
     if extra is not None:

--- a/tqdm/_version.py
+++ b/tqdm/_version.py
@@ -47,6 +47,9 @@ if os.path.isdir(gitdir):  # pragma: nocover
             else:
                 extra = extra[:8]
 
-    # Append to version string
+    # Append commit hash (and branch) to version string if not tagged
     if extra is not None:
-        __version__ += '-' + extra
+        with io_open(os.path.join(gitdir, "refs", "tags",
+                                  'v' + __version__)) as fdv:
+            if fdv.readline().strip()[:8] != extra[:8]:
+                __version__ += '-' + extra

--- a/tqdm/_version.py
+++ b/tqdm/_version.py
@@ -14,7 +14,7 @@ __version__ = '.'.join(map(str, version_info))
 # auto -extra based on commit hash (if not tagged as release)
 scriptdir = os.path.dirname(__file__)
 gitdir = os.path.abspath(os.path.join(scriptdir, "..", ".git"))
-if os.path.isdir(gitdir):
+if os.path.isdir(gitdir):  # pragma: nocover
     extra = None
     # Open config file to check if we are in tqdm project
     with io_open(os.path.join(gitdir, "config"), 'r') as fh_config:

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -48,6 +48,8 @@ def checkCpuTime(sleeptime=0.2):
     if (abs(t1) < 0.0001 and (t1 < t2 / 10)):
         return True
     raise SkipTest
+
+
 checkCpuTime.passed = False
 
 

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -28,6 +28,7 @@ from io import IOBase  # to support unicode strings
 class DeprecationError(Exception):
     pass
 
+
 # Ensure we can use `with closing(...) as ... :` syntax
 if getattr(StringIO, '__exit__', False) and \
    getattr(StringIO, '__enter__', False):
@@ -1515,9 +1516,10 @@ def test_monitoring_thread():
 def test_postfix():
     """Test postfix"""
     postfix = {'float': 0.321034, 'gen': 543, 'str': 'h', 'lst': [2]}
-    postfix_order = (('w', 'w'), ('a', 0))  # no need for a OrderedDict, set is OK
+    postfix_order = (('w', 'w'), ('a', 0))  # no need for OrderedDict
     expected = ['float=0.321', 'gen=543', 'lst=[2]', 'str=h']
-    expected_order = ['w=w', 'a=0', 'float=0.321', 'gen=543', 'lst=[2]', 'str=h']
+    expected_order = ['w=w', 'a=0', 'float=0.321', 'gen=543', 'lst=[2]',
+                      'str=h']
 
     # Test postfix set at init
     with closing(StringIO()) as our_file:

--- a/tqdm/tests/tests_version.py
+++ b/tqdm/tests/tests_version.py
@@ -4,7 +4,8 @@ import re
 def test_version():
     """ Test version string """
     from tqdm import __version__
-    Mmpe = re.split('[.-]', __version__)
+    Mmpe = __version__.split()[0]  # remove part after space (branch name)
+    Mmpe = re.split('[.-]', Mmpe)  # split by dot and dash
     assert 3 <= len(Mmpe) <= 4
     try:
         map(int, Mmpe[:3])

--- a/tqdm/tests/tests_version.py
+++ b/tqdm/tests/tests_version.py
@@ -4,10 +4,10 @@ import re
 def test_version():
     """ Test version string """
     from tqdm import __version__
-    Mmpe = __version__.split()[0]  # remove part after space (branch name)
-    Mmpe = re.split('[.-]', Mmpe)  # split by dot and dash
-    assert 3 <= len(Mmpe) <= 4
+    version_parts = __version__.split()[0]  # remove part after space (branch name)
+    version_parts = re.split('[.-]', version_parts)  # split by dot and dash
+    assert 3 <= len(version_parts) <= 4
     try:
-        map(int, Mmpe[:3])
+        map(int, version_parts[:3])
     except:
         raise TypeError('Version major, minor, patch must be integers')

--- a/tqdm/tests/tests_version.py
+++ b/tqdm/tests/tests_version.py
@@ -4,10 +4,9 @@ import re
 def test_version():
     """ Test version string """
     from tqdm import __version__
-    version_parts = __version__.split()[0]  # remove part after space (branch name)
-    version_parts = re.split('[.-]', version_parts)  # split by dot and dash
-    assert 3 <= len(version_parts) <= 4
+    version_parts = re.split('[.-]', __version__)
+    assert 3 <= len(version_parts)  # must have at least Major.minor.patch
     try:
         map(int, version_parts[:3])
-    except:
-        raise TypeError('Version major, minor, patch must be integers')
+    except ValueError:
+        raise TypeError('Version Major.minor.patch must be 3 integers')


### PR DESCRIPTION
and add branch name in ```__version__``` if available.

This should fix the security issue reported in #328 (thanks to @jwilk!) alias CVE-2016-10075.

TODO (but can be done later, we should merge ASAP a fix for this issue):
- [ ] restore 100% coverage (need to virtualize .git folder and create 3 scenarios: no tqdm in config, head detached so commit hash directly in HEAD file, head in a branch so commit hash is in a ref file). Maybe use something like `with unittest.mock.patch.dict(os.environ, PATH='/nonexistent')` (courtesy of @jwilk)?