### PR TITLE
Add suffix to progress

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -286,9 +286,9 @@ class tqdm(Comparable):
         rate_fmt = rate_inv_fmt if inv_rate and inv_rate > 1 else rate_noinv_fmt
 
         if unit_scale:
-            n_fmt = format_sizeof(n, divisor=unit_divisor)
-            total_fmt = format_sizeof(total, divisor=unit_divisor) \
-                if total else None
+            n_fmt = format_sizeof(n, suffix=unit, divisor=unit_divisor)
+            total_fmt = format_sizeof(total, suffix=unit, \
+                divisor=unit_divisor) if total else None
         else:
             n_fmt = str(n)
             total_fmt = str(total)


### PR DESCRIPTION
Previously tqdm formatted units with both M and MiB when using unit
kwarg:

```
Uploading githubwatch-dev-1534354789.zip (14.8MiB)..
100%|###########################| 15.5M/15.5M [00:03<00:00, 4.54MiB/s]
```

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
