### PR TITLE
Fix typo in _tqdm_notebook.py (juputer -> jupyter)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.py[cod]
 *.so
+/wiki/
+/docs/
+/feedstock/
 
 # Packages
 tqdm.egg-info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,4 +271,15 @@ For expereinced devs, once happy with local master:
 6. `git tag vM.m.p && git push --tags`
 7. `[python setup.py] make distclean`
 8. `[python setup.py] make build`
-9. `[python setup.py] make pypi`
+9. upload to PyPI using one of the following:
+    a) `[python setup.py] make pypi`
+    b) `twine upload -s -i $(git config user.signingkey) dist/tqdm-*`
+10. create new release on https://github.com/tqdm/tqdm/releases
+    a) add helpful release notes
+    b) attach dist/tqdm-* binaries (usually only *.whl*)
+11. run `make` in the `wiki` submodule to update release notes
+12. run `make deploy` in the `docs` submodule to update website
+13. accept the automated PR in the `feedstock` submodule to update conda
+
+The last thee steps require a one-time `make submodules` to clone
+`docs`, `wiki`, and `feedstock`.

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,11 @@ toxclean:
 installdev:
 	python setup.py develop --uninstall
 	python setup.py develop
+submodules:
+	git clone git@github.com:tqdm/tqdm.wiki wiki
+	git clone git@github.com:tqdm/tqdm.github.io docs
+	git clone git@github.com:conda-forge/tqdm-feedstock feedstock
+	cd feedstock && git remote add autotick-bot git@github.com:regro-cf-autotick-bot/tqdm-feedstock
 
 install:
 	python setup.py install

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -581,6 +581,10 @@ class tqdm(Comparable):
                             not isinstance(df, _Rolling_and_Expanding):
                         # DataFrame or Panel
                         axis = kwargs.get('axis', 0)
+                        if axis == 'index':
+                            axis = 0
+                        elif axis == 'columns':
+                            axis = 1
                         # when axis=0, total is shape[axis1]
                         total = df.size // df.shape[axis]
 

--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -102,7 +102,7 @@ class tqdm_notebook(tqdm):
         except NameError:
             # #187 #451 #558
             raise ImportError(
-                "IntProgress not found. Please update juputer and ipywidgets."
+                "IntProgress not found. Please update jupyter and ipywidgets."
                 " See https://ipywidgets.readthedocs.io/en/stable"
                 "/user_install.html")
 

--- a/tqdm/tests/tests_pandas.py
+++ b/tqdm/tests/tests_pandas.py
@@ -104,7 +104,7 @@ def test_pandas_data_frame():
         assert res1.equals(res2)
 
         # apply
-        for axis in [0, 1]:
+        for axis in [0, 1, 'index', 'columns']:
             res3 = df.progress_apply(task_func, axis=axis)
             res4 = df.apply(task_func, axis=axis)
             assert res3.equals(res4)


### PR DESCRIPTION
- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
