### PR TITLE
Add missing isatty() method to DummyTqdmFile

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -794,6 +794,9 @@ A reusable canonical example is given below:
         def flush(self):
             return getattr(self.file, "flush", lambda: None)()
 
+        def isatty(self):
+            return getattr(self.file, "isatty", lambda: False)()
+
     @contextlib.contextmanager
     def std_out_err_redirect_tqdm():
         orig_out_err = sys.stdout, sys.stderr

--- a/README.rst
+++ b/README.rst
@@ -974,6 +974,9 @@ A reusable canonical example is given below:
         def flush(self):
             return getattr(self.file, "flush", lambda: None)()
 
+        def isatty(self):
+            return getattr(self.file, "isatty", lambda: False)()
+
     @contextlib.contextmanager
     def std_out_err_redirect_tqdm():
         orig_out_err = sys.stdout, sys.stderr

--- a/examples/redirect_print.py
+++ b/examples/redirect_print.py
@@ -32,6 +32,9 @@ class DummyTqdmFile(object):
     def flush(self):
         return getattr(self.file, "flush", lambda: None)()
 
+    def isatty(self):
+        return getattr(self.file, "isatty", lambda: False)()
+
 
 @contextlib.contextmanager
 def std_out_err_redirect_tqdm():


### PR DESCRIPTION
This adds a `isatty()` method to the `DummyTqdmFile` example. Similar to #439, this makes it a better replacement for `sys.stdout` and `sys.stderr`.

More general thoughts:
* You might want to override `__getattr__` to forward everything except for `write` and `writelines`.
* This should be added to the library, so bugfixes will propagate to all users. Right now, everyone copies the example, so all the copies need to be fixed separately (e.g., hyperopt/hyperopt/pull/496).