### PR TITLE
Fix TMonitor thread termination

### DIFF
--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -1,5 +1,5 @@
 from threading import Event, Thread
-from time import time, sleep
+from time import time
 __all__ = ["TMonitor"]
 
 

--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -19,7 +19,7 @@ class TMonitor(Thread):
 
     # internal vars for unit testing
     _time = None
-    _sleep = None
+    _event = None
 
     def __init__(self, tqdm_cls, sleep_interval):
         Thread.__init__(self)
@@ -32,10 +32,10 @@ class TMonitor(Thread):
             self._time = TMonitor._time
         else:
             self._time = time
-        if TMonitor._sleep is not None:
-            self._sleep = TMonitor._sleep
+        if TMonitor._event is not None:
+            self._event = TMonitor._event
         else:
-            self._sleep = sleep
+            self._event = Event
         self.start()
 
     def exit(self):

--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -50,8 +50,9 @@ class TMonitor(Thread):
             # Need to be done just before sleeping
             self.woken = cur_t
             # Sleep some time...
+            self.was_killed.wait(self.sleep_interval)
             # Quit if killed
-            if self.was_killed.wait(self.sleep_interval):
+            if self.was_killed.is_set():
                 return
             # Then monitor!
             # Acquire lock (to access _instances)

--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -1,4 +1,4 @@
-from threading import Thread
+from threading import Event, Thread
 from time import time, sleep
 __all__ = ["TMonitor"]
 
@@ -24,7 +24,7 @@ class TMonitor(Thread):
     def __init__(self, tqdm_cls, sleep_interval):
         Thread.__init__(self)
         self.daemon = True  # kill thread when main killed (KeyboardInterrupt)
-        self.was_killed = False
+        self.was_killed = Event()
         self.woken = 0  # last time woken up, to sync with monitor
         self.tqdm_cls = tqdm_cls
         self.sleep_interval = sleep_interval
@@ -39,8 +39,8 @@ class TMonitor(Thread):
         self.start()
 
     def exit(self):
-        self.was_killed = True
-        # self.join()  # DO NOT, blocking event, slows down tqdm at closing
+        self.was_killed.set()
+        self.join()
         return self.report()
 
     def run(self):
@@ -50,10 +50,8 @@ class TMonitor(Thread):
             # Need to be done just before sleeping
             self.woken = cur_t
             # Sleep some time...
-            self._sleep(self.sleep_interval)
             # Quit if killed
-            # if self.exit_event.is_set():  # TODO: should work but does not...
-            if self.was_killed:
+            if self.was_killed.wait(self.sleep_interval):
                 return
             # Then monitor!
             # Acquire lock (to access _instances)
@@ -61,6 +59,9 @@ class TMonitor(Thread):
                 cur_t = self._time()
                 # Check tqdm instances are waiting too long to print
                 for instance in self.tqdm_cls._instances:
+                    # Check event in loop to reduce blocking time on exit
+                    if self.was_killed.is_set():
+                        return
                     # Avoid race by checking that the instance started
                     if not hasattr(instance, 'start_t'):  # pragma: nocover
                         continue
@@ -76,5 +77,4 @@ class TMonitor(Thread):
                         instance.refresh(nolock=True)
 
     def report(self):
-        # return self.is_alive()  # TODO: does not work...
-        return not self.was_killed
+        return not self.was_killed.is_set()

--- a/tqdm/tests/tests_synchronisation.py
+++ b/tqdm/tests/tests_synchronisation.py
@@ -1,0 +1,144 @@
+from tqdm import tqdm
+from tests_tqdm import with_setup, pretest, posttest, StringIO, closing
+from tests_tqdm import DiscreteTimer, cpu_timify
+
+from time import sleep
+from threading import Event
+from tqdm import TMonitor
+
+
+class FakeSleep(object):
+    """Wait until the discrete timer reached the required time"""
+    def __init__(self, dtimer):
+        self.dtimer = dtimer
+
+    def sleep(self, t):
+        end = t + self.dtimer.t
+        while self.dtimer.t < end:
+            sleep(0.0000001)  # sleep a bit to interrupt (instead of pass)
+
+
+def make_create_fake_sleep_event(sleep):
+    def wait(self, timeout=None):
+        if timeout is not None:
+            sleep(timeout)
+        return self.is_set()
+
+    def create_fake_sleep_event():
+        event = Event()
+        event.wait = wait
+        return event
+
+    return create_fake_sleep_event
+
+
+@with_setup(pretest, posttest)
+def test_monitoring_thread():
+    # Note: should fix miniters for these tests, else with dynamic_miniters
+    # it's too complicated to handle with monitoring update and maxinterval...
+    maxinterval = 10
+
+    # 1- Configure and test the thread alone
+    # Setup a discrete timer
+    timer = DiscreteTimer()
+    TMonitor._time = timer.time
+    # And a fake sleeper
+    sleeper = FakeSleep(timer)
+    TMonitor._event = make_create_fake_sleep_event(sleeper.sleep)
+
+    # And a fake tqdm
+    class fake_tqdm(object):
+        _instances = []
+
+    # Instanciate the monitor
+    monitor = TMonitor(fake_tqdm, maxinterval)
+    # Test if alive, then killed
+    assert monitor.report()
+    monitor.exit()
+    timer.sleep(maxinterval * 2)  # need to go out of the sleep to die
+    assert not monitor.report()
+    # assert not monitor.is_alive()  # not working dunno why, thread not killed
+    del monitor
+
+    # 2- Test for real with a tqdm instance that takes too long
+    total = 1000
+    # Setup a discrete timer
+    timer = DiscreteTimer()
+    # And a fake sleeper
+    sleeper = FakeSleep(timer)
+    # Setup TMonitor to use the timer
+    TMonitor._time = timer.time
+    TMonitor._event = make_create_fake_sleep_event(sleeper.sleep)
+    # Set monitor interval
+    tqdm.monitor_interval = maxinterval
+    with closing(StringIO()) as our_file:
+        with tqdm(total=total, file=our_file, miniters=500, mininterval=0.1,
+                  maxinterval=maxinterval) as t:
+            cpu_timify(t, timer)
+            # Do a lot of iterations in a small timeframe
+            # (smaller than monitor interval)
+            timer.sleep(maxinterval / 2)  # monitor won't wake up
+            t.update(500)
+            # check that our fixed miniters is still there
+            assert t.miniters == 500
+            # Then do 1 it after monitor interval, so that monitor kicks in
+            timer.sleep(maxinterval * 2)
+            t.update(1)
+            # Wait for the monitor to get out of sleep's loop and update tqdm..
+            timeend = timer.time()
+            while not (t.monitor.woken >= timeend and t.miniters == 1):
+                timer.sleep(1)  # Force monitor to wake up if it woken too soon
+                sleep(0.000001)  # sleep to allow interrupt (instead of pass)
+            assert t.miniters == 1  # check that monitor corrected miniters
+            # Note: at this point, there may be a race condition: monitor saved
+            # current woken time but timer.sleep() happen just before monitor
+            # sleep. To fix that, either sleep here or increase time in a loop
+            # to ensure that monitor wakes up at some point.
+
+            # Try again but already at miniters = 1 so nothing will be done
+            timer.sleep(maxinterval * 2)
+            t.update(2)
+            timeend = timer.time()
+            while not (t.monitor.woken >= timeend):
+                timer.sleep(1)  # Force monitor to wake up if it woken too soon
+                sleep(0.000001)
+            # Wait for the monitor to get out of sleep's loop and update tqdm..
+            assert t.miniters == 1  # check that monitor corrected miniters
+
+    # 3- Check that class var monitor is deleted if no instance left
+    assert tqdm.monitor is None
+
+    # 4- Test on multiple bars, one not needing miniters adjustment
+    total = 1000
+    # Setup a discrete timer
+    timer = DiscreteTimer()
+    # And a fake sleeper
+    sleeper = FakeSleep(timer)
+    # Setup TMonitor to use the timer
+    TMonitor._time = timer.time
+    TMonitor._event = make_create_fake_sleep_event(sleeper.sleep)
+    with closing(StringIO()) as our_file:
+        with tqdm(total=total, file=our_file, miniters=500, mininterval=0.1,
+                  maxinterval=maxinterval) as t1:
+            # Set high maxinterval for t2 so monitor does not need to adjust it
+            with tqdm(total=total, file=our_file, miniters=500, mininterval=0.1,
+                      maxinterval=1E5) as t2:
+                cpu_timify(t1, timer)
+                cpu_timify(t2, timer)
+                # Do a lot of iterations in a small timeframe
+                timer.sleep(5)
+                t1.update(500)
+                t2.update(500)
+                assert t1.miniters == 500
+                assert t2.miniters == 500
+                # Then do 1 it after monitor interval, so that monitor kicks in
+                timer.sleep(maxinterval * 2)
+                t1.update(1)
+                t2.update(1)
+                # Wait for the monitor to get out of sleep and update tqdm
+                timeend = timer.time()
+                while not (t.monitor.woken >= timeend and t1.miniters == 1):
+                    timer.sleep(1)
+                    sleep(0.000001)
+                assert t1.miniters == 1  # check that monitor corrected miniters
+                assert t2.miniters == 500  # check that t2 was not adjusted

--- a/tqdm/tests/tests_synchronisation.py
+++ b/tqdm/tests/tests_synchronisation.py
@@ -137,7 +137,7 @@ def test_monitoring_thread():
                 t2.update(1)
                 # Wait for the monitor to get out of sleep and update tqdm
                 timeend = timer.time()
-                while not (t.monitor.woken >= timeend and t1.miniters == 1):
+                while not (t1.monitor.woken >= timeend and t1.miniters == 1):
                     timer.sleep(1)
                     sleep(0.000001)
                 assert t1.miniters == 1  # check that monitor corrected miniters

--- a/tqdm/tests/tests_synchronisation.py
+++ b/tqdm/tests/tests_synchronisation.py
@@ -18,6 +18,10 @@ class FakeSleep(object):
             sleep(0.0000001)  # sleep a bit to interrupt (instead of pass)
 
 
+class FakeTqdm(object):
+    _instances = []
+
+
 def make_create_fake_sleep_event(sleep):
     def wait(self, timeout=None):
         if timeout is not None:
@@ -46,12 +50,8 @@ def test_monitoring_thread():
     sleeper = FakeSleep(timer)
     TMonitor._event = make_create_fake_sleep_event(sleeper.sleep)
 
-    # And a fake tqdm
-    class fake_tqdm(object):
-        _instances = []
-
     # Instanciate the monitor
-    monitor = TMonitor(fake_tqdm, maxinterval)
+    monitor = TMonitor(FakeTqdm, maxinterval)
     # Test if alive, then killed
     assert monitor.report()
     monitor.exit()

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -11,13 +11,10 @@ from nose import with_setup
 from nose.plugins.skip import SkipTest
 from nose.tools import assert_raises
 from contextlib import contextmanager
-from threading import Event
-from time import sleep
 
 from tqdm import tqdm
 from tqdm import trange
 from tqdm import TqdmDeprecationWarning
-from tqdm._tqdm import TMonitor
 
 try:
     from StringIO import StringIO
@@ -34,7 +31,6 @@ class DeprecationError(Exception):
 # Ensure we can use `with closing(...) as ... :` syntax
 if getattr(StringIO, '__exit__', False) and \
    getattr(StringIO, '__enter__', False):
-
     def closing(arg):
         return arg
 else:
@@ -81,32 +77,6 @@ class DiscreteTimer(object):
     def time(self):
         """Get the current time"""
         return self.t
-
-
-class FakeSleep(object):
-    """Wait until the discrete timer reached the required time"""
-
-    def __init__(self, dtimer):
-        self.dtimer = dtimer
-
-    def sleep(self, t):
-        end = t + self.dtimer.t
-        while self.dtimer.t < end:
-            sleep(0.0000001)  # sleep a bit to interrupt (instead of pass)
-
-
-def make_create_fake_sleep_event(sleep):
-    def wait(self, timeout=None):
-        if timeout is not None:
-            sleep(timeout)
-        return self.is_set()
-
-    def create_fake_sleep_event():
-        event = Event()
-        event.wait = wait
-        return event
-
-    return create_fake_sleep_event
 
 
 def cpu_timify(t, timer=None):
@@ -1392,7 +1362,7 @@ def test_len():
     """Test advance len (numpy array shape)"""
     try:
         import numpy as np
-    except:
+    except ImportError:
         raise SkipTest
     with closing(StringIO()) as f:
         with tqdm(np.zeros((3, 4)), file=f) as t:
@@ -1430,118 +1400,6 @@ def test_deprecation_exception():
 
     assert_raises(TqdmDeprecationWarning, test_TqdmDeprecationWarning)
     assert_raises(Exception, test_TqdmDeprecationWarning_nofpwrite)
-
-
-@with_setup(pretest, posttest)
-def test_monitoring_thread():
-    # Note: should fix miniters for these tests, else with dynamic_miniters
-    # it's too complicated to handle with monitoring update and maxinterval...
-    maxinterval = 10
-
-    # 1- Configure and test the thread alone
-    # Setup a discrete timer
-    timer = DiscreteTimer()
-    TMonitor._time = timer.time
-    # And a fake sleeper
-    sleeper = FakeSleep(timer)
-    TMonitor._event = make_create_fake_sleep_event(sleeper.sleep)
-
-    # And a fake tqdm
-    class fake_tqdm(object):
-        _instances = []
-
-    # Instanciate the monitor
-    monitor = TMonitor(fake_tqdm, maxinterval)
-    # Test if alive, then killed
-    assert monitor.report()
-    monitor.exit()
-    timer.sleep(maxinterval * 2)  # need to go out of the sleep to die
-    assert not monitor.report()
-    # assert not monitor.is_alive()  # not working dunno why, thread not killed
-    del monitor
-
-    # 2- Test for real with a tqdm instance that takes too long
-    total = 1000
-    # Setup a discrete timer
-    timer = DiscreteTimer()
-    # And a fake sleeper
-    sleeper = FakeSleep(timer)
-    # Setup TMonitor to use the timer
-    TMonitor._time = timer.time
-    TMonitor._event = make_create_fake_sleep_event(sleeper.sleep)
-    # Set monitor interval
-    tqdm.monitor_interval = maxinterval
-    with closing(StringIO()) as our_file:
-        with tqdm(total=total, file=our_file, miniters=500, mininterval=0.1,
-                  maxinterval=maxinterval) as t:
-            cpu_timify(t, timer)
-            # Do a lot of iterations in a small timeframe
-            # (smaller than monitor interval)
-            timer.sleep(maxinterval / 2)  # monitor won't wake up
-            t.update(500)
-            # check that our fixed miniters is still there
-            assert t.miniters == 500
-            # Then do 1 it after monitor interval, so that monitor kicks in
-            timer.sleep(maxinterval * 2)
-            t.update(1)
-            # Wait for the monitor to get out of sleep's loop and update tqdm..
-            timeend = timer.time()
-            while not (t.monitor.woken >= timeend and t.miniters == 1):
-                timer.sleep(1)  # Force monitor to wake up if it woken too soon
-                sleep(0.000001)  # sleep to allow interrupt (instead of pass)
-            assert t.miniters == 1  # check that monitor corrected miniters
-            # Note: at this point, there may be a race condition: monitor saved
-            # current woken time but timer.sleep() happen just before monitor
-            # sleep. To fix that, either sleep here or increase time in a loop
-            # to ensure that monitor wakes up at some point.
-
-            # Try again but already at miniters = 1 so nothing will be done
-            timer.sleep(maxinterval * 2)
-            t.update(2)
-            timeend = timer.time()
-            while not (t.monitor.woken >= timeend):
-                timer.sleep(1)  # Force monitor to wake up if it woken too soon
-                sleep(0.000001)
-            # Wait for the monitor to get out of sleep's loop and update tqdm..
-            assert t.miniters == 1  # check that monitor corrected miniters
-
-    # 3- Check that class var monitor is deleted if no instance left
-    assert tqdm.monitor is None
-
-    # 4- Test on multiple bars, one not needing miniters adjustment
-    total = 1000
-    # Setup a discrete timer
-    timer = DiscreteTimer()
-    # And a fake sleeper
-    sleeper = FakeSleep(timer)
-    # Setup TMonitor to use the timer
-    TMonitor._time = timer.time
-    TMonitor._event = make_create_fake_sleep_event(sleeper.sleep)
-    with closing(StringIO()) as our_file:
-        with tqdm(total=total, file=our_file, miniters=500, mininterval=0.1,
-                  maxinterval=maxinterval) as t1:
-            # Set high maxinterval for t2 so monitor does not need to adjust it
-            with tqdm(total=total, file=our_file, miniters=500, mininterval=0.1,
-                      maxinterval=1E5) as t2:
-                cpu_timify(t1, timer)
-                cpu_timify(t2, timer)
-                # Do a lot of iterations in a small timeframe
-                timer.sleep(5)
-                t1.update(500)
-                t2.update(500)
-                assert t1.miniters == 500
-                assert t2.miniters == 500
-                # Then do 1 it after monitor interval, so that monitor kicks in
-                timer.sleep(maxinterval * 2)
-                t1.update(1)
-                t2.update(1)
-                # Wait for the monitor to get out of sleep and update tqdm
-                timeend = timer.time()
-                while not (t.monitor.woken >= timeend and t1.miniters == 1):
-                    timer.sleep(1)
-                    sleep(0.000001)
-                assert t1.miniters == 1  # check that monitor corrected miniters
-                assert t2.miniters == 500  # check that t2 was not adjusted
 
 
 @with_setup(pretest, posttest)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -11,7 +11,7 @@ from nose import with_setup
 from nose.plugins.skip import SkipTest
 from nose.tools import assert_raises
 from contextlib import contextmanager
-from functional import partial
+from functools import partial
 from threading import Event
 from time import sleep
 


### PR DESCRIPTION
Fixes https://github.com/conda/conda/issues/7002 in which `tqdm 4.14.0` is used on a Travis-CI Linux host with Python provided by https://repo.anaconda.com/miniconda/Miniconda2-4.4.10-Linux-x86_64.sh.

At least with Python 2.7, the un`join`ed `TMonitor` threads seem to go rogue when the Python process is terminated. I suspect those threads access some resources that are being unloaded while the process is shutting down, which leads to a segmentation fault.

I did not try it out with the latest version, but at least monkey patched the `TMonitor` from `4.19.8` into `4.14.0` and could still replicate the (very sporadic) segfaults.
I also didn't run the tests locally, so those changes are just a guess -- feel free to correct/alter anything in this PR.
I did not notice any performance impacts, which were mentioned in the deleted code comments.

