### PR TITLE
[Feature] Allow `total=float("inf")` 

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -702,8 +702,8 @@ class tqdm(Comparable):
             Prefix for the progressbar.
         total  : int, optional
             The number of expected iterations. If unspecified,
-            len(iterable) is used if possible. As a last resort, only basic
-            progress statistics are displayed (no ETA, no progressbar).
+            len(iterable) is used if possible. As a last resort (or when passing `float("inf")'),
+            only basic progress statistics are displayed (no ETA, no progressbar).
             If `gui` is True and this parameter needs subsequent updating,
             specify an initial arbitrary large positive integer,
             e.g. int(9e9).
@@ -801,6 +801,9 @@ class tqdm(Comparable):
                 total = len(iterable)
             except (TypeError, AttributeError):
                 total = None
+        if total == float("inf"):
+            # Infinite iterations, behave same as unknown
+            total = None
 
         if disable:
             self.iterable = iterable

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -728,6 +728,35 @@ def test_disable():
 
 
 @with_setup(pretest, posttest)
+def test_infinite_total():
+    """Test treatment of infinite total"""
+
+    class _TestInfiniteIterable(object):
+
+        def __len__(self):
+            return float("inf")
+
+        def __getitem__(self, item):
+            # Never raises StopIteration, so the iterator is infinite
+            return item
+
+    with closing(StringIO()) as our_file:
+        try:
+            for _ in tqdm(_range(3), file=our_file, total=float("inf")):
+                pass
+        except (TypeError, OverflowError):
+            assert False
+    with closing(StringIO()) as our_file:
+        # This is a bit contrived, but useful for real infinite iterables
+        try:
+            for i in tqdm(iter(_TestInfiniteIterable()), file=our_file):
+                if i > 3:
+                    break
+        except (TypeError, OverflowError):
+            assert False
+
+
+@with_setup(pretest, posttest)
 def test_unit():
     """Test SI unit prefix"""
     with closing(StringIO()) as our_file:

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -731,35 +731,12 @@ def test_disable():
 def test_infinite_total():
     """Test treatment of infinite total"""
 
-    # Need to disable pylint here, this only serves as a test case example
-    # There is no better way to get an object that has __len__ and __getitem__
-    class _TestInfiniteIterable(object):  # pylint: disable=too-few-public-methods
-
-        def __len__(self):
-            return float("inf")
-
-        def __getitem__(self, item):
-            # Never raises StopIteration, so the iterator is infinite
-            return item
-
     with closing(StringIO()) as our_file:
         try:
             for _ in tqdm(_range(3), file=our_file, total=float("inf")):
                 pass
         except (TypeError, OverflowError):
             assert False
-        
-    with closing(StringIO()) as our_file:
-        # This is a bit contrived, but useful for real infinite iterables
-        try:
-            progress_bar = tqdm(iter(_TestInfiniteIterable()), file=our_file)
-            for i in progress_bar:
-                if i > 3:
-                    break
-        except (TypeError, OverflowError):
-            assert False
-
-        progress_bar.close()
 
 
 @with_setup(pretest, posttest)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -731,7 +731,9 @@ def test_disable():
 def test_infinite_total():
     """Test treatment of infinite total"""
 
-    class _TestInfiniteIterable(object):
+    # Need to disable pylint here, this only serves as a test case example
+    # There is no better way to get an object that has __len__ and __getitem__
+    class _TestInfiniteIterable(object):  # pylint: disable=too-few-public-methods
 
         def __len__(self):
             return float("inf")
@@ -746,14 +748,18 @@ def test_infinite_total():
                 pass
         except (TypeError, OverflowError):
             assert False
+        
     with closing(StringIO()) as our_file:
         # This is a bit contrived, but useful for real infinite iterables
         try:
-            for i in tqdm(iter(_TestInfiniteIterable()), file=our_file):
+            progress_bar = tqdm(iter(_TestInfiniteIterable()), file=our_file)
+            for i in progress_bar:
                 if i > 3:
                     break
         except (TypeError, OverflowError):
             assert False
+
+        progress_bar.close()
 
 
 @with_setup(pretest, posttest)


### PR DESCRIPTION
Treats iterables that are explicitly stated to be infinite the same as unknown length, instead of crashing with a TypeError or OverflowError.

Sample use case:

```
def infinite():
    i = 0
    while True:
        yield i

progress_bar = tqdm(infinite(), total=float("inf"))
```

In theory, this would also work with a class whose length is infinite.
However, this is currently not supported by python itself. (`__len__` must return an integer)
