### PR TITLE
Minor tidy 2

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -752,9 +752,10 @@ class tqdm(object):
         self.start_t = self.last_print_t
 
     def __len__(self):
-        return (self.iterable.shape[0] if hasattr(self.iterable, 'shape')
-                else len(self.iterable)) if self.iterable is not None \
-            else self.total
+        return self.total if self.iterable is None else \
+                (self.iterable.shape[0] if hasattr(self.iterable, "shape")
+                 else len(self.iterable) if hasattr(self.iterable, "__len__")
+                 else self.total)
 
     def __enter__(self):
         return self
@@ -769,7 +770,9 @@ class tqdm(object):
     def __repr__(self):
         return self.format_meter(self.n, self.total,
                                  self._time() - self.start_t,
-                                 self.ncols, self.desc, self.ascii, self.unit,
+                                 self.dynamic_ncols(self.fp)
+                                 if self.dynamic_ncols else self.ncols,
+                                 self.desc, self.ascii, self.unit,
                                  self.unit_scale, 1 / self.avg_time
                                  if self.avg_time else None, self.bar_format,
                                  self.postfix)
@@ -953,13 +956,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                     self.moveto(self.pos)
 
                 # Print bar's update
-                self.sp(self.format_meter(
-                    self.n, self.total, elapsed,
-                    (self.dynamic_ncols(self.fp) if self.dynamic_ncols
-                     else self.ncols),
-                    self.desc, self.ascii, self.unit, self.unit_scale,
-                    1 / self.avg_time if self.avg_time else None,
-                    self.bar_format, self.postfix))
+                self.sp(self.__repr__())
 
                 if self.pos:
                     self.moveto(-self.pos)

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1018,7 +1018,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                 cur_t = self._time()
                 # stats for overall rate (no weighted average)
                 self.elapsed = cur_t - self.start_t
-                self.sp(self.__repr__)
+                self.sp(self.__repr__())
             if pos:
                 self.moveto(-pos)
             else:

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -767,7 +767,7 @@ class tqdm(object):
     def __repr__(self):
 # self.elapsed replaces self._time() - self.start_t
 # self._time() - self.start_t added to fns prior to __repr__ call where elapsed otherwise undefined.
-      return self.format_meter(self.n, self.total,
+        return self.format_meter(self.n, self.total,
                                  self.elapsed,
                                  self.dynamic_ncols(self.fp)
                                  if self.dynamic_ncols else self.ncols,

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -861,7 +861,7 @@ class tqdm(object):
             with self._lock:
                 if self.pos:
                     self.moveto(self.pos)
-                self.sp(self.format_meter(self.__repr__()) # elapsed already set to 0 & total already stored in self
+                self.sp(self.format_meter(self.__repr__())) # elapsed already set to 0 & total already stored in self
                 if self.pos:
                     self.moveto(-self.pos)
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -861,7 +861,7 @@ class tqdm(object):
             with self._lock:
                 if self.pos:
                     self.moveto(self.pos)
-                self.sp(self.format_meter(self.__repr__())) # elapsed already set to 0 & total already stored in self
+                self.sp(self.__repr__()) # elapsed already set to 0 & total already stored in self
                 if self.pos:
                     self.moveto(-self.pos)
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -766,7 +766,7 @@ class tqdm(object):
 
     def __repr__(self):
 # self.elapsed replaces self._time() - self.start_t
-# self._time() - self.start_t added to fns prior to __repr__ call where elapsed otherwise undefined.      
+# self._time() - self.start_t added to fns prior to __repr__ call where elapsed otherwise undefined.
       return self.format_meter(self.n, self.total,
                                  self.elapsed,
                                  self.dynamic_ncols(self.fp)

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -5,7 +5,7 @@ CUR_OS = _curos()
 IS_WIN = CUR_OS in ['Windows', 'cli']
 IS_NIX = (not IS_WIN) and any(
     CUR_OS.startswith(i) for i in
-    ['CYGWIN', 'MSYS', 'Linux', 'Darwin', 'SunOS', 'FreeBSD'])
+    ['CYGWIN', 'MSYS', 'Linux', 'Darwin', 'SunOS', 'FreeBSD', 'NetBSD'])
 
 
 # Py2/3 compat. Empty conditional to avoid coverage

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -927,7 +927,7 @@ def test_smoothing():
         # Get result for manually updated bar
         c2 = progressbar_rate(get_bar(our_file2.getvalue(), 3))
 
-    # Check that medium smoothing's rate is between no and max smoothing rates (inclusive)  
+    # Check that medium smoothing's rate is between no and max smoothing rates (inclusive)
     assert a <= c <= b
     assert a2 <= c2 <= b2
 

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -927,9 +927,9 @@ def test_smoothing():
         # Get result for manually updated bar
         c2 = progressbar_rate(get_bar(our_file2.getvalue(), 3))
 
-    # Check that medium smoothing's rate is between no and max smoothing rates
-    assert a < c < b
-    assert a2 < c2 < b2
+    # Check that medium smoothing's rate is between no and max smoothing rates (inclusive)  
+    assert a <= c <= b
+    assert a2 <= c2 <= b2
 
 
 @with_setup(pretest, posttest)


### PR DESCRIPTION
remove misc calls to `format_meter`
replace with calls to `__repr__` - this will allow for greater future flexibility

Follow-up to e18f20497b4253e21174d4114b22559db3f612ec