### PR TITLE
flush on refresh

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,8 @@
 - [ ] I have visited the [source website], and in particular
   read the [known issues]
 - [ ] I have searched through the [issue tracker] for duplicates
+- [ ] I have mentioned version numbers, operating system and
+  environment, where applicable
 
   [source website]: https://github.com/tqdm/tqdm/
   [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
 - [ ] I have visited the [source website], and in particular
   read the [known issues]
 - [ ] I have searched through the [issue tracker] for duplicates
-- [ ] If applicable, I have mentioned the relevant/related issue(s) in this PR
+- [ ] I have mentioned version numbers, operating system and
+  environment, where applicable
+- [ ] If applicable, I have mentioned the relevant/related issue(s)
 
   [source website]: https://github.com/tqdm/tqdm/
   [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ all:
 	@+make build
 
 flake8:
-	@+flake8 --max-line-length=80 --count --statistics --exit-zero -j 8 --exclude .asv .
+	@+flake8 --max-line-length=80 --count --statistics --exit-zero -j 8 --exclude .asv,.tox .
 
 test:
 	tox --skip-missing-interpreters

--- a/README.rst
+++ b/README.rst
@@ -327,10 +327,10 @@ Parameters
     [default: '{l_bar}{bar}{r_bar}'], where
     l_bar='{desc}: {percentage:3.0f}%|' and
     r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, '
-          '{rate_fmt}{postfix}]'
+    '{rate_fmt}{postfix}]'
     Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt,
-        percentage, rate, rate_fmt, rate_noinv, rate_noinv_fmt,
-        rate_inv, rate_inv_fmt, elapsed, remaining, desc, postfix.
+    percentage, rate, rate_fmt, rate_noinv, rate_noinv_fmt,
+    rate_inv, rate_inv_fmt, elapsed, remaining, desc, postfix.
     Note that a trailing ": " is automatically removed after {desc}
     if the latter is empty.
 * initial  : int, optional  
@@ -732,25 +732,25 @@ Monitoring thread, intervals and miniters
 
 ``tqdm`` implements a few tricks to to increase efficiency and reduce overhead.
 
-1. Avoid unnecessary frequent bar refreshing: ``mininterval`` defines how long
-   to wait between each refresh. ``tqdm`` always gets updated in the background,
-   but it will diplay only every ``mininterval``.
-2. Reduce number of calls to check system clock/time.
-3. ``mininterval`` is more intuitive to configure than ``miniters``.
-   A clever adjustment system ``dynamic_miniters`` will automatically adjust
-   ``miniters`` to the amount of iterations that fit into time ``mininterval``.
-   Essentially, ``tqdm`` will check if it's time to print without actually
-   checking time. This behavior can be still be bypassed by manually setting
-   ``miniters``.
+- Avoid unnecessary frequent bar refreshing: ``mininterval`` defines how long
+  to wait between each refresh. ``tqdm`` always gets updated in the background,
+  but it will diplay only every ``mininterval``.
+- Reduce number of calls to check system clock/time.
+- ``mininterval`` is more intuitive to configure than ``miniters``.
+  A clever adjustment system ``dynamic_miniters`` will automatically adjust
+  ``miniters`` to the amount of iterations that fit into time ``mininterval``.
+  Essentially, ``tqdm`` will check if it's time to print without actually
+  checking time. This behavior can be still be bypassed by manually setting
+  ``miniters``.
 
 However, consider a case with a combination of fast and slow iterations.
 After a few fast iterations, ``dynamic_miniters`` will set ``miniters`` to a
 large number. When interation rate subsequently slows, ``miniters`` will
 remain large and thus reduce display update frequency. To address this:
 
-4. ``maxinterval`` defines the maximum time between display refreshes.
-   A concurrent monitoring thread checks for overdue updates and forces one
-   where necessary.
+- ``maxinterval`` defines the maximum time between display refreshes.
+  A concurrent monitoring thread checks for overdue updates and forces one
+  where necessary.
 
 The monitoring thread should not have a noticeable overhead, and guarantees
 updates at least every 10 seconds by default.

--- a/examples/redirect_print.py
+++ b/examples/redirect_print.py
@@ -57,8 +57,9 @@ with std_out_err_redirect_tqdm() as orig_stdout:
     # tqdm needs the original stdout
     # and dynamic_ncols=True to autodetect console width
     for i in tqdm(range(3), file=orig_stdout, dynamic_ncols=True):
-        sleep(.5)
+        # order of the following two lines should not matter
         some_fun(i)
+        sleep(.5)
 
 # After the `with`, printing is restored
 print("Done!")

--- a/setup.py
+++ b/setup.py
@@ -175,8 +175,8 @@ setup(
     platforms=['any'],
     packages=['tqdm'],
     entry_points={'console_scripts': ['tqdm=tqdm._main:main'], },
-    data_files = [('man/man1', ['tqdm.1'])],
-    package_data = {'': ['CONTRIBUTING.md', 'LICENCE', 'examples/*.py']},
+    data_files=[('man/man1', ['tqdm.1'])],
+    package_data={'': ['CONTRIBUTING.md', 'LICENCE', 'examples/*.py']},
     long_description=README_rst,
     classifiers=[
         # Trove classifiers

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1222,9 +1222,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         if not nolock:
             self._lock.acquire()
         self.moveto(self.pos)
-        # clear up the bar (can't rely on sp(''))
-        self.fp.write('\r')
-        self.fp.write(' ' * (self.ncols if self.ncols else 10))
+        self.sp('')
         self.fp.write('\r')  # place cursor back at the beginning of line
         self.moveto(-self.pos)
         if not nolock:

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -283,10 +283,10 @@ class tqdm(object):
             [default: '{l_bar}{bar}{r_bar}'], where
             l_bar='{desc}: {percentage:3.0f}%|' and
             r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, '
-                  '{rate_fmt}{postfix}]'
+              '{rate_fmt}{postfix}]'
             Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt,
-                percentage, rate, rate_fmt, rate_noinv, rate_noinv_fmt,
-                rate_inv, rate_inv_fmt, elapsed, remaining, desc, postfix.
+              percentage, rate, rate_fmt, rate_noinv, rate_noinv_fmt,
+              rate_inv, rate_inv_fmt, elapsed, remaining, desc, postfix.
             Note that a trailing ": " is automatically removed after {desc}
             if the latter is empty.
         postfix  : str, optional

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1212,7 +1212,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
     def moveto(self, n):
         self.fp.write(_unicode('\n' * n + _term_move_up() * -n))
 
-    def clear(self, nomove=False, nolock=False):
+    def clear(self, nolock=False):
         """
         Clear current bar display
         """
@@ -1221,14 +1221,12 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
 
         if not nolock:
             self._lock.acquire()
-        if not nomove:
-            self.moveto(self.pos)
+        self.moveto(self.pos)
         # clear up the bar (can't rely on sp(''))
         self.fp.write('\r')
         self.fp.write(' ' * (self.ncols if self.ncols else 10))
         self.fp.write('\r')  # place cursor back at the beginning of line
-        if not nomove:
-            self.moveto(-self.pos)
+        self.moveto(-self.pos)
         if not nolock:
             self._lock.release()
 
@@ -1242,14 +1240,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         if not nolock:
             self._lock.acquire()
         self.moveto(self.pos)
-
-        # clear up this line's content (whatever there was)
-        self.clear(nomove=True, nolock=True)
-        # Print current/last bar state
-        self.fp.write(_unicode(self.__repr__()))
-        getattr(self.fp, "flush", lambda: None)()
-        # TODO: possibly replace above block with self.sp(self.__repr__())
-
+        self.sp(self.__repr__())
         self.moveto(-self.pos)
         if not nolock:
             self._lock.release()

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1242,10 +1242,14 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
         if not nolock:
             self._lock.acquire()
         self.moveto(self.pos)
+
         # clear up this line's content (whatever there was)
         self.clear(nomove=True, nolock=True)
         # Print current/last bar state
-        self.fp.write(self.__repr__())
+        self.fp.write(_unicode(self.__repr__()))
+        getattr(self.fp, "flush", lambda: None)()
+        # TODO: possibly replace above block with self.sp(self.__repr__())
+
         self.moveto(-self.pos)
         if not nolock:
             self._lock.release()

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1362,8 +1362,7 @@ def test_write():
             assert after_err_res == [u'\rpos0 bar:   0%',
                                      u'\rpos0 bar:  10%',
                                      u'\r      ',
-                                     u'\r\r      ',
-                                     u'\rpos0 bar:  10%']
+                                     u'\r\rpos0 bar:  10%']
             assert after_out == s + '\n'
     # Restore stdout and stderr
     sys.stderr = stde


### PR DESCRIPTION
- [x] flush on `refresh()`
    + fixes #459
    + fixes #348
    + fixes #387
    + fixes #398
    + fixes (maybe) #420
    + makes order of the two lines in the loop in https://github.com/tqdm/tqdm/commit/ab1bd789f143b79da7b7c18ba942269afcd7df7d unimportant
    + bug introduced in #317
    + precursor to #399
- [x] note to mention version/env in issue/PRs
- [x] fix pypi ReST
    + indentation error (fixed in `v4.19.1.post1` on pypi)
    + enumeration warning
- [x] maybe add `sp()` call on relevant line
    + fixes #331 (from #327). see note below
    + maybe related to #336
- [x] add/fix/(re)check unit tests

Note on #331, regarding https://github.com/tqdm/tqdm/pull/331#issuecomment-272310356, `sp()` can only be used for bar printing/clearing as it keeps track of the last message length. It can't be used in for e.g. `tqdm.write()` as that would set a wrong last message length. Note that `sp()` is still unaware that the last message length may refer to a different nested progress bar, but that can be addressed in another PR (and is also an extremely small edge case, where a terminal has been resized after the update of one nested bar and before the update of another).