### PR TITLE
Avoid manipulating uninitialized instances on monitoring thread.

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -142,6 +142,9 @@ class TMonitor(Thread):
                 cur_t = self._time()
                 # Check tqdm instances are waiting too long to print
                 for instance in self.tqdm_cls._instances:
+                    # Avoid race by checking that the instance started
+                    if not hasattr(instance, 'start_t'):  # pragma: nocover
+                        continue
                     # Only if mininterval > 1 (else iterations are just slow)
                     # and last refresh exceeded maxinterval
                     if instance.miniters > 1 and \


### PR DESCRIPTION
This change addresses the race that causes #404 and also mentioned in #323, which is a race that happens with some regularity (but intermittently).  The problem is that the monitoring thread is manipulating instances that have been inserted into `cls._instances` (at the end of `__new__`) before they have finished their `__init__`.

This change doesn't change when instances are added to `_instances` (which might be another change to consider).  This change verifies that any retrieved instances have been initialized before manipulating them in the monitoring thread.

The bug is difficult to reproduce, but this fix seems to prevent the bug from occurring for me. 

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
