### PR TITLE
Workaround lack of multiprocessing on Jython

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -21,7 +21,6 @@ from numbers import Number
 from time import time
 from contextlib import contextmanager
 # For parallelism safety
-import multiprocessing as mp
 import threading as th
 from warnings import warn
 
@@ -104,7 +103,8 @@ class TqdmDefaultWriteLock(object):
     def create_mp_lock(cls):
         if not hasattr(cls, 'mp_lock'):
             try:
-                cls.mp_lock = mp.RLock()  # multiprocessing lock
+                from multiprocessing import RLock
+                cls.mp_lock = RLock()  # multiprocessing lock
             except ImportError:  # pragma: no cover
                 cls.mp_lock = None
             except OSError:  # pragma: no cover


### PR DESCRIPTION
Jython doesn't have the `multiprocessing` module since, without the GIL, threads can be used more efficiently.
This is a simple change that is avoiding that import and seems to be all that is required to get tqdm work on Jython.
I didn't try the "advanced" stuff and couldn't run tox, but the iterable way seems to be working fine.