### PR TITLE
tqdm: fix casting to boolean to mimic self.iterable

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -947,6 +947,17 @@ class tqdm(Comparable):
         # NB: Avoid race conditions by setting start_t at the very end of init
         self.start_t = self.last_print_t
 
+    def __bool__(self):
+        if self.total is not None:
+            return self.total > 0
+        if self.iterable is None:
+            raise TypeError('Boolean cast is undefined'
+                            ' for tqdm objects that have no iterable or total')
+        return bool(self.iterable)
+
+    def __nonzero__(self):
+        return self.__bool__()
+
     def __len__(self):
         return self.total if self.iterable is None else \
             (self.iterable.shape[0] if hasattr(self.iterable, "shape")

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1710,27 +1710,32 @@ def test_threading():
 @with_setup(pretest, posttest)
 def test_bool():
     """Test boolean cast"""
+
     def internal(our_file, disable):
-        with tqdm(total=10, file=our_file, disable=disable) as t:
-            assert t
-        with tqdm(total=0, file=our_file, disable=disable) as t:
-            assert not t
         with trange(10, file=our_file, disable=disable) as t:
             assert t
         with trange(0, file=our_file, disable=disable) as t:
             assert not t
-        with tqdm([], file=our_file, disable=disable) as t:
-            assert not t
-        with tqdm([0], file=our_file, disable=disable) as t:
-            assert t
-        with tqdm(file=our_file, disable=disable) as t:
-            try:
-                print(bool(t))
-            except TypeError:
-                pass
-            else:
-                raise TypeError(
-                    "Expected tqdm() with neither total nor iterable to fail")
+
+        def get_bool_for_tqdm(*args, **kwargs):
+            kwargs['file'] = our_file
+            kwargs['disable'] = disable
+            with tqdm(*args, **kwargs) as t:
+                return bool(t)
+
+        assert get_bool_for_tqdm(total=10)
+        assert not get_bool_for_tqdm(total=0)
+        assert not get_bool_for_tqdm([])
+        assert get_bool_for_tqdm([0])
+        assert get_bool_for_tqdm((x for x in []))
+        assert get_bool_for_tqdm((x for x in [1,2,3]))
+        try:
+            get_bool_for_tqdm()
+        except TypeError:
+            pass
+        else:
+            raise TypeError(
+                "Expected tqdm() with neither total nor iterable to fail")
 
     # test with and without disable
     with closing(StringIO()) as our_file:


### PR DESCRIPTION
I have hit an issue described in #353 today with what can be boiled down to:
```
In [28]: bool(tqdm.tqdm((1 for i in range(10))))                                                                                                                                              
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-28-e62055aa18f4> in <module>
----> 1 bool(tqdm.tqdm((1 for i in range(10))))

TypeError: 'NoneType' object cannot be interpreted as an integer

In [29]:   import tqdm, sys 
    ...:   print(tqdm.__version__, sys.version, sys.platform)                                                                                                                                 
4.29.1 3.6.6 (default, Oct  9 2018, 14:19:21) 
[GCC 5.4.0 20160609] linux

```

This is a stab at fixing it: it will make the `tqdm` wrapper behave in exactly the same way as the wrapped `self.iterable` when cast to boolean. Admittedly, it could be made more intelligent by comparing the current position to the total length if it is known, but that would complicate things and I wanted to start with a simple solution.

- [X] I have visited the [source website], and in particular
  read the [known issues]
- [X] I have searched through the [issue tracker] for duplicates
- [X] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
- [X] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
