### PR TITLE
CLI: add `--man-path` option

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,10 @@ include tox.ini
 
 # Test suite
 recursive-include tqdm/tests *.py
+
+# Sub-packages
 recursive-include tqdm/autonotebook *.py
+recursive-include tqdm/auto *.py
 
 # Examples/Documentation
 recursive-include examples *.py

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ setup(
     platforms=['any'],
     packages=['tqdm'] + ['tqdm.' + i for i in find_packages('tqdm')],
     entry_points={'console_scripts': ['tqdm=tqdm._main:main'], },
-    data_files=[('man/man1', ['tqdm.1'])],
+    # data_files=[('man/man1', ['tqdm.1'])],
     package_data={'': ['CONTRIBUTING.md', 'LICENCE', 'examples/*.py']},
     long_description=README_rst,
     python_requires='>=2.6, !=3.0.*, !=3.1.*',

--- a/setup.py
+++ b/setup.py
@@ -182,8 +182,8 @@ setup(
     platforms=['any'],
     packages=['tqdm'] + ['tqdm.' + i for i in find_packages('tqdm')],
     entry_points={'console_scripts': ['tqdm=tqdm._main:main'], },
-    # data_files=[('man/man1', ['tqdm.1'])],
-    package_data={'': ['CONTRIBUTING.md', 'LICENCE', 'examples/*.py']},
+    package_data={'tqdm': ['CONTRIBUTING.md', 'LICENCE', 'examples/*.py',
+                           'tqdm.1']},
     long_description=README_rst,
     python_requires='>=2.6, !=3.0.*, !=3.1.*',
     classifiers=[

--- a/tqdm.1
+++ b/tqdm.1
@@ -221,6 +221,12 @@ If true, will count bytes, ignore \f[C]delim\f[], and default
 .RS
 .RE
 .TP
+.B \-\-man_path=\f[I]man_path\f[]
+str, optional.
+Directory in which to install tqdm man pages.
+.RS
+.RE
+.TP
 .B \-\-log=\f[I]log\f[]
 str, optional.
 CRITICAL|FATAL|ERROR|WARN(ING)|[default: \[aq]INFO\[aq]]|DEBUG|NOTSET.

--- a/tqdm/_main.py
+++ b/tqdm/_main.py
@@ -109,6 +109,8 @@ CLI_EXTRA_DOC = r"""
         bytes  : bool, optional
             If true, will count bytes, ignore `delim`, and default
             `unit_scale` to True, `unit_divisor` to 1024, and `unit` to 'B'.
+        man_path  : str, optional
+            Directory in which to install tqdm man pages.
         log  : str, optional
             CRITICAL|FATAL|ERROR|WARN(ING)|[default: 'INFO']|DEBUG|NOTSET.
 """
@@ -189,6 +191,16 @@ Options:
         buf_size = tqdm_args.pop('buf_size', 256)
         delim = tqdm_args.pop('delim', '\n')
         delim_per_char = tqdm_args.pop('bytes', False)
+        man_path = tqdm_args.pop('man_path', None)
+        if man_path is not None:
+            from os import path
+            from shutil import copyfile
+            fi = path.dirname(path.dirname(path.abspath(__file__)))
+            fi = path.join(fi, 'tqdm.1')
+            fo = path.join(man_path, 'tqdm.1')
+            copyfile(fi, fo)
+            log.info("written:" + fo)
+            sys.exit(0)
         if delim_per_char:
             tqdm_args.setdefault('unit', 'B')
             tqdm_args.setdefault('unit_scale', True)

--- a/tqdm/_main.py
+++ b/tqdm/_main.py
@@ -109,7 +109,7 @@ CLI_EXTRA_DOC = r"""
         bytes  : bool, optional
             If true, will count bytes, ignore `delim`, and default
             `unit_scale` to True, `unit_divisor` to 1024, and `unit` to 'B'.
-        man_path  : str, optional
+        manpath  : str, optional
             Directory in which to install tqdm man pages.
         log  : str, optional
             CRITICAL|FATAL|ERROR|WARN(ING)|[default: 'INFO']|DEBUG|NOTSET.
@@ -191,13 +191,13 @@ Options:
         buf_size = tqdm_args.pop('buf_size', 256)
         delim = tqdm_args.pop('delim', '\n')
         delim_per_char = tqdm_args.pop('bytes', False)
-        man_path = tqdm_args.pop('man_path', None)
-        if man_path is not None:
+        manpath = tqdm_args.pop('manpath', None)
+        if manpath is not None:
             from os import path
             from shutil import copyfile
-            fi = path.dirname(path.dirname(path.abspath(__file__)))
-            fi = path.join(fi, 'tqdm.1')
-            fo = path.join(man_path, 'tqdm.1')
+            from pkg_resources import resource_filename, Requirement
+            fi = resource_filename(Requirement.parse('tqdm'), 'tqdm/tqdm.1')
+            fo = path.join(manpath, 'tqdm.1')
             copyfile(fi, fo)
             log.info("written:" + fo)
             sys.exit(0)


### PR DESCRIPTION
- fixes #460
- fixes #628
- [info](https://github.com/click-contrib/click-man#automatic-man-page-installation-with-setuptools-and-pip)

# TODO

- [x] remove [`tqdm.1`](https://github.com/tqdm/tqdm/blob/master/tqdm.1) from [setup.py data_files](https://github.com/tqdm/tqdm/blob/master/setup.py#L185)
- [x] add CLI option `--manpath` to install man page to specified location
  - [ ] maybe add setuptools option as well
- [ ] generate said documentation [on-the-fly](https://github.com/click-contrib/click-man#3-we-want-to-generate-man-pages-on-the-fly)