### PR TITLE
Avoid global multiprocessing locks

### DIFF
--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -711,6 +711,44 @@ def test_smoothed_dynamic_min_iters_with_min_interval():
 
 
 @with_setup(pretest, posttest)
+def test_rlock_creation():
+    """Test that importing tqdm does not create multiprocessing objects."""
+    import multiprocessing as mp
+    if sys.version_info < (3, 3):
+        # unittest.mock is a 3.3+ feature
+        raise SkipTest
+
+    # Use 'spawn' instead of 'fork' so that the process does not inherit any
+    # globals that have been constructed by running other tests
+    ctx = mp.get_context('spawn')
+    with ctx.Pool(1) as pool:
+        # The pool will propagate the error if the target method fails
+        pool.apply(_rlock_creation_target)
+
+
+def _rlock_creation_target():
+    """Check that the RLock has not been constructed."""
+    from unittest.mock import patch
+    import multiprocessing as mp
+
+    # Patch the RLock class/method but use the original implementation
+    with patch('multiprocessing.RLock', wraps=mp.RLock) as rlock_mock:
+        # Importing the module should not create a lock
+        from tqdm import tqdm
+        assert rlock_mock.call_count == 0
+        # Creating a progress bar should initialize the lock
+        with closing(StringIO()) as our_file:
+            with tqdm(file=our_file) as t:
+                pass
+        assert rlock_mock.call_count == 1
+        # Creating a progress bar again should reuse the lock
+        with closing(StringIO()) as our_file:
+            with tqdm(file=our_file) as t:
+                pass
+        assert rlock_mock.call_count == 1
+
+
+@with_setup(pretest, posttest)
 def test_disable():
     """Test disable"""
     with closing(StringIO()) as our_file:


### PR DESCRIPTION
- Moving locks to class properties
- Adding lazy initialization for multiprocessing locks

Fixes #611 

The current behavior of initializing a multiprocessing lock is undocumented behavior. The main documentation says to feed in a lock explicitly for windows compatibility.

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [ ] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=


Here is how this change affects the following use cases:
- Create a multiprocessing pool, then use tqdm to wrap `pool.imap` or similar methods.
  - Write locking will no longer work, since the lock will not exist at the time of forking
- Same as above, but create the progress bar before the pool
  - Write locking will be unaffected since the progress bar will initialize the write lock before forking
- Set the multiprocessing method to `spawn`, create a progress bar in the main thread, run a multiprocessing pool
  - This will no longer cause the errors mentioned in #611 
- Create a thread pool, create a set of progress bars inside of the threads
  - This should be unaffected
- Feed in the lock explicitly with `tqdm.set_lock`
  - This should be unaffected