### PR TITLE
cleanup doc re: postfix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+[attr]py-file  eol=lf
+*.py           py-file
+
+.git*          export-ignore
+.mailmap       export-ignore
+images/        export-ignore
+benchmarks/    export-ignore
+MANIFEST.in    export-ignore
+.travis.yml    export-ignore
+codecov.yml    export-ignore
+asv.conf.json  export-ignore
+.style.yapf    export-ignore

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,10 @@
+[style]
+allow_multiline_dictionary_keys=True
+allow_multiline_lambdas=True
+coalesce_brackets=True
+column_limit=80
+each_dict_entry_on_separate_line=False
+i18n_comment=NOQA
+indent_dictionary_value=True
+space_between_ending_comma_and_closing_bracket=False
+split_before_named_assigns=False

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,11 +6,10 @@ include logo.png
 # include images/logo.gif
 include Makefile
 include README.rst
-include RELEASE
 include tox.ini
 
 # Test suite
 recursive-include tqdm/tests *.py
 
 # Examples/Documentation
-recursive-include examples *
+recursive-include examples *.py

--- a/README.rst
+++ b/README.rst
@@ -325,10 +325,12 @@ Parameters
 * bar_format  : str, optional  
     Specify a custom bar string formatting. May impact performance.
     If unspecified, will use '{l_bar}{bar}{r_bar}', where l_bar is
-    '{desc}{percentage:3.0f}%|' and r_bar is
+    '{desc}: {percentage:3.0f}%|' and r_bar is
     '| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]'
     Possible vars: bar, n, n_fmt, total, total_fmt, percentage,
     rate, rate_fmt, elapsed, remaining, l_bar, r_bar, desc.
+    Note that a trailing ": " is automatically stripped after {desc}
+    if the latter is empty.
 * initial  : int, optional  
     The initial counter value. Useful when restarting a progress
     bar [default: 0].

--- a/README.rst
+++ b/README.rst
@@ -338,6 +338,8 @@ Parameters
     Useful to manage multiple bars at once (eg, from threads).
 * postfix  : dict, optional  
     Specify additional stats to display at the end of the bar.
+    Note: postfix is a dict ({'key': value} pairs) for this method,
+    not a string.
 * unit_divisor  : float, optional  
     [default: 1000], ignored unless `unit_scale` is True.
 

--- a/examples/7zx.py
+++ b/examples/7zx.py
@@ -32,7 +32,6 @@ __licence__ = "MPLv2.0"
 __version__ = "0.2.0"
 __license__ = __licence__
 
-
 RE_SCN = re.compile("([0-9]+)\s+([0-9]+)\s+(.*)$", flags=re.M)
 
 
@@ -55,7 +54,7 @@ def main():
         totals = map(int, finfo[-1][:2])
         # log.debug(totals)
         for s in range(2):
-            assert(sum(map(int, (inf[s] for inf in finfo[:-1]))) == totals[s])
+            assert (sum(map(int, (inf[s] for inf in finfo[:-1]))) == totals[s])
         fcomp = dict((n, int(c if args['--compressed'] else u))
                      for (u, c, n) in finfo[:-1])
         # log.debug(fcomp)
@@ -71,10 +70,11 @@ def main():
               unit="B", unit_scale=True) as tall:
         for fn, fcomp in zips.items():
             md, sd = pty.openpty()
-            ex = subprocess.Popen(cmd7zx + [fn],
-                                  bufsize=1,
-                                  stdout=md,  # subprocess.PIPE,
-                                  stderr=subprocess.STDOUT)
+            ex = subprocess.Popen(
+                cmd7zx + [fn],
+                bufsize=1,
+                stdout=md,  # subprocess.PIPE,
+                stderr=subprocess.STDOUT)
             os.close(sd)
             with io.open(md, mode="rU", buffering=1) as m:
                 with tqdm(total=sum(fcomp.values()), disable=len(zips) < 2,
@@ -91,26 +91,24 @@ def main():
                             t.update(s)
                             tall.update(s)
                         elif l:
-                            if not any(l.startswith(i) for i in
-                                       ("7-Zip ",
-                                        "p7zip Version ",
-                                        "Everything is Ok",
-                                        "Folders: ",
-                                        "Files: ",
-                                        "Size: ",
-                                        "Compressed: ")):
+                            if not any(
+                                    l.startswith(i)
+                                    for i in ("7-Zip ", "p7zip Version ",
+                                              "Everything is Ok", "Folders: ",
+                                              "Files: ", "Size: ",
+                                              "Compressed: ")):
                                 if l.startswith("Processing archive: "):
                                     if not args['--silent']:
-                                        t.write(t.format_interval(
-                                            t.start_t - tall.start_t) + ' ' +
-                                            l.lstrip("Processing archive: "))
+                                        t.write(
+                                            t.format_interval(
+                                                t.start_t - tall.start_t) + ' '
+                                            + l.lstrip("Processing archive: "))
                                 else:
                                     t.write(l)
             ex.wait()
 
 
 main.__doc__ = __doc__
-
 
 if __name__ == "__main__":
     main()

--- a/examples/include_no_requirements.py
+++ b/examples/include_no_requirements.py
@@ -2,6 +2,7 @@
 try:
     from tqdm import tqdm
 except ImportError:
+
     def tqdm(*args, **kwargs):
         if args:
             return args[0]

--- a/examples/pandas_progress_apply.py
+++ b/examples/pandas_progress_apply.py
@@ -14,7 +14,6 @@ df.progress_apply(lambda x: x**2)
 # can also groupby:
 # df.groupby(0).progress_apply(lambda x: x**2)
 
-
 # -- Source code for `tqdm_pandas` (really simple!)
 # def tqdm_pandas(t):
 #   from pandas.core.frame import DataFrame

--- a/examples/simple_examples.py
+++ b/examples/simple_examples.py
@@ -61,5 +61,4 @@ stmts = filter(None, re.split(r'\n\s*#.*?\n', __doc__))
 for s in stmts:
     print(s.replace('import tqdm\n', ''))
     print(timeit(stmt='try:\n\t_range = xrange'
-                      '\nexcept:\n\t_range = range\n' + s, number=1),
-          'seconds')
+                 '\nexcept:\n\t_range = range\n' + s, number=1), 'seconds')

--- a/examples/tqdm_wget.py
+++ b/examples/tqdm_wget.py
@@ -54,6 +54,7 @@ def my_hook(t):
             t.total = tsize
         t.update((b - last_b[0]) * bsize)
         last_b[0] = b
+
     return update_to
 
 
@@ -65,6 +66,7 @@ class TqdmUpTo(tqdm):
     Inspired by [twine#242](https://github.com/pypa/twine/pull/242),
     [here](https://github.com/pypa/twine/commit/42e55e06).
     """
+
     def update_to(self, b=1, bsize=1, tsize=None):
         """
         b  : int, optional
@@ -90,5 +92,5 @@ eg_out = opts['--output'].replace("/dev/null", devnull)
 #                        reporthook=my_hook(t), data=None)
 with TqdmUpTo(unit='B', unit_scale=True, unit_divisor=1024, miniters=1,
               desc=eg_file) as t:  # all optional kwargs
-    urllib.urlretrieve(eg_link, filename=eg_out,
-                       reporthook=t.update_to, data=None)
+    urllib.urlretrieve(eg_link, filename=eg_out, reporthook=t.update_to,
+                       data=None)

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -241,13 +241,16 @@ class tqdm(object):
             If [default: None], uses n/elapsed.
         bar_format  : str, optional
             Specify a custom bar string formatting. May impact performance.
-            [default: '{l_bar}{bar}{r_bar}'],
-            where l_bar is '{desc}{percentage:3.0f}%|' and
-            r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]'
+            [default: '{l_bar}{bar}{r_bar}'], where
+            l_bar='{desc}{percentage:3.0f}%|' and
+            r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, '
+                  '{rate_fmt}{postfix}]'
             Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt,
-                percentage, rate, rate_fmt, elapsed, remaining, desc, postfix.
+                percentage, rate, rate_fmt, elapsed, remaining, desc,
+                postfix.
         postfix  : str, optional
-            Similar to prefix, but placed at the end (e.g. for additional stats).
+            Similar to `prefix`, but placed at the end
+            (e.g. for additional stats).
             Note: postfix is a string for this method. Not a dict.
         unit_divisor  : float, optional
             [default: 1000], ignored unless `unit_scale` is True.
@@ -652,7 +655,8 @@ class tqdm(object):
             Useful to manage multiple bars at once (eg, from threads).
         postfix  : dict, optional
             Specify additional stats to display at the end of the bar.
-            Note: postfix is a dict ({'key':value} pairs) for this method. Not a string.
+            Note: postfix is a dict ({'key': value} pairs) for this method,
+            not a string.
         unit_divisor  : float, optional
             [default: 1000], ignored unless `unit_scale` is True.
         gui  : bool, optional
@@ -1089,9 +1093,15 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         """
         self.desc = desc + ': ' if desc else ''
 
+    def set_description_str(self, desc=None):
+        """
+        Set/modify description without ': ' appended.
+        """
+        self.desc = desc or ''
+
     def set_postfix(self, ordered_dict=None, **kwargs):
         """
-        Set/modify postfix (additional stats) given 'key':value pairs
+        Set/modify postfix (additional stats) given 'key': value pairs
         (and other arbitrary parameters with their values)
         with automatic formatting based on datatype.
         """
@@ -1112,7 +1122,10 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         self.postfix = ', '.join(key + '=' + postfix[key].strip()
                                  for key in postfix.keys())
 
-    def set_postfix_direct(self, s=''): # for e.g. status messages
+    def set_postfix_str(self, s=''):
+        """
+        Postfix without dictionary expansion, similar to prefix handling.
+        """
         self.postfix = str(s)
 
     def moveto(self, n):

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -197,12 +197,13 @@ class tqdm(object):
             len_s = len(s)
             fp_write('\r' + s + (' ' * max(last_len[0] - len_s, 0)))
             last_len[0] = len_s
+
         return print_status
 
     @staticmethod
-    def format_meter(n, total, elapsed, ncols=None, prefix='',
-                     ascii=False, unit='it', unit_scale=False, rate=None,
-                     bar_format=None, postfix=None, unit_divisor=1000):
+    def format_meter(n, total, elapsed, ncols=None, prefix='', ascii=False,
+                     unit='it', unit_scale=False, rate=None, bar_format=None,
+                     postfix=None, unit_divisor=1000):
         """
         Return a string-based progress bar given some parameters
 
@@ -300,8 +301,8 @@ class tqdm(object):
             l_bar = (prefix if prefix else '') + \
                 '{0:3.0f}%|'.format(percentage)
             r_bar = '| {0}/{1} [{2}<{3}, {4}{5}]'.format(
-                    n_fmt, total_fmt, elapsed_str, remaining_str, rate_fmt,
-                    ', ' + postfix if postfix else '')
+                n_fmt, total_fmt, elapsed_str, remaining_str, rate_fmt,
+                ', ' + postfix if postfix else '')
 
             if ncols == 0:
                 return l_bar[:-1] + r_bar[1:]
@@ -387,8 +388,8 @@ class tqdm(object):
             cls._instances = WeakSet()
         cls._instances.add(instance)
         # Create the monitoring thread
-        if cls.monitor_interval and (cls.monitor is None or
-                                     not cls.monitor.report()):
+        if cls.monitor_interval and (cls.monitor is None
+                                     or not cls.monitor.report()):
             cls.monitor = TMonitor(cls, cls.monitor_interval)
         # Return the instance
         return instance
@@ -439,8 +440,8 @@ class tqdm(object):
             # Clear instance if in the target output file
             # or if write output + tqdm output are both either
             # sys.stdout or sys.stderr (because both are mixed in terminal)
-            if inst.fp == fp or all(f in (sys.stdout, sys.stderr)
-                                    for f in (fp, inst.fp)):
+            if inst.fp == fp or all(
+                    f in (sys.stdout, sys.stderr) for f in (fp, inst.fp)):
                 inst.clear()
                 inst_cleared.append(inst)
         # Write the message
@@ -541,6 +542,7 @@ class tqdm(object):
                 # Close bar and return pandas calculation result
                 t.close()
                 return result
+
             return inner
 
         # Monkeypatch pandas to provide easy methods
@@ -562,12 +564,11 @@ class tqdm(object):
         GroupBy.progress_transform = inner_generator('transform')
 
     def __init__(self, iterable=None, desc=None, total=None, leave=True,
-                 file=None, ncols=None, mininterval=0.1,
-                 maxinterval=10.0, miniters=None, ascii=None, disable=False,
-                 unit='it', unit_scale=False, dynamic_ncols=False,
-                 smoothing=0.3, bar_format=None, initial=0, position=None,
-                 postfix=None, unit_divisor=1000,
-                 gui=False, **kwargs):
+                 file=None, ncols=None, mininterval=0.1, maxinterval=10.0,
+                 miniters=None, ascii=None, disable=False, unit='it',
+                 unit_scale=False, dynamic_ncols=False, smoothing=0.3,
+                 bar_format=None, initial=0, position=None, postfix=None,
+                 unit_divisor=1000, gui=False, **kwargs):
         """
         Parameters
         ----------
@@ -680,9 +681,8 @@ class tqdm(object):
             self._instances.remove(self)
             raise (TqdmDeprecationWarning("""\
 `nested` is deprecated and automated. Use position instead for manual control.
-""", fp_write=getattr(file, 'write', sys.stderr.write))
-                if "nested" in kwargs else
-                TqdmKeyError("Unknown argument(s): " + str(kwargs)))
+""", fp_write=getattr(file, 'write', sys.stderr.write)) if "nested" in kwargs
+                   else TqdmKeyError("Unknown argument(s): " + str(kwargs)))
 
         # Preprocess the arguments
         if total is None and iterable is not None:
@@ -800,14 +800,13 @@ class tqdm(object):
         self.close()
 
     def __repr__(self):
-        return self.format_meter(self.n, self.total,
-                                 self._time() - self.start_t,
-                                 self.dynamic_ncols(self.fp)
-                                 if self.dynamic_ncols else self.ncols,
-                                 self.desc, self.ascii, self.unit,
-                                 self.unit_scale, 1 / self.avg_time
-                                 if self.avg_time else None, self.bar_format,
-                                 self.postfix)
+        return self.format_meter(
+            self.n, self.total, self._time() - self.start_t,
+            self.dynamic_ncols(self.fp)
+            if self.dynamic_ncols else self.ncols, self.desc, self.ascii,
+            self.unit, self.unit_scale,
+            1 / self.avg_time if self.avg_time else None,
+            self.bar_format, self.postfix)
 
     def __lt__(self, other):
         return self.pos < other.pos

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -224,6 +224,7 @@ class tqdm(object):
             will not print any meter (only stats).
         prefix  : str, optional
             Prefix message (included in total width) [default: ''].
+            Use as {desc} in bar_format string.
         ascii  : bool, optional
             If not set, use unicode (smooth blocks) to fill the meter
             [default: False]. The fallback is to use ASCII characters
@@ -240,13 +241,14 @@ class tqdm(object):
             If [default: None], uses n/elapsed.
         bar_format  : str, optional
             Specify a custom bar string formatting. May impact performance.
-            [default: '{l_bar}{bar}{r_bar}'], where l_bar is
-            '{desc}{percentage:3.0f}%|' and r_bar is
-            '| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]'
-            Possible vars: bar, n, n_fmt, total, total_fmt, percentage,
-            rate, rate_fmt, elapsed, remaining, l_bar, r_bar, desc.
+            [default: '{l_bar}{bar}{r_bar}'],
+            where l_bar is '{desc}{percentage:3.0f}%|' and
+            r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]'
+            Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt,
+                percentage, rate, rate_fmt, elapsed, remaining, desc, postfix.
         postfix  : str, optional
-            Same as prefix but will be placed at the end as additional stats.
+            Similar to prefix, but placed at the end (e.g. for additional stats).
+            Note: postfix is a string for this method. Not a dict.
         unit_divisor  : float, optional
             [default: 1000], ignored unless `unit_scale` is True.
 
@@ -650,6 +652,7 @@ class tqdm(object):
             Useful to manage multiple bars at once (eg, from threads).
         postfix  : dict, optional
             Specify additional stats to display at the end of the bar.
+            Note: postfix is a dict ({'key':value} pairs) for this method. Not a string.
         unit_divisor  : float, optional
             [default: 1000], ignored unless `unit_scale` is True.
         gui  : bool, optional
@@ -1088,7 +1091,8 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
 
     def set_postfix(self, ordered_dict=None, **kwargs):
         """
-        Set/modify postfix (additional stats)
+        Set/modify postfix (additional stats) given 'key':value pairs
+        (and other arbitrary parameters with their values)
         with automatic formatting based on datatype.
         """
         # Sort in alphabetical order to be more deterministic
@@ -1107,6 +1111,9 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         # Stitch together to get the final postfix
         self.postfix = ', '.join(key + '=' + postfix[key].strip()
                                  for key in postfix.keys())
+
+    def set_postfix_direct(self, s=''): # for e.g. status messages
+        self.postfix = str(s)
 
     def moveto(self, n):
         self.fp.write(_unicode('\n' * n + _term_move_up() * -n))

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -305,8 +305,12 @@ class tqdm(object):
                 if rate else '?'
 
             # format the stats displayed to the left and right sides of the bar
-            l_bar = ((prefix + ": ") if prefix else '') + \
-                '{0:3.0f}%|'.format(percentage)
+            bool_prefix_colon_already = (prefix[-2:] == ": ") # old prefix setup work around
+            if prefix:
+              l_bar = prefix if bool_prefix_colon_already else prefix + ": "
+            else:
+              l_bar = ''
+            l_bar += '{0:3.0f}%|'.format(percentage)
             r_bar = '| {0}/{1} [{2}<{3}, {4}{5}]'.format(
                 n_fmt, total_fmt, elapsed_str, remaining_str, rate_fmt,
                 ', ' + postfix if postfix else '')

--- a/tqdm/tests/tests_main.py
+++ b/tqdm/tests/tests_main.py
@@ -15,12 +15,10 @@ def _sh(*cmd, **kwargs):
 def test_main():
     """Test command line pipes"""
     ls_out = _sh('ls').replace('\r\n', '\n')
-    ls = subprocess.Popen(('ls'),
-                          stdout=subprocess.PIPE,
+    ls = subprocess.Popen(('ls'), stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT)
     res = _sh(sys.executable, '-c', 'from tqdm import main; main()',
-              stdin=ls.stdout,
-              stderr=subprocess.STDOUT)
+              stdin=ls.stdout, stderr=subprocess.STDOUT)
     ls.wait()
 
     # actual test:

--- a/tqdm/tests/tests_pandas.py
+++ b/tqdm/tests/tests_pandas.py
@@ -19,8 +19,7 @@ def test_pandas_groupby_apply():
         df = pd.DataFrame(randint(0, 50, (500, 3)))
         df.groupby(0).progress_apply(lambda x: None)
 
-        dfs = pd.DataFrame(randint(0, 50, (500, 3)),
-                           columns=list('abc'))
+        dfs = pd.DataFrame(randint(0, 50, (500, 3)), columns=list('abc'))
         dfs.groupby(['a']).progress_apply(lambda x: None)
 
         our_file.seek(0)
@@ -48,8 +47,7 @@ def test_pandas_apply():
         df = pd.DataFrame(randint(0, 50, (500, 3)))
         df.progress_apply(lambda x: None)
 
-        dfs = pd.DataFrame(randint(0, 50, (500, 3)),
-                           columns=list('abc'))
+        dfs = pd.DataFrame(randint(0, 50, (500, 3)), columns=list('abc'))
         dfs.a.progress_apply(lambda x: None)
 
         our_file.seek(0)
@@ -71,8 +69,7 @@ def test_pandas_map():
 
     with closing(StringIO()) as our_file:
         tqdm.pandas(file=our_file, leave=True, ascii=True)
-        dfs = pd.DataFrame(randint(0, 50, (500, 3)),
-                           columns=list('abc'))
+        dfs = pd.DataFrame(randint(0, 50, (500, 3)), columns=list('abc'))
         dfs.a.progress_map(lambda x: None)
 
         if our_file.getvalue().count('100%') < 1:
@@ -99,8 +96,8 @@ def test_pandas_leave():
         exres = '100%|##########| 101/101'
         if exres not in our_file.read():
             our_file.seek(0)
-            raise AssertionError("\nExpected:\n{0}\nIn:{1}\n".format(
-                exres, our_file.read()))
+            raise AssertionError(
+                "\nExpected:\n{0}\nIn:{1}\n".format(exres, our_file.read()))
 
 
 @with_setup(pretest, posttest)

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -27,7 +27,7 @@ def get_relative_time(prevtime=0):
 def cpu_sleep(t):
     """Sleep the given amount of cpu time"""
     start = process_time()
-    while((process_time() - start) < t):
+    while ((process_time() - start) < t):
         pass
 
 
@@ -79,13 +79,16 @@ def retry_on_except(n=3):
                         raise
                 else:
                     return
+
         test_inner.__doc__ = fn.__doc__
         return test_inner
+
     return wrapper
 
 
 class MockIO(StringIO):
     """Wraps StringIO to mock a file with no I/O"""
+
     def write(self, data):
         return
 
@@ -131,15 +134,14 @@ def simple_progress(iterable=None, total=None, file=sys.stdout, desc='',
 
                 bar = "#" * int(frac * width)
                 barfill = " " * int((1.0 - frac) * width)
-                bar_length, frac_bar_length = divmod(
-                    int(frac * width * 10), 10)
+                bar_length, frac_bar_length = divmod(int(frac * width * 10), 10)
                 bar = '#' * bar_length
                 frac_bar = chr(48 + frac_bar_length) if frac_bar_length \
                     else ' '
 
-                file.write("\r%s %i%%|%s%s%s| %i/%i [%s<%s, %s]"
-                           % (desc, percentage, bar, frac_bar, barfill, n[0],
-                              total, spent_fmt, eta_fmt, rate_fmt))
+                file.write("\r%s %i%%|%s%s%s| %i/%i [%s<%s, %s]" %
+                           (desc, percentage, bar, frac_bar, barfill, n[0],
+                            total, spent_fmt, eta_fmt, rate_fmt))
 
                 if n[0] == total and leave:
                     file.write("\n")
@@ -169,7 +171,7 @@ def test_iter_overhead():
         with relative_timer() as time_tqdm:
             for i in trange(total, file=our_file):
                 a += i
-        assert(a == (total * total - total) / 2.0)
+        assert (a == (total * total - total) / 2.0)
 
         a = 0
         with relative_timer() as time_bench:
@@ -220,10 +222,10 @@ def test_iter_overhead_hard():
     with closing(MockIO()) as our_file:
         a = 0
         with relative_timer() as time_tqdm:
-            for i in trange(total, file=our_file, leave=True,
-                            miniters=1, mininterval=0, maxinterval=0):
+            for i in trange(total, file=our_file, leave=True, miniters=1,
+                            mininterval=0, maxinterval=0):
                 a += i
-        assert(a == (total * total - total) / 2.0)
+        assert (a == (total * total - total) / 2.0)
 
         a = 0
         with relative_timer() as time_bench:
@@ -233,7 +235,7 @@ def test_iter_overhead_hard():
 
     # Compute relative overhead of tqdm against native range()
     try:
-        assert(time_tqdm() < 60 * time_bench())
+        assert (time_tqdm() < 60 * time_bench())
     except AssertionError:
         raise AssertionError('trange(%g): %f, range(%g): %f' %
                              (total, time_tqdm(), total, time_bench()))
@@ -247,8 +249,8 @@ def test_manual_overhead_hard():
     total = int(1e5)
 
     with closing(MockIO()) as our_file:
-        t = tqdm(total=total * 10, file=our_file, leave=True,
-                 miniters=1, mininterval=0, maxinterval=0)
+        t = tqdm(total=total * 10, file=our_file, leave=True, miniters=1,
+                 mininterval=0, maxinterval=0)
         a = 0
         with relative_timer() as time_tqdm:
             for i in _range(total):
@@ -263,7 +265,7 @@ def test_manual_overhead_hard():
 
     # Compute relative overhead of tqdm against native range()
     try:
-        assert(time_tqdm() < 100 * time_bench())
+        assert (time_tqdm() < 100 * time_bench())
     except AssertionError:
         raise AssertionError('tqdm(%g): %f, range(%g): %f' %
                              (total, time_tqdm(), total, time_bench()))
@@ -279,21 +281,21 @@ def test_iter_overhead_simplebar_hard():
     with closing(MockIO()) as our_file:
         a = 0
         with relative_timer() as time_tqdm:
-            for i in trange(total, file=our_file, leave=True,
-                            miniters=1, mininterval=0, maxinterval=0):
+            for i in trange(total, file=our_file, leave=True, miniters=1,
+                            mininterval=0, maxinterval=0):
                 a += i
-        assert(a == (total * total - total) / 2.0)
+        assert (a == (total * total - total) / 2.0)
 
         a = 0
         with relative_timer() as time_bench:
-            for i in simple_progress(_range(total), file=our_file,
-                                     leave=True, miniters=1,
-                                     mininterval=0):
+            for i in simple_progress(
+                    _range(total), file=our_file, leave=True, miniters=1,
+                    mininterval=0):
                 a += i
 
     # Compute relative overhead of tqdm against native range()
     try:
-        assert(time_tqdm() < 2 * time_bench())
+        assert (time_tqdm() < 2 * time_bench())
     except AssertionError:
         raise AssertionError('trange(%g): %f, simple_progress(%g): %f' %
                              (total, time_tqdm(), total, time_bench()))
@@ -307,17 +309,16 @@ def test_manual_overhead_simplebar_hard():
     total = int(1e4)
 
     with closing(MockIO()) as our_file:
-        t = tqdm(total=total * 10, file=our_file, leave=True,
-                 miniters=1, mininterval=0, maxinterval=0)
+        t = tqdm(total=total * 10, file=our_file, leave=True, miniters=1,
+                 mininterval=0, maxinterval=0)
         a = 0
         with relative_timer() as time_tqdm:
             for i in _range(total):
                 a += i
                 t.update(10)
 
-        simplebar_update = simple_progress(total=total, file=our_file,
-                                           leave=True, miniters=1,
-                                           mininterval=0)
+        simplebar_update = simple_progress(
+            total=total, file=our_file, leave=True, miniters=1, mininterval=0)
         a = 0
         with relative_timer() as time_bench:
             for i in _range(total):
@@ -326,7 +327,7 @@ def test_manual_overhead_simplebar_hard():
 
     # Compute relative overhead of tqdm against native range()
     try:
-        assert(time_tqdm() < 2 * time_bench())
+        assert (time_tqdm() < 2 * time_bench())
     except AssertionError:
         raise AssertionError('tqdm(%g): %f, simple_progress(%g): %f' %
                              (total, time_tqdm(), total, time_bench()))

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -33,6 +33,7 @@ class DeprecationError(Exception):
 # Ensure we can use `with closing(...) as ... :` syntax
 if getattr(StringIO, '__exit__', False) and \
    getattr(StringIO, '__enter__', False):
+
     def closing(arg):
         return arg
 else:
@@ -62,7 +63,8 @@ CTRLCHR = [r'\r', r'\n', r'\x1b\[A']  # Need to escape [ for regex
 RE_rate = re.compile(r'(\d+\.\d+)it/s')
 RE_ctrlchr = re.compile("(%s)" % '|'.join(CTRLCHR))  # Match control chars
 RE_ctrlchr_excl = re.compile('|'.join(CTRLCHR))  # Match and exclude ctrl chars
-RE_pos = re.compile(r'((\x1b\[A|\r|\n)+((pos\d+) bar:\s+\d+%|\s{3,6})?)')  # NOQA
+RE_pos = re.compile(
+    r'((\x1b\[A|\r|\n)+((pos\d+) bar:\s+\d+%|\s{3,6})?)')  # NOQA
 
 
 class DiscreteTimer(object):
@@ -82,12 +84,13 @@ class DiscreteTimer(object):
 
 class FakeSleep(object):
     '''Wait until the discrete timer reached the required time'''
+
     def __init__(self, dtimer):
         self.dtimer = dtimer
 
     def sleep(self, t):
         end = t + self.dtimer.t
-        while(self.dtimer.t < end):
+        while (self.dtimer.t < end):
             sleep(0.0000001)  # sleep a bit to interrupt (instead of pass)
 
 
@@ -103,8 +106,7 @@ def cpu_timify(t, timer=None):
 
 def pretest():
     # setcheckinterval is deprecated
-    getattr(sys, 'setswitchinterval',
-            getattr(sys, 'setcheckinterval'))(100)
+    getattr(sys, 'setswitchinterval', getattr(sys, 'setcheckinterval'))(100)
 
     if getattr(tqdm, "_instances", False):
         n = len(tqdm._instances)
@@ -399,8 +401,8 @@ def test_max_interval():
             cpu_timify(t, timer)
 
             # without maxinterval
-            t2 = tqdm(total=total, file=our_file2, miniters=None,
-                      mininterval=0, smoothing=1, maxinterval=None)
+            t2 = tqdm(total=total, file=our_file2, miniters=None, mininterval=0,
+                      smoothing=1, maxinterval=None)
             cpu_timify(t2, timer)
 
             assert t.dynamic_miniters
@@ -818,8 +820,8 @@ def test_close():
         exres = res + '\n'
         if exres != our_file.read():
             our_file.seek(0)
-            raise AssertionError("\nExpected:\n{0}\nGot:{1}\n".format(
-                exres, our_file.read()))
+            raise AssertionError(
+                "\nExpected:\n{0}\nGot:{1}\n".format(exres, our_file.read()))
 
     # Closing after the output stream has closed
     with closing(StringIO()) as our_file:
@@ -997,8 +999,8 @@ def test_position():
     # Artificially test nested loop printing
     # Without leave
     our_file = StringIO()
-    t = tqdm(total=2, file=our_file, miniters=1, mininterval=0,
-             maxinterval=0, desc='pos2 bar', leave=False, position=2)
+    t = tqdm(total=2, file=our_file, miniters=1, mininterval=0, maxinterval=0,
+             desc='pos2 bar', leave=False, position=2)
     t.update()
     t.close()
     our_file.seek(0)
@@ -1014,8 +1016,8 @@ def test_position():
 
     # Test iteration-based tqdm positioning
     our_file = StringIO()
-    for _ in trange(2, file=our_file, miniters=1, mininterval=0,
-                    maxinterval=0, desc='pos0 bar', position=0):
+    for _ in trange(2, file=our_file, miniters=1, mininterval=0, maxinterval=0,
+                    desc='pos0 bar', position=0):
         for _ in trange(2, file=our_file, miniters=1, mininterval=0,
                         maxinterval=0, desc='pos1 bar', position=1):
             for _ in trange(2, file=our_file, miniters=1, mininterval=0,
@@ -1052,12 +1054,12 @@ def test_position():
 
     # Test manual tqdm positioning
     our_file = StringIO()
-    t1 = tqdm(total=2, file=our_file, miniters=1, mininterval=0,
-              maxinterval=0, desc='pos0 bar', position=0)
-    t2 = tqdm(total=2, file=our_file, miniters=1, mininterval=0,
-              maxinterval=0, desc='pos1 bar', position=1)
-    t3 = tqdm(total=2, file=our_file, miniters=1, mininterval=0,
-              maxinterval=0, desc='pos2 bar', position=2)
+    t1 = tqdm(total=2, file=our_file, miniters=1, mininterval=0, maxinterval=0,
+              desc='pos0 bar', position=0)
+    t2 = tqdm(total=2, file=our_file, miniters=1, mininterval=0, maxinterval=0,
+              desc='pos1 bar', position=1)
+    t3 = tqdm(total=2, file=our_file, miniters=1, mininterval=0, maxinterval=0,
+              desc='pos2 bar', position=2)
     for _ in _range(2):
         t1.update()
         t3.update()
@@ -1095,8 +1097,7 @@ def test_position():
                  '\x1b[A\x1b[A']
         if res != exres:
             raise AssertionError(
-                "\nExpected:\n{0}\nGot:\n{1}\n".format(
-                    str(exres), str(res)))
+                "\nExpected:\n{0}\nGot:\n{1}\n".format(str(exres), str(res)))
 
         t2.close()
         t4 = tqdm(total=10, file=our_file, desc='pos3 bar', mininterval=0)
@@ -1114,8 +1115,7 @@ def test_position():
                  '\x1b[A\x1b[A']
         if res != exres:
             raise AssertionError(
-                "\nExpected:\n{0}\nGot:\n{1}\n".format(
-                    str(exres), str(res)))
+                "\nExpected:\n{0}\nGot:\n{1}\n".format(str(exres), str(res)))
         t4.close()
         t3.close()
         t1.close()
@@ -1154,8 +1154,7 @@ def test_deprecated_gui():
             # t.close()
             # len(tqdm._instances) += 1  # undo the close() decrement
 
-        t = tqdm(_range(3), gui=True, file=our_file,
-                 miniters=1, mininterval=0)
+        t = tqdm(_range(3), gui=True, file=our_file, miniters=1, mininterval=0)
         try:
             for _ in t:
                 pass
@@ -1218,8 +1217,7 @@ def test_clear():
     with closing(StringIO()) as our_file:
         t1 = tqdm(total=10, file=our_file, desc='pos0 bar',
                   bar_format='{l_bar}')
-        t2 = trange(10, file=our_file, desc='pos1 bar',
-                    bar_format='{l_bar}')
+        t2 = trange(10, file=our_file, desc='pos1 bar', bar_format='{l_bar}')
         before = squash_ctrlchars(our_file.getvalue())
         t2.clear()
         t1.clear()
@@ -1392,9 +1390,8 @@ def test_autodisable_enable():
 def test_deprecation_exception():
     def test_TqdmDeprecationWarning():
         with closing(StringIO()) as our_file:
-            raise (TqdmDeprecationWarning('Test!',
-                                          fp_write=getattr(our_file, 'write',
-                                                           sys.stderr.write)))
+            raise (TqdmDeprecationWarning('Test!', fp_write=getattr(
+                our_file, 'write', sys.stderr.write)))
 
     def test_TqdmDeprecationWarning_nofpwrite():
         raise (TqdmDeprecationWarning('Test!', fp_write=None))
@@ -1443,8 +1440,8 @@ def test_monitoring_thread():
     # Set monitor interval
     tqdm.monitor_interval = maxinterval
     with closing(StringIO()) as our_file:
-        with tqdm(total=total, file=our_file, miniters=500,
-                  mininterval=0.1, maxinterval=maxinterval) as t:
+        with tqdm(total=total, file=our_file, miniters=500, mininterval=0.1,
+                  maxinterval=maxinterval) as t:
             cpu_timify(t, timer)
             # Do a lot of iterations in a small timeframe
             # (smaller than monitor interval)
@@ -1489,11 +1486,11 @@ def test_monitoring_thread():
     TMonitor._time = timer.time
     TMonitor._sleep = sleeper.sleep
     with closing(StringIO()) as our_file:
-        with tqdm(total=total, file=our_file, miniters=500,
-                  mininterval=0.1, maxinterval=maxinterval) as t1:
+        with tqdm(total=total, file=our_file, miniters=500, mininterval=0.1,
+                  maxinterval=maxinterval) as t1:
             # Set high maxinterval for t2 so monitor does not need to adjust it
-            with tqdm(total=total, file=our_file, miniters=500,
-                      mininterval=0.1, maxinterval=1E5) as t2:
+            with tqdm(total=total, file=our_file, miniters=500, mininterval=0.1,
+                      maxinterval=1E5) as t2:
                 cpu_timify(t1, timer)
                 cpu_timify(t2, timer)
                 # Do a lot of iterations in a small timeframe
@@ -1533,8 +1530,8 @@ def test_postfix():
 
     # Test postfix set after init
     with closing(StringIO()) as our_file:
-        with trange(10, file=our_file, desc='pos1 bar',
-                    bar_format='{r_bar}', postfix=None) as t2:
+        with trange(10, file=our_file, desc='pos1 bar', bar_format='{r_bar}',
+                    postfix=None) as t2:
             t2.set_postfix(**postfix)
             t2.refresh()
             out2 = our_file.getvalue()
@@ -1546,8 +1543,8 @@ def test_postfix():
 
     # Test postfix set after init and with ordered dict
     with closing(StringIO()) as our_file:
-        with trange(10, file=our_file, desc='pos2 bar',
-                    bar_format='{r_bar}', postfix=None) as t3:
+        with trange(10, file=our_file, desc='pos2 bar', bar_format='{r_bar}',
+                    postfix=None) as t3:
             t3.set_postfix(postfix_order, **postfix)
             t3.refresh()
             out3 = our_file.getvalue()

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -235,6 +235,8 @@ def test_format_meter():
 
     assert format_meter(0, 1000, 13) == \
         "  0%|          | 0/1000 [00:13<?, ?it/s]"
+    # If not implementing any changes to _tqdm.py, set prefix='desc'
+    # or else ": : " will be in output, so assertion should change
     assert format_meter(0, 1000, 13, ncols=68, prefix='desc: ') == \
         "desc:   0%|                                | 0/1000 [00:13<?, ?it/s]"
     assert format_meter(231, 1000, 392) == \
@@ -1120,18 +1122,18 @@ def test_position():
         t3.close()
         t1.close()
 
-
-@with_setup(pretest, posttest)
-def test_set_description():
-    """Test set description"""
-    with closing(StringIO()) as our_file:
-        with tqdm(desc='Hello', file=our_file) as t:
-            assert t.desc == 'Hello: '
-            t.set_description('World')
-            assert t.desc == 'World: '
-            t.set_description()
-            assert t.desc == ''
-
+# test removed 2017-05-05 MPagel as per lack of
+# set_description function, desc no longer explicitly containing :
+# @with_setup(pretest, posttest)
+# def test_set_description():
+#    """Test set description"""
+#    with closing(StringIO()) as our_file:
+#        with tqdm(desc='Hello', file=our_file) as t:
+#            assert t.desc == 'Hello: '
+#            t.set_description('World')
+#            assert t.desc == 'World: '
+#            t.set_description()
+#            assert t.desc == ''
 
 @with_setup(pretest, posttest)
 def test_deprecated_gui():

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1122,18 +1122,20 @@ def test_position():
         t3.close()
         t1.close()
 
-# test removed 2017-05-05 MPagel as per lack of
-# set_description function, desc no longer explicitly containing :
-# @with_setup(pretest, posttest)
-# def test_set_description():
-#    """Test set description"""
-#    with closing(StringIO()) as our_file:
-#        with tqdm(desc='Hello', file=our_file) as t:
-#            assert t.desc == 'Hello: '
-#            t.set_description('World')
-#            assert t.desc == 'World: '
-#            t.set_description()
-#            assert t.desc == ''
+
+@with_setup(pretest, posttest)
+def test_set_description():
+   """Test set description"""
+   with closing(StringIO()) as our_file:
+       with tqdm(desc='Hello', file=our_file) as t:
+           assert t.desc == 'Hello'
+           t.set_description_str('World')
+           assert t.desc == 'World'
+           t.set_description()
+           assert t.desc == ''
+           t.set_description('Bye')
+           assert t.desc == 'Bye: '
+
 
 @with_setup(pretest, posttest)
 def test_deprecated_gui():
@@ -1553,6 +1555,17 @@ def test_postfix():
 
     out3 = out3[1:-1].split(', ')[3:]
     assert out3 == expected_order
+
+    # Test setting postfix string directly
+    with closing(StringIO()) as our_file:
+        with trange(10, file=our_file, desc='pos2 bar', bar_format='{r_bar}',
+                    postfix=None) as t4:
+            t4.set_postfix_str("Hello")
+            t4.refresh()
+            out4 = our_file.getvalue()
+
+    out4 = out4[1:-1].split(', ')[3:]
+    assert out4 == ["Hello"]
 
 
 class DummyTqdmFile(object):


### PR DESCRIPTION
documents the availability of {postfix} for the bar_format string and distinguishes where postfix is a string vs dict. Also contrasts postfix behavior from desc/prefix behavior a bit more.

Adds set_postfix_direct method which allows for a keyless value to be added.

Augmentation for
#266 & #270 

- [x] add to docstrings
- [x] sync with README
- [x] add set_postfix_str()
- [x] add set_description_str() to address #347 
- [x] unit tests