### PR TITLE
Change default for `file` in `tqdm` to sys.stdout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -288,7 +288,7 @@ Parameters
     upon termination of iteration.
 * file  : ``io.TextIOWrapper`` or ``io.StringIO``, optional  
     Specifies where to output the progress messages
-    (default: sys.stderr). Uses ``file.write(str)`` and ``file.flush()``
+    (default: sys.stdout). Uses ``file.write(str)`` and ``file.flush()``
     methods.
 * ncols  : int, optional  
     The width of the entire output message. If specified,


### PR DESCRIPTION
Looking at [_tqdm.py:508](https://github.com/tqdm/tqdm/blob/350640d3171a568fb3f22d64d898e154541acc56/tqdm/_tqdm.py#L508)

Correct description of `file` parameter in `tqdm` should be:

* file  : ``io.TextIOWrapper`` or ``io.StringIO``, optional  
    Specifies where to output the progress messages
    (default: sys.stdout). Uses ``file.write(str)`` and ``file.flush()``
    methods.

I.e.`(default: sys.stdout)` instead of `(default: sys.stderr)`
