### PR TITLE
Fix warnings that are called but not raised

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -658,7 +658,7 @@ class tqdm(Comparable):
 
                 if len(args) > 0:
                     # *args intentionally not supported (see #244, #299)
-                    TqdmDeprecationWarning(
+                    raise TqdmDeprecationWarning(
                         "Except func, normal arguments are intentionally" +
                         " not supported by" +
                         " `(DataFrame|Series|GroupBy).progress_apply`." +

--- a/tqdm/_tqdm_pandas.py
+++ b/tqdm/_tqdm_pandas.py
@@ -35,7 +35,7 @@ def tqdm_pandas(tclass, *targs, **tkwargs):
 
     if isinstance(tclass, type) or (getattr(tclass, '__name__', '').startswith(
             'tqdm_')):  # delayed adapter case
-        TqdmDeprecationWarning("""\
+        raise TqdmDeprecationWarning("""\
 Please use `tqdm.pandas(...)` instead of `tqdm_pandas(tqdm, ...)`.
 """, fp_write=getattr(tkwargs.get('file', None), 'write', sys.stderr.write))
         tclass.pandas(*targs, **tkwargs)


### PR DESCRIPTION
Raise two warnings in `tqdm\_tqdm.py` and `tqdm\_tqdm_pandas.py` that are called but not raised

I work for Semmle and I noticed these issues using our LGTM code analyzer
https://lgtm.com/projects/g/tqdm/tqdm/alerts/?mode=tree&severity=error&ruleFocus=1505923886371

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
