### PR TITLE
address pandas compatibility in test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.py[cod]
 *.so
+/wiki/
+/docs/
+/feedstock/
 
 # Packages
 tqdm.egg-info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,4 +271,15 @@ For expereinced devs, once happy with local master:
 6. `git tag vM.m.p && git push --tags`
 7. `[python setup.py] make distclean`
 8. `[python setup.py] make build`
-9. `[python setup.py] make pypi`
+9. upload to PyPI using one of the following:
+    a) `[python setup.py] make pypi`
+    b) `twine upload -s -i $(git config user.signingkey) dist/tqdm-*`
+10. create new release on https://github.com/tqdm/tqdm/releases
+    a) add helpful release notes
+    b) attach dist/tqdm-* binaries (usually only *.whl*)
+11. run `make` in the `wiki` submodule to update release notes
+12. run `make deploy` in the `docs` submodule to update website
+13. accept the automated PR in the `feedstock` submodule to update conda
+
+The last thee steps require a one-time `make submodules` to clone
+`docs`, `wiki`, and `feedstock`.

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,11 @@ toxclean:
 installdev:
 	python setup.py develop --uninstall
 	python setup.py develop
+submodules:
+	git clone git@github.com:tqdm/tqdm.wiki wiki
+	git clone git@github.com:tqdm/tqdm.github.io docs
+	git clone git@github.com:conda-forge/tqdm-feedstock feedstock
+	cd feedstock && git remote add autotick-bot git@github.com:regro-cf-autotick-bot/tqdm-feedstock
 
 install:
 	python setup.py install

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
     - coveralls
     codecov
 
-# no cython/numpy/pandas for py{py,py3,26,33,37}
+# no cython/numpy/pandas for py{py,py3,26,33,34}
 
 [testenv:py26]
 # no codecov and timer for py26
@@ -60,13 +60,6 @@ commands = {[extra]commands}
 
 [testenv:py34]
 # py34-compatible pandas
-deps =
-    {[extra]deps}
-    cython
-    numpy
-    pandas<0.21
-
-[testenv:py37]
 deps = {[extra]deps}
 commands = {[extra]commands}
 

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -581,6 +581,10 @@ class tqdm(Comparable):
                             not isinstance(df, _Rolling_and_Expanding):
                         # DataFrame or Panel
                         axis = kwargs.get('axis', 0)
+                        if axis == 'index':
+                            axis = 0
+                        elif axis == 'columns':
+                            axis = 1
                         # when axis=0, total is shape[axis1]
                         total = df.size // df.shape[axis]
 

--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -102,7 +102,7 @@ class tqdm_notebook(tqdm):
         except NameError:
             # #187 #451 #558
             raise ImportError(
-                "IntProgress not found. Please update juputer and ipywidgets."
+                "IntProgress not found. Please update jupyter and ipywidgets."
                 " See https://ipywidgets.readthedocs.io/en/stable"
                 "/user_install.html")
 

--- a/tqdm/tests/tests_pandas.py
+++ b/tqdm/tests/tests_pandas.py
@@ -33,12 +33,12 @@ def test_pandas_rolling_expanding():
         tqdm.pandas(file=our_file, leave=True, ascii=True)
 
         series = pd.Series(randint(0, 50, (123,)))
-        res1 = series.rolling(10).progress_apply(lambda x: 1)
-        res2 = series.rolling(10).apply(lambda x: 1)
+        res1 = series.rolling(10).progress_apply(lambda x: 1, raw=True)
+        res2 = series.rolling(10).apply(lambda x: 1, raw=True)
         assert res1.equals(res2)
 
-        res3 = series.expanding(10).progress_apply(lambda x: 2)
-        res4 = series.expanding(10).apply(lambda x: 2)
+        res3 = series.expanding(10).progress_apply(lambda x: 2, raw=True)
+        res4 = series.expanding(10).apply(lambda x: 2, raw=True)
         assert res3.equals(res4)
 
         expects = ['114it']  # 123-10+1

--- a/tqdm/tests/tests_pandas.py
+++ b/tqdm/tests/tests_pandas.py
@@ -104,7 +104,7 @@ def test_pandas_data_frame():
         assert res1.equals(res2)
 
         # apply
-        for axis in [0, 1]:
+        for axis in [0, 1, 'index', 'columns']:
             res3 = df.progress_apply(task_func, axis=axis)
             res4 = df.apply(task_func, axis=axis)
             assert res3.equals(res4)


### PR DESCRIPTION
1. Drop test cases in python34, and add them for python37
Currently, pandas Officially supports Python 2.7, 3.5, 3.6, and 3.7.

2. Address the future warning in Pandas
In the recent update of Pandas v0.23.0 (May 15, 2018), it says
```
Series.rolling().apply(), DataFrame.rolling().apply(), Series.expanding().apply(), and DataFrame.expanding().apply() have gained a raw=None parameter. This is similar to DataFame.apply(). This parameter, if True allows one to send a np.ndarray to the applied function. If False a Series will be passed. The default is None, which preserves backward compatibility, so this will default to True, sending an np.ndarray. In a future version the default will be changed to False, sending a Series. (GH5071, GH20584)
```

Hence, the test cases of ``test_pandas.py`` will raise a future warning about it as follows
```
/Users/guchen/Documents/Github/tqdm/tqdm/tests/tests_pandas.py:37: FutureWarning: Currently, 'apply' passes the values as ndarrays to the applied function. In the future, this will change to passing it as Series objects. You need to specify 'raw=True' to keep the current behaviour, and you can pass 'raw=False' to silence this warning
  res2 = series.rolling(10).apply(lambda x: 1)
```

This PR fixes the problem, adding ``raw=True`` to relevant apply functions. **It only impact the tqdm test cases.** 

As the last pandas version (0.20) for py34 does not have this ``raw=True`` support, and it is not officially supported, so I drop the pandas test for py34 in tox.ini

REF https://pandas.pydata.org/pandas-docs/version/0.23.0/whatsnew.html#rolling-expanding-apply-accepts-raw-false-to-pass-a-series-to-the-function