### PR TITLE
Use ANSI escape to clear to end of line

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -243,12 +243,8 @@ class tqdm(Comparable):
             fp.write(_unicode(s))
             fp_flush()
 
-        last_len = [0]
-
         def print_status(s):
-            len_s = len(s)
-            fp_write('\r' + s + (' ' * max(last_len[0] - len_s, 0)))
-            last_len[0] = len_s
+            fp_write("\r" + s + "\x1b[K")
 
         return print_status
 


### PR DESCRIPTION
This switches from trying to remember the length of the previous output,
and instead uses an ANSI sequence to clear to the end of the line.

This fixes issue #728