### PR TITLE
Fix usage

### DIFF
--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -3,7 +3,7 @@ IPython/Jupyter Notebook progressbar decorator for iterators.
 Includes a default (x)range iterator printing to stderr.
 
 Usage:
-  >>> from tqdm_notebook import tnrange[, tqdm_notebook]
+  >>> from tqdm import tnrange[, tqdm_notebook]
   >>> for i in tnrange(10): #same as: for i in tqdm_notebook(xrange(10))
   ...     ...
 """


### PR DESCRIPTION
You can't import `tqdm_notebook`. You either import `tnrange()` from `tqdm` or `._tqdm_notebook`.

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
