### PR TITLE
Clarify pandas and tqdm_notebook notation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -602,7 +602,7 @@ for ``DataFrame.progress_apply`` and ``DataFrameGroupBy.progress_apply``:
     df = pd.DataFrame(np.random.randint(0, 100, (100000, 6)))
 
     # Register `pandas.progress_apply` and `pandas.Series.map_apply` with `tqdm`
-    # (can use `tqdm_gui`, `tqdm_notebook`, optional kwargs, etc.)
+    # (can use `tqdm_gui().pandas()`, `tqdm_notebook().pandas()`, optional kwargs, etc.)
     tqdm.pandas(desc="my bar!")
 
     # Now you can use `progress_apply` instead of `apply`

--- a/examples/pandas_progress_apply.py
+++ b/examples/pandas_progress_apply.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 df = pd.DataFrame(np.random.randint(0, 100, (100000, 6)))
 
 # Register `pandas.progress_apply` and `pandas.Series.map_apply` with `tqdm`
-# (can use `tqdm_gui`, `tqdm_notebook`, optional kwargs, etc.)
+# (can use `tqdm_gui().pandas()`, `tqdm_notebook().pandas()`, optional kwargs, etc.)
 tqdm.pandas(desc="my bar!")
 
 # Now you can use `progress_apply` instead of `apply`


### PR DESCRIPTION
In response to #473, I propose clarifying the documentation.
It is not:
`tqdm.pandas(tqdm_notebook)`, 
but 
`tqdm_notebook().pandas()`.