### PR TITLE
Fix flush() in clean() and refresh()

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1049,8 +1049,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         if not nomove:
             self.moveto(self.pos)
         # clear up the bar (can't rely on sp(''))
-        self.fp.write('\r')
-        self.fp.write(' ' * (self.ncols if self.ncols else 10))
+        self.sp('')
         self.fp.write('\r')  # place cursor back at the beginning of line
         if not nomove:
             self.moveto(-self.pos)
@@ -1066,9 +1065,8 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         # clear up this line's content (whatever there was)
         self.clear(nomove=True)
         # Print current/last bar state
-        self.fp.write(self.__repr__())
+        self.sp(self.__repr__())
         self.moveto(-self.pos)
-        self.fp.flush()
 
 
 def trange(*args, **kwargs):

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1068,6 +1068,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         # Print current/last bar state
         self.fp.write(self.__repr__())
         self.moveto(-self.pos)
+        self.fp.flush()
 
 
 def trange(*args, **kwargs):

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1345,8 +1345,7 @@ def test_write():
             assert after_err_res == [u'\rpos0 bar:   0%',
                                      u'\rpos0 bar:  10%',
                                      u'\r      ',
-                                     u'\r\r      ',
-                                     u'\rpos0 bar:  10%']
+                                     u'\r\r\r\rpos0 bar:  10%']
             assert after_out == s + '\n'
     # Restore stdout and stderr
     sys.stderr = stde


### PR DESCRIPTION
Continuation of #327 by @deeenes.

We now use `status_printer()` in `clean()` and `refresh()`, so not only this automatically does `flush()`, but it also saves the last print length, which will provide a more consistent display after executing `clean()` or `refresh()` and then displaying the bar again (I guess doing `clean()` and `update()` in this order might produce weird displays sometimes, this should be fixed by this PR).

Just one test for `write()` had to be adapted, I checked myself with old example scripts using `write()` in various sceniarios, everything looks OK.

TODO:
- Nothing.