### PR TITLE
fix current thread join runtime error

### DIFF
--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -1,4 +1,4 @@
-from threading import Event, Thread
+from threading import Event, Thread, current_thread
 from time import time
 from warnings import warn
 import atexit
@@ -49,7 +49,8 @@ class TMonitor(Thread):
 
     def exit(self):
         self.was_killed.set()
-        self.join()
+        if self is not current_thread():
+            self.join()
         return self.report()
 
     def get_instances(self):


### PR DESCRIPTION
This PR fixes #613 

Explain:
When ``exit``, a ``TMonitor`` thread wants to join itself, but if it cannot do that if it is the current thread, which will raise an error as in File "/Users/guchen/anaconda3/lib/python3.6/threading.py"
```python
if self is current_thread():
            raise RuntimeError("cannot join current thread")
```

I just add one line to check whether it is the current thread. See #613 for more discussion. In fact, it rarely happens. For instance, in a case that the main thread is killed by accident (eg, by errors) and only the TMonitor thread remains.

Code to reproduce the error
```python
from time import sleep
from tqdm.auto import tqdm

for i in tqdm(range(10)):
    if i == 3:
        sleep(20)
        raise Exception("Wrong!")
    else:
        sleep(1)
```