### PR TITLE
fix: race condition causes "AttributeError: 'tqdm' object has no attr…

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -400,6 +400,7 @@ class tqdm(object):
     def __new__(cls, *args, **kwargs):
         # Create a new instance
         instance = object.__new__(cls)
+        instance.pos = 0
         # Add to the list of instances
         if "_instances" not in cls.__dict__:
             cls._instances = WeakSet()


### PR DESCRIPTION
fix: race condition causes "AttributeError: 'tqdm' object has no attribute 'pos'"

cls._instances were being generated asynchronously and tqdm._get_free_pos
was being called between `__new__` and `__init__`. _get_free_pos was accessing
the tqdm.pos attribute which was going to be set in `__init__`.

Fixed this by setting instance.pos = 0 in `__new__` which will then be
corrected in `__init__`.

This should resolve #323 