### PR TITLE
Fix for aarch64 Android which lacks a functioning sem_open implementation

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -51,7 +51,10 @@ class TqdmDeprecationWarning(Exception):
 # Create global parallelism locks to avoid racing issues with parallel bars
 # works only if fork available (Linux, MacOSX, but not on Windows)
 try:
-    mp_lock = mp.RLock()  # multiprocessing lock
+    try:
+        mp_lock = mp.RLock()  # multiprocessing lock
+    except ImportError:
+        mp_lock = None
     th_lock = th.RLock()  # thread lock
 except OSError:  # pragma: no cover
     mp_lock = None


### PR DESCRIPTION
The tqdm module fails on aarch64 Android because parts of the multiprocessing module aren't available.
```
Traceback (most recent call last):
  File "/data/data/com.termux/files/usr/lib/python3.6/multiprocessing/synchronize.py", line 29, in <module>
    from _multiprocessing import SemLock, sem_unlink
ImportError: cannot import name 'SemLock'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./progress.py", line 3, in <module>
    from tqdm import tqdm
  File "/data/data/com.termux/files/usr/lib/python3.6/site-packages/tqdm/__init__.py", line 1, in <module>
    from ._tqdm import tqdm
  File "/data/data/com.termux/files/usr/lib/python3.6/site-packages/tqdm/_tqdm.py", line 54, in <module>
    mp_lock = mp.RLock()  # multiprocessing lock
  File "/data/data/com.termux/files/usr/lib/python3.6/multiprocessing/context.py", line 71, in RLock
    from .synchronize import RLock
  File "/data/data/com.termux/files/usr/lib/python3.6/multiprocessing/synchronize.py", line 34, in <module>
    " function, see issue 3770.")
ImportError: This platform lacks a functioning sem_open implementation, therefore, the required synchronization primitives needed will not function, see issue 3770.

```