### PR TITLE
Fix usage

### DIFF
--- a/tqdm/_tqdm_gui.py
+++ b/tqdm/_tqdm_gui.py
@@ -3,7 +3,7 @@ GUI progressbar decorator for iterators.
 Includes a default (x)range iterator printing to stderr.
 
 Usage:
-  >>> from tqdm_gui import tgrange[, tqdm_gui]
+  >>> from tqdm import tgrange[, tqdm_gui]
   >>> for i in tgrange(10): #same as: for i in tqdm_gui(xrange(10))
   ...     ...
 """


### PR DESCRIPTION
You can't import `tqdm_gui`. You either import `tgrange()` from `tqdm` or `._tqdm_gui`.

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
