### PR TITLE
fix the problem #299 in terms of using tqdm in pandas

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,11 +222,20 @@ of a neat one-line progress bar.
       `IDLE <https://github.com/tqdm/tqdm/issues/191#issuecomment-230168030>`__,
       `ConEmu <https://github.com/tqdm/tqdm/issues/254>`__ and
       `PyCharm <https://github.com/tqdm/tqdm/issues/203>`__ (also
-      `here <https://github.com/tqdm/tqdm/issues/208>`__ and
-      `here <https://github.com/tqdm/tqdm/issues/307>`__)
+      `here <https://github.com/tqdm/tqdm/issues/208>`__,
+      `here <https://github.com/tqdm/tqdm/issues/307>`__, and
+      `here <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__)
       lack full support.
     * Windows: additionally may require the Python module ``colorama``
       to ensure nested bars stay within their respective lines.
+- Unicode:
+    * Environments which report that they support unicode will have solid smooth
+      progressbars. The fallback is an `ascii`-only bar.
+    * Windows consoles often only partially support unicode and thus
+      `often require explicit ascii=True <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__
+      (also `here <https://github.com/tqdm/tqdm/issues/499>`__). This is due to
+      either normal-width unicode characters being incorrectly displayed as
+      "wide", or some unicode characters not rendering.
 - Wrapping enumerated iterables: use ``enumerate(tqdm(...))`` instead of
   ``tqdm(enumerate(...))``. The same applies to ``numpy.ndenumerate``.
   This is because enumerate functions tend to hide the length of iterables.

--- a/tqdm/__init__.py
+++ b/tqdm/__init__.py
@@ -4,7 +4,7 @@ from ._tqdm_gui import tqdm_gui
 from ._tqdm_gui import tgrange
 from ._tqdm_pandas import tqdm_pandas
 from ._main import main
-from ._monitor import TMonitor
+from ._monitor import TMonitor, TqdmSynchronisationWarning
 from ._version import __version__  # NOQA
 from ._tqdm import TqdmTypeError, TqdmKeyError, TqdmDeprecationWarning, \
     TqdmMonitorWarning
@@ -12,7 +12,7 @@ from ._tqdm import TqdmTypeError, TqdmKeyError, TqdmDeprecationWarning, \
 __all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_pandas',
            'tqdm_notebook', 'tnrange', 'main', 'TMonitor',
            'TqdmTypeError', 'TqdmKeyError', 'TqdmDeprecationWarning',
-           'TqdmMonitorWarning',
+           'TqdmMonitorWarning', 'TqdmSynchronisationWarning',
            '__version__']
 
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -567,11 +567,10 @@ class tqdm(object):
 Except func, normal arguments are intentionally \
 not supported by (DataFrame|Series|GroupBy).progress_apply. \
 Use keyword arguments instead.""", fp_write=getattr(t.fp, 'write', sys.stderr.write))
-                
                 # Define bar updating wrapper
                 def wrapper(*args, **kwargs):
                     # update tbar correctly
-                    # it seems pandas apply calls func twice on the first column/row 
+                    # it seems pandas apply calls func twice on the first column/row
                     # to decide whether it can take a fast or slow code path.
                     # so stop when t.total==t.n
                     t.update(n=1 if t.total and t.n < t.total else 0)

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -550,9 +550,10 @@ class tqdm(object):
                         total = df.size
                     elif isinstance(df, Series):
                         total = len(df)
-                    else: #DataFrame or Panel
+                    else:  # DataFrame or Panel
                         axis = kwargs.get('axis', 0)
-                        total = df.size // df.shape[axis] # when axis=0, total is shape[axis1]
+                        # when axis=0, total is shape[axis1]
+                        total = df.size // df.shape[axis]
 
                 # Init bar
                 if deprecated_t[0] is not None:
@@ -563,16 +564,19 @@ class tqdm(object):
 
                 if len(args) > 0:
                     # *args intentionally not supported (see #244, #299)
-                    TqdmDeprecationWarning("""\
-Except func, normal arguments are intentionally \
-not supported by (DataFrame|Series|GroupBy).progress_apply. \
-Use keyword arguments instead.""", fp_write=getattr(t.fp, 'write', sys.stderr.write))
+                    TqdmDeprecationWarning(
+                        "Except func, normal arguments are intentionally" +
+                        " not supported by" +
+                        " `(DataFrame|Series|GroupBy).progress_apply`." +
+                        " Use keyword arguments instead.",
+                        fp_write=getattr(t.fp, 'write', sys.stderr.write))
+
                 # Define bar updating wrapper
                 def wrapper(*args, **kwargs):
                     # update tbar correctly
-                    # it seems pandas apply calls func twice on the first column/row
-                    # to decide whether it can take a fast or slow code path.
-                    # so stop when t.total==t.n
+                    # it seems `pandas apply` calls `func` twice
+                    # on the first column/row to decide whether it can
+                    # take a fast or slow code path; so stop when t.total==t.n
                     t.update(n=1 if t.total and t.n < t.total else 0)
                     return func(*args, **kwargs)
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -540,8 +540,10 @@ class tqdm(object):
                 func  : function
                     To be applied on the (grouped) data.
                 **kwargs  : optional
-                    Transmitted to `df.apply()`. *args not intentionally supported.
+                    Transmitted to `df.apply()`.
                 """
+                # *args intentionally not supported (see #244, #299)
+
                 # Precompute total iterations
                 total = getattr(df, 'ngroups', None)
                 if total is None:  # not grouped

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -531,7 +531,7 @@ class tqdm(object):
         deprecated_t = [tkwargs.pop('deprecated_t', None)]
 
         def inner_generator(df_function='apply'):
-            def inner(df, func, *args, **kwargs):
+            def inner(df, func, **kwargs):
                 """
                 Parameters
                 ----------
@@ -539,8 +539,8 @@ class tqdm(object):
                     Data (may be grouped).
                 func  : function
                     To be applied on the (grouped) data.
-                *args, *kwargs  : optional
-                    Transmitted to `df.apply()`.
+                **kwargs  : optional
+                    Transmitted to `df.apply()`. *args not intentionally supported.
                 """
                 # Precompute total iterations
                 total = getattr(df, 'ngroups', None)
@@ -567,9 +567,9 @@ class tqdm(object):
                     t.update()
                     return func(*args, **kwargs)
 
-                # Apply the provided function (in *args and **kwargs)
+                # Apply the provided function (in **kwargs)
                 # on the df using our wrapper (which provides bar updating)
-                result = getattr(df, df_function)(wrapper, *args, **kwargs)
+                result = getattr(df, df_function)(wrapper, **kwargs)
 
                 # Close bar and return pandas calculation result
                 t.close()

--- a/tqdm/tests/tests_pandas.py
+++ b/tqdm/tests/tests_pandas.py
@@ -5,6 +5,77 @@ from tests_tqdm import with_setup, pretest, posttest, StringIO, closing
 
 
 @with_setup(pretest, posttest)
+def test_pandas_series():
+    """Test pandas.Series.progress_apply and .progress_map"""
+    try:
+        from numpy.random import randint
+        import pandas as pd
+    except:
+        raise SkipTest
+
+    with closing(StringIO()) as our_file:
+        tqdm.pandas(file=our_file, leave=True, ascii=True)
+
+        series = pd.Series(randint(0, 50, (123,)))
+        res1 = series.progress_apply(lambda x: x + 10)
+        res2 = series.apply(lambda x: x + 10)
+        assert res1.equals(res2)
+
+        res3 = series.progress_map(lambda x: x + 10)
+        res4 = series.map(lambda x: x + 10)
+        assert res3.equals(res4)
+
+        expects = ['100%', '123/123']
+        for exres in expects:
+            our_file.seek(0)
+            if our_file.getvalue().count(exres) < 2:
+                our_file.seek(0)
+                raise AssertionError(
+                    "\nExpected:\n{0}\nIn:\n{1}\n".format(exres + " at least twice.", our_file.read()))
+
+
+@with_setup(pretest, posttest)
+def test_pandas_data_frame():
+    """Test pandas.DataFrame.progress_apply and .progress_applymap"""
+    try:
+        from numpy.random import randint
+        import pandas as pd
+    except:
+        raise SkipTest
+
+    with closing(StringIO()) as our_file:
+        tqdm.pandas(file=our_file, leave=True, ascii=True)
+        df = pd.DataFrame(randint(0, 50, (100, 200)))
+
+        def task_func(x): return x + 1
+        # applymap
+        res1 = df.progress_applymap(task_func)
+        res2 = df.applymap(task_func)
+        assert res1.equals(res2)
+
+        # apply
+        for axis in [0,1]:
+            res3 = df.progress_apply(task_func, axis=axis)
+            res4 = df.apply(task_func, axis=axis)
+            assert res3.equals(res4)
+
+        our_file.seek(0)
+        if our_file.read().count('100%') < 3:
+            our_file.seek(0)
+            raise AssertionError("\nExpected:\n{0}\nIn:\n{1}\n".format(
+                '100% at least three times', our_file.read()))
+
+        # apply_map, apply axis=0, apply axis=1
+        expects = ['20000/20000', '200/200', '100/100']
+        for exres in expects:
+            our_file.seek(0)
+            if our_file.getvalue().count(exres) < 0:
+                our_file.seek(0)
+                raise AssertionError(
+                    "\nExpected:\n{0}\nIn:\n {1}\n".format(exres+" at least once.", our_file.read()))
+
+
+@with_setup(pretest, posttest)
 def test_pandas_groupby_apply():
     """Test pandas.DataFrame.groupby(...).progress_apply"""
     try:
@@ -32,51 +103,6 @@ def test_pandas_groupby_apply():
             raise AssertionError("\nDid not expect:\n{0}\nIn:{1}\n".format(
                 nexres, our_file.read()))
 
-
-@with_setup(pretest, posttest)
-def test_pandas_apply():
-    """Test pandas.DataFrame[.series].progress_apply"""
-    try:
-        from numpy.random import randint
-        import pandas as pd
-    except:
-        raise SkipTest
-
-    with closing(StringIO()) as our_file:
-        tqdm.pandas(file=our_file, leave=True, ascii=True)
-        df = pd.DataFrame(randint(0, 50, (500, 3)))
-        df.progress_apply(lambda x: None)
-
-        dfs = pd.DataFrame(randint(0, 50, (500, 3)), columns=list('abc'))
-        dfs.a.progress_apply(lambda x: None)
-
-        our_file.seek(0)
-
-        if our_file.read().count('100%') < 2:
-            our_file.seek(0)
-            raise AssertionError("\nExpected:\n{0}\nIn:{1}\n".format(
-                '100% at least twice', our_file.read()))
-
-
-@with_setup(pretest, posttest)
-def test_pandas_map():
-    """Test pandas.Series.progress_map"""
-    try:
-        from numpy.random import randint
-        import pandas as pd
-    except:
-        raise SkipTest
-
-    with closing(StringIO()) as our_file:
-        tqdm.pandas(file=our_file, leave=True, ascii=True)
-        dfs = pd.DataFrame(randint(0, 50, (500, 3)), columns=list('abc'))
-        dfs.a.progress_map(lambda x: None)
-
-        if our_file.getvalue().count('100%') < 1:
-            raise AssertionError("\nExpected:\n{0}\nIn:{1}\n".format(
-                '100% at least twice', our_file.getvalue()))
-
-
 @with_setup(pretest, posttest)
 def test_pandas_leave():
     """Test pandas with `leave=True`"""
@@ -93,7 +119,7 @@ def test_pandas_leave():
 
         our_file.seek(0)
 
-        exres = '100%|##########| 101/101'
+        exres = '100%|##########| 100/100'
         if exres not in our_file.read():
             our_file.seek(0)
             raise AssertionError(

--- a/tqdm/tests/tests_pandas.py
+++ b/tqdm/tests/tests_pandas.py
@@ -10,7 +10,7 @@ def test_pandas_series():
     try:
         from numpy.random import randint
         import pandas as pd
-    except:
+    except ImportError:
         raise SkipTest
 
     with closing(StringIO()) as our_file:
@@ -31,7 +31,8 @@ def test_pandas_series():
             if our_file.getvalue().count(exres) < 2:
                 our_file.seek(0)
                 raise AssertionError(
-                    "\nExpected:\n{0}\nIn:\n{1}\n".format(exres + " at least twice.", our_file.read()))
+                    "\nExpected:\n{0}\nIn:\n{1}\n".format(
+                        exres + " at least twice.", our_file.read()))
 
 
 @with_setup(pretest, posttest)
@@ -40,21 +41,23 @@ def test_pandas_data_frame():
     try:
         from numpy.random import randint
         import pandas as pd
-    except:
+    except ImportError:
         raise SkipTest
 
     with closing(StringIO()) as our_file:
         tqdm.pandas(file=our_file, leave=True, ascii=True)
         df = pd.DataFrame(randint(0, 50, (100, 200)))
 
-        def task_func(x): return x + 1
+        def task_func(x):
+            return x + 1
+
         # applymap
         res1 = df.progress_applymap(task_func)
         res2 = df.applymap(task_func)
         assert res1.equals(res2)
 
         # apply
-        for axis in [0,1]:
+        for axis in [0, 1]:
             res3 = df.progress_apply(task_func, axis=axis)
             res4 = df.apply(task_func, axis=axis)
             assert res3.equals(res4)
@@ -72,7 +75,8 @@ def test_pandas_data_frame():
             if our_file.getvalue().count(exres) < 1:
                 our_file.seek(0)
                 raise AssertionError(
-                    "\nExpected:\n{0}\nIn:\n {1}\n".format(exres+" at least once.", our_file.read()))
+                    "\nExpected:\n{0}\nIn:\n {1}\n".format(
+                        exres + " at least once.", our_file.read()))
 
 
 @with_setup(pretest, posttest)
@@ -81,7 +85,7 @@ def test_pandas_groupby_apply():
     try:
         from numpy.random import randint
         import pandas as pd
-    except:
+    except ImportError:
         raise SkipTest
 
     with closing(StringIO()) as our_file:
@@ -105,29 +109,30 @@ def test_pandas_groupby_apply():
 
     with closing(StringIO()) as our_file:
         tqdm.pandas(file=our_file, leave=True, ascii=True)
-        
+
         dfs = pd.DataFrame(randint(0, 50, (500, 3)), columns=list('abc'))
-        dfs.loc[0] = [2,1,1]
+        dfs.loc[0] = [2, 1, 1]
         dfs['d'] = 100
 
-        dfs.groupby(dfs.index).progress_apply(lambda x: None) #total = 500
-        dfs.groupby('d').progress_apply(lambda x: None) #total = 1
-        dfs.groupby(dfs.columns,axis=1).progress_apply(lambda x: None) #total = 4
-        dfs.groupby([2,2,1,1],axis=1).progress_apply(lambda x: None) #total = 2
+        expects = ['500/500', '1/1', '4/4', '2/2']
+        dfs.groupby(dfs.index).progress_apply(lambda x: None)
+        dfs.groupby('d').progress_apply(lambda x: None)
+        dfs.groupby(dfs.columns, axis=1).progress_apply(lambda x: None)
+        dfs.groupby([2, 2, 1, 1], axis=1).progress_apply(lambda x: None)
 
         our_file.seek(0)
         if our_file.read().count('100%') < 4:
             our_file.seek(0)
             raise AssertionError("\nExpected:\n{0}\nIn:\n{1}\n".format(
                 '100% at least four times', our_file.read()))
-        
-        expects = ['500/500', '1/1', '4/4', '2/2']
+
         for exres in expects:
             our_file.seek(0)
             if our_file.getvalue().count(exres) < 1:
                 our_file.seek(0)
                 raise AssertionError(
-                    "\nExpected:\n{0}\nIn:\n {1}\n".format(exres+" at least once.", our_file.read()))
+                    "\nExpected:\n{0}\nIn:\n {1}\n".format(
+                        exres + " at least once.", our_file.read()))
 
 
 @with_setup(pretest, posttest)
@@ -136,7 +141,7 @@ def test_pandas_leave():
     try:
         from numpy.random import randint
         import pandas as pd
-    except:
+    except ImportError:
         raise SkipTest
 
     with closing(StringIO()) as our_file:
@@ -155,23 +160,26 @@ def test_pandas_leave():
 
 @with_setup(pretest, posttest)
 def test_pandas_apply_args_deprecation():
-    """Test warning info in pandas.Dataframe(Series).progress_apply(func,*args)"""
+    """Test warning info in
+    `pandas.Dataframe(Series).progress_apply(func, *args)`"""
     try:
         from numpy.random import randint
         from tqdm import tqdm_pandas
         import pandas as pd
-    except:
+    except ImportError:
         raise SkipTest
 
     with closing(StringIO()) as our_file:
         tqdm_pandas(tqdm(file=our_file, leave=False, ascii=True, ncols=20))
         df = pd.DataFrame(randint(0, 50, (500, 3)))
-        df.progress_apply(lambda x: None, 1) # 1 shall cause a warning
+        df.progress_apply(lambda x: None, 1)  # 1 shall cause a warning
         # Check deprecation message
-        assert "TqdmDeprecationWarning" in our_file.getvalue()
-        assert "not supported" in our_file.getvalue()
-        assert "keyword arguments instead" in our_file.getvalue()
-    
+        res = our_file.getvalue()
+        assert all([i in res for i in (
+            "TqdmDeprecationWarning", "not supported",
+            "keyword arguments instead")])
+
+
 @with_setup(pretest, posttest)
 def test_pandas_deprecation():
     """Test bar object instance as argument deprecation"""
@@ -179,7 +187,7 @@ def test_pandas_deprecation():
         from numpy.random import randint
         from tqdm import tqdm_pandas
         import pandas as pd
-    except:
+    except ImportError:
         raise SkipTest
 
     with closing(StringIO()) as our_file:


### PR DESCRIPTION
- [x] rebase on to master
- [x] Add new test cases about pandas
- [x] fix #299 - find the correct `total` when using `progress_apply` and other functions in pandas.

#299 partially achieved its goal. With forbidding `*args`, one can get correct axis now, and use it to get the `total` (as number of iterations in `progress_apply`)

However, pandas sometimes runs several more iterations to optimise itself. For example, in `dataframe.progress_apply(func)`.

- if `func` is a `numpy.ufunc` or is very slow, then it will be executed `total` times.
- but if it is very quick or in some other cases, it will be executed `total+1` or `total+shape[axis0]` times.

I think there is no need to adjust such particular pandas implementation, so in the wrapper function, I write
```python
def wrapper(*args, **kwargs):
                    # update tbar correctly
                    # it seems pandas apply calls func twice on the first column/row 
                    # to decide whether it can take a fast or slow code path.
                    # so stop when t.total==t.n
                    t.update(n=1 if t.total and t.n < t.total else 0)
                    return func(*args, **kwargs)
``` 
if `total` is achieved, `tbar` will not be updated.