### PR TITLE
Recognize OpenBSD as a NIX

### DIFF
--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -6,7 +6,7 @@ CUR_OS = _curos()
 IS_WIN = CUR_OS in ['Windows', 'cli']
 IS_NIX = (not IS_WIN) and any(
     CUR_OS.startswith(i) for i in
-    ['CYGWIN', 'MSYS', 'Linux', 'Darwin', 'SunOS', 'FreeBSD', 'NetBSD'])
+    ['CYGWIN', 'MSYS', 'Linux', 'Darwin', 'SunOS', 'FreeBSD', 'NetBSD', 'OpenBSD'])
 RE_ANSI = re.compile(r"\x1b\[[;\d]*[A-Za-z]")
 
 


### PR DESCRIPTION
- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
```
4.28.1 3.6.6 (default, Oct 11 2018, 12:39:19)
[GCC 4.2.1 Compatible OpenBSD Clang 6.0.0 (tags/RELEASE_600/final)] openbsd6
```
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
