### PR TITLE
Fix minor documentation typo.

### DIFF
--- a/tqdm/_main.py
+++ b/tqdm/_main.py
@@ -118,7 +118,7 @@ CLI_EXTRA_DOC = r"""
 
 def main(fp=sys.stderr, argv=None):
     """
-    Paramters (internal use only)
+    Parameters (internal use only)
     ---------
     fp  : file-like object for tqdm
     argv  : list (default: sys.argv[1:])


### PR DESCRIPTION
- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
