### PR TITLE
Fix tqdm_notebook description being truncated for long descriptions. #582

### DIFF
--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -108,6 +108,7 @@ class tqdm_notebook(tqdm):
 
         if desc:
             pbar.description = desc
+            pbar.style = {'description_width': 'initial'}
         # Prepare status text
         ptext = HTML()
         # Only way to place text to the right of the bar is to use a container
@@ -170,6 +171,7 @@ class tqdm_notebook(tqdm):
             # Update description
             if desc:
                 pbar.description = desc
+                pbar.style = {'description_width': 'initial'}
 
         return print_status
 


### PR DESCRIPTION
Fix tqdm_notebook description being truncated for long descriptions.
Related to issue #582