### PR TITLE
Pandas apply on either axis

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -504,7 +504,10 @@ class tqdm(object):
                 total = getattr(df, 'ngroups', None)
                 if total is None:  # not grouped
                     # apply can be on either axis
-                    total = df.shape[0] if kwargs.get('axis', 0) else df.shape[1]
+                    if kwargs.get('axis', 0) or isinstance(df, Series):
+                        total = df.shape[0]
+                    else:
+                        total = df.shape[1]
                 else:
                     total += 1  # pandas calls update once too many
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -503,8 +503,8 @@ class tqdm(object):
                 # Precompute total iterations
                 total = getattr(df, 'ngroups', None)
                 if total is None:  # not grouped
-                    total = len(df) if isinstance(df, Series) \
-                        else df.size // len(df)
+                    # apply can be on either axis
+                    total = df.shape[0] if kwargs.get('axis', 0) else df.shape[1]
                 else:
                     total += 1  # pandas calls update once too many
 


### PR DESCRIPTION
* This fix allows progress bar for pandas apply on either axis.
* Relevant PR https://github.com/tqdm/tqdm/pull/299 seems to have stalled, and is out of date.

Summary for`tox --skip-missing-interpreters`:
```
SKIPPED:  py32: InterpreterNotFound: python3.2
SKIPPED:  py33: InterpreterNotFound: python3.3
SKIPPED:  py34: InterpreterNotFound: python3.4
  py26: commands succeeded
  py27: commands succeeded
  py35: commands succeeded
  py36: commands succeeded
SKIPPED:  pypy: InterpreterNotFound: pypy
SKIPPED:  pypy3: InterpreterNotFound: pypy3
  pypy3.3-5.2-alpha1: commands succeeded
  flake8: commands succeeded
ERROR:   setup.py: commands failed
  perf: commands succeeded
```
