### PR TITLE
Add 'fixed' option to fix the position of progress bars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -356,6 +356,10 @@ Parameters
     Calls ``set_postfix(**postfix)`` if possible (dict).
 * unit_divisor  : float, optional  
     [default: 1000], ignored unless `unit_scale` is True.
+* fixed  : bool, optional
+    If [default: False], fix the progress bars on its position regardless of leave or termination.
+    If set it True, leave will be False automatically. (because it is meaningless when leave is True)
+    Useful to make the position of multiple bars fixed while using multiprocessing.
 
 Extra CLI Options
 ~~~~~~~~~~~~~~~~~
@@ -397,7 +401,7 @@ Returns
               [default: 1].
           """
 
-      def close(self):
+      def close(self. on_exit=False):
           """
           Cleanup and (if leave=False) close the progressbar.
           """

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -649,7 +649,7 @@ class tqdm(Comparable):
                  miniters=None, ascii=None, disable=False, unit='it',
                  unit_scale=False, dynamic_ncols=False, smoothing=0.3,
                  bar_format=None, initial=0, position=None, postfix=None,
-                 unit_divisor=1000, gui=False, **kwargs):
+                 unit_divisor=1000, fixed=False, gui=False, **kwargs):
         """
         Parameters
         ----------
@@ -738,6 +738,10 @@ class tqdm(Comparable):
             Calls `set_postfix(**postfix)` if possible (dict).
         unit_divisor  : float, optional
             [default: 1000], ignored unless `unit_scale` is True.
+        fixed  : bool, optional
+            If [default: False], fix the progress bars on its position regardless of leave or termination.
+            If set it True, leave will be False automatically. (because it is meaningless when leave is True)
+            Useful to make the position of multiple bars fixed while using multiprocessing.
         gui  : bool, optional
             WARNING: internal parameter - do not use.
             Use tqdm_gui(...) instead. If set, will attempt to use
@@ -832,6 +836,7 @@ class tqdm(Comparable):
         self.unit = unit
         self.unit_scale = unit_scale
         self.unit_divisor = unit_divisor
+        self.fixed = fixed
         self.gui = gui
         self.dynamic_ncols = dynamic_ncols
         self.smoothing = smoothing
@@ -856,6 +861,10 @@ class tqdm(Comparable):
                 self.pos = self._get_free_pos(self)
             else:  # mark fixed positions as negative
                 self.pos = -position
+
+        # If fixed is true, it force set the leave to False
+        if fixed:
+            self.leave = False
 
         if not gui:
             # Initialize the screen printer
@@ -882,7 +891,7 @@ class tqdm(Comparable):
         return self
 
     def __exit__(self, *exc):
-        self.close()
+        self.close(on_exit=True)
         return False
 
     def __del__(self):
@@ -1080,7 +1089,7 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                 self.last_print_n = self.n
                 self.last_print_t = cur_t
 
-    def close(self):
+    def close(self, on_exit=False):
         """
         Cleanup and (if leave=False) close the progressbar.
         """
@@ -1125,7 +1134,8 @@ Please use `tqdm_gui(...)` instead of `tqdm(..., gui=True)`
                     # only if not nested (#477)
                     fp_write('\n')
             else:
-                self.sp('')  # clear up last bar
+                if not (on_exit and self.fixed):
+                    self.sp('')  # clear up last bar
                 if pos:
                     self.moveto(-pos)
                 else:


### PR DESCRIPTION
I've added `fixed` option to fix the position of progress bars. I think it is useful to make the position of multiple bars fixed while using multiprocessing.

With `fixed` option, you can fix the position of progress bars and make the bars keeping on its position even though a process was completed.

### Real case

I wanted to run 8 jobs with 3 processes with `multiprocessing`. As you know, an order of job running is unexpectable, so it may be challenging to keep the progress bars for each job on its fixed positions.

1. `leave=True` (default) and using `position`

`with tqdm(total=srcr.dbsize(), ascii=True, unit='keys', unit_scale=True, position=pos) as pbar:`

<img width="1071" alt="screenshot 2018-09-17 20 05 24" src="https://user-images.githubusercontent.com/6178510/45621007-c6185680-bab9-11e8-934f-0647ee63f02e.png">

Yes it is tracing option, so, unexpected process switching are all traced. So I can't fix progress bars on a single line for a process.

2. `leave=False` and using `position`

`with tqdm(total=srcr.dbsize(), leave=False, ascii=True, unit='keys', unit_scale=True, position=pos) as pbar:`

<img width="1071" alt="screenshot 2018-09-17 20 05 45" src="https://user-images.githubusercontent.com/6178510/45621072-024bb700-baba-11e8-9882-3428b98074f9.png">

With `leave=False`, each progress bar will be updated on its (fixed) position. But, when a progress is completed, bars will be disappeared. So, I could not see completed output.

3. `fixed=True` and using `position`

`with tqdm(total=srcr.dbsize(), fixed=True, ascii=True, unit='keys', unit_scale=True, position=pos) as pbar:`

<img width="1072" alt="screenshot 2018-09-17 20 42 40" src="https://user-images.githubusercontent.com/6178510/45621125-3d4dea80-baba-11e8-817f-26fd2d4dfd55.png">

With `fixed=True`, I could see completed outputs which were not disappeared.`fixed` option is very simillar to `leave=Fasle` except that it does not "clear" the completed progress bar (at `__exit()__`).