### PR TITLE
Progress bar not disappering issue in jupyter notebook is solved

### DIFF
--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -143,7 +143,8 @@ class tqdm_notebook(tqdm):
 
             # Special signal to close the bar
             if close and pbar.bar_style != 'danger':  # hide only if no error
-                container.visible = False
+                # container.visible = False
+                container.close()
 
         return print_status
 


### PR DESCRIPTION
Recent update of ipywidget disable the feature for close the progress bar after finished
So I checked ipywidget and found container.visible = False not working anymore.
From new version of ipywidget, it need to be changed as container.close()
Hope this is updated and also can be compatible for old version of ipywidget

In this PR, I only change the code for updated version if ipywidget