### PR TITLE
Fixed an error when running the code in Nested progress bar in the Examples and Advanced Usage section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -519,7 +519,7 @@ you may specify ``position=n`` where ``n=0`` for the outermost bar,
 .. code:: python
 
     from time import sleep
-    from tqdm import trange
+    from tqdm import trange, tqdm
     from multiprocessing import Pool, freeze_support, RLock
 
     L = list(range(9))


### PR DESCRIPTION
https://github.com/tqdm/tqdm/#nested-progress-bars: In the second example, it gives "NameError: name 'tqdm' is not defined" when run as tqdm was not imported. This commit fixes the error