### PR TITLE
ignore ANSI escape codes in the bar length calculation

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -13,7 +13,7 @@ from __future__ import division
 # compatibility functions and utilities
 from ._utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
-    Comparable
+    _strip_ansi_escape_codes, Comparable
 from ._monitor import TMonitor
 # native libraries
 import sys
@@ -362,8 +362,11 @@ class tqdm(Comparable):
 
             # Formatting progress bar
             # space available for bar's display
-            N_BARS = max(1, ncols - len(l_bar) - len(r_bar)) if ncols \
-                else 10
+            if ncols:
+                N_BARS = max(1, ncols - len(_strip_ansi_escape_codes(l_bar))
+                             - len(_strip_ansi_escape_codes(r_bar)))
+            else:
+                N_BARS = 10
 
             # format bar depending on availability of unicode/ascii chars
             if ascii:

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -13,7 +13,7 @@ from __future__ import division
 # compatibility functions and utilities
 from ._utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
-    _strip_ansi_escape_codes, Comparable
+    Comparable, RE_ANSI
 from ._monitor import TMonitor
 # native libraries
 import sys
@@ -360,11 +360,9 @@ class tqdm(Comparable):
                     # Else no progress bar, we can just format and return
                     return bar_format.format(**bar_args)
 
-            # Formatting progress bar
-            # space available for bar's display
+            # Formatting progress bar space available for bar's display
             if ncols:
-                N_BARS = max(1, ncols - len(_strip_ansi_escape_codes(l_bar))
-                             - len(_strip_ansi_escape_codes(r_bar)))
+                N_BARS = max(1, ncols - len(RE_ANSI.sub('', l_bar + r_bar)))
             else:
                 N_BARS = 10
 

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -234,7 +234,3 @@ def _environ_cols_linux(fp):  # pragma: no cover
 
 def _term_move_up():  # pragma: no cover
     return '' if (os.name == 'nt') and (colorama is None) else '\x1b[A'
-
-
-def _strip_ansi_escape_codes(string):
-    return RE_ANSI.sub('', string)

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -1,11 +1,13 @@
 import os
 import subprocess
 from platform import system as _curos
+import re
 CUR_OS = _curos()
 IS_WIN = CUR_OS in ['Windows', 'cli']
 IS_NIX = (not IS_WIN) and any(
     CUR_OS.startswith(i) for i in
     ['CYGWIN', 'MSYS', 'Linux', 'Darwin', 'SunOS', 'FreeBSD', 'NetBSD'])
+RE_ANSI = re.compile(r"\x1b\[[;\d]*[A-Za-z]")
 
 
 # Py2/3 compat. Empty conditional to avoid coverage
@@ -232,3 +234,7 @@ def _environ_cols_linux(fp):  # pragma: no cover
 
 def _term_move_up():  # pragma: no cover
     return '' if (os.name == 'nt') and (colorama is None) else '\x1b[A'
+
+
+def _strip_ansi_escape_codes(string):
+    return RE_ANSI.sub('', string)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -255,6 +255,19 @@ def test_format_meter():
         unich(0x258f) + "|test"
 
 
+def test_ansi_escape_codes():
+    """Test stripping of ANSI escape codes"""
+    format_meter = tqdm.format_meter
+    ansi = {'BOLD': '\033[1m',
+            'RED': '\033[91m',
+            'END': '\033[0m'}
+    desc = '{BOLD}{RED}Colored{END} description'.format(**ansi)
+    ncols = 123
+    ansi_len = sum([len(code) for code in ansi.values()])
+    meter = format_meter(0, 100, 0, ncols=ncols, prefix=desc)
+    assert len(meter) == ncols + ansi_len
+
+
 def test_si_format():
     """Test SI unit prefixes"""
     format_meter = tqdm.format_meter


### PR DESCRIPTION
Fixes #591.

This strips ANSI escape codes from the description string before calculating the remaining length of the bar, such that strings containing e.g. color codes are still displayed with the correct width.