### PR TITLE
Fixed missing attr pos when used in multi-threaded enviornment

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -443,7 +443,7 @@ class tqdm(Comparable):
             else:
                 for inst in cls._instances:
                     # negative `pos` means fixed
-                    if inst.pos > abs(instance.pos):
+                    if hasattr(inst, "pos") and inst.pos > abs(instance.pos):
                         inst.pos -= 1
                         # TODO: check this doesn't overwrite another fixed bar
         # Kill monitor if no instances are left


### PR DESCRIPTION
Fixes attribute error on pos during decr_instances, uses similar approach as in #546