### PR TITLE
always flush after moving the cursor to a different line

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1215,6 +1215,8 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
 
     def moveto(self, n):
         self.fp.write(_unicode('\n' * n + _term_move_up() * -n))
+        if n:
+            self.fp.flush()
 
     def clear(self, nolock=False):
         """

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1215,8 +1215,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
 
     def moveto(self, n):
         self.fp.write(_unicode('\n' * n + _term_move_up() * -n))
-        if n:
-            self.fp.flush()
+        self.fp.flush()
 
     def clear(self, nolock=False):
         """


### PR DESCRIPTION
This fixes the issue I'm having in #398, by making sure that moveto always flushes the control codes it might write to the terminal in order to move the cursor up one or more lines.

Unfortunately I have no idea of how to write a test case for this. The existing test cases still work, though.