### PR TITLE
Fix print_status when using widechars in desc

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 from __future__ import division
 # compatibility functions and utilities
 from .utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
-    _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
+    _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, _text_width, \
     Comparable, RE_ANSI, _is_ascii, SimpleTextIOWrapper, FormatReplace
 from ._monitor import TMonitor
 # native libraries
@@ -300,7 +300,7 @@ class tqdm(Comparable):
         last_len = [0]
 
         def print_status(s):
-            len_s = len(s)
+            len_s = _text_width(s)
             fp_write('\r' + s + (' ' * max(last_len[0] - len_s, 0)))
             last_len[0] = len_s
 
@@ -474,7 +474,7 @@ class tqdm(Comparable):
             # Formatting progress bar space available for bar's display
             full_bar = Bar(
                 frac,
-                max(1, ncols - len(RE_ANSI.sub('', nobar))) if ncols else 10,
+                max(1, ncols - _text_width(RE_ANSI.sub('', nobar))) if ncols else 10,
                 charset=Bar.ASCII if ascii is True else ascii or Bar.UTF)
             if not _is_ascii(full_bar.charset) and _is_ascii(bar_format):
                 bar_format = _unicode(bar_format)

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -293,6 +293,6 @@ def _text_width(s):  # pragma: no cover
     else:
         try:
             return len(s) + sum(east_asian_width(ch) in 'FW' for ch in s)
-        except UnicodeDecodeError:  # Py2
+        except TypeError:  # Py2
             s = s.decode('utf-8')
             return len(s) + sum(east_asian_width(ch) in 'FW' for ch in s)

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -283,3 +283,16 @@ def _environ_cols_linux(fp):  # pragma: no cover
 
 def _term_move_up():  # pragma: no cover
     return '' if (os.name == 'nt') and (colorama is None) else '\x1b[A'
+
+
+def _text_width(s):  # pragma: no cover
+    try:
+        from unicodedata import east_asian_width
+    except ImportError:
+        return len(s)
+    else:
+        try:
+            return len(s) + sum(east_asian_width(ch) in 'FW' for ch in s)
+        except UnicodeDecodeError:  # Py2
+            s = s.decode('utf-8')
+            return len(s) + sum(east_asian_width(ch) in 'FW' for ch in s)


### PR DESCRIPTION
I found that passing widechars into `set_description()` would cause the width of description field miscalculated, and break the progress bar.

These are the screen records of [before] and [after] this fix.

  [before]: https://photos.app.goo.gl/0JimrcKJklZOSka32
  [after]: https://photos.app.goo.gl/2op5CiNpISBk5FHc2