### PR TITLE
Correct prefix for 'kilo' is 'k', not 'K'

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -189,7 +189,7 @@ class tqdm(object):
         out  : str
             Number with Order of Magnitude SI unit postfix.
         """
-        for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
+        for unit in ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z']:
             if abs(num) < 999.95:
                 if abs(num) < 99.95:
                     if abs(num) < 9.995:
@@ -276,7 +276,7 @@ class tqdm(object):
             The iteration unit [default: 'it'].
         unit_scale  : bool or int or float, optional
             If 1 or True, the number of iterations will be printed with an
-            appropriate SI metric prefix (K = 10^3, M = 10^6, etc.)
+            appropriate SI metric prefix (k = 10^3, M = 10^6, etc.)
             [default: False]. If any other non-zero number, will scale
             `total` and `n`.
         rate  : float, optional

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -248,7 +248,7 @@ def test_format_meter():
         " 23%|" + '#' * 3 + '6' + \
         "            | 231/1000 [06:32<21:44,  1.70s/it]"
     assert format_meter(100000, 1000, 13, unit_scale=True, unit='iB') == \
-        "100KiB [00:13, 7.69KiB/s]"
+        "100kiB [00:13, 7.69kiB/s]"
     assert format_meter(100, 1000, 12, ncols=0, rate=7.33) == \
         " 10% 100/1000 [00:12<02:02,  7.33it/s]"
     # Check that bar_format correctly adapts {bar} size to the rest
@@ -277,10 +277,10 @@ def test_si_format():
     assert '9.00 ' in format_meter(1, 9, 1, unit_scale=True, unit='B')
     assert '99.0 ' in format_meter(1, 99, 1, unit_scale=True)
     assert '999 ' in format_meter(1, 999, 1, unit_scale=True)
-    assert '9.99K ' in format_meter(1, 9994, 1, unit_scale=True)
-    assert '10.0K ' in format_meter(1, 9999, 1, unit_scale=True)
-    assert '99.5K ' in format_meter(1, 99499, 1, unit_scale=True)
-    assert '100K ' in format_meter(1, 99999, 1, unit_scale=True)
+    assert '9.99k ' in format_meter(1, 9994, 1, unit_scale=True)
+    assert '10.0k ' in format_meter(1, 9999, 1, unit_scale=True)
+    assert '99.5k ' in format_meter(1, 99499, 1, unit_scale=True)
+    assert '100k ' in format_meter(1, 99999, 1, unit_scale=True)
     assert '1.00M ' in format_meter(1, 999999, 1, unit_scale=True)
     assert '1.00G ' in format_meter(1, 999999999, 1, unit_scale=True)
     assert '1.00T ' in format_meter(1, 999999999999, 1, unit_scale=True)


### PR DESCRIPTION
Correct prefix for 'kilo' is 'k', not 'K'.

Sources:

* https://physics.nist.gov/cuu/Units/prefixes.html
* https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes
* http://www.npl.co.uk/reference/measurement-units/si-prefixes/
* ...