### PR TITLE
Unwrap fps before comparing them

### DIFF
--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -166,6 +166,16 @@ class SimpleTextIOWrapper(object):
         return setattr(self._wrapped, name, value)
 
 
+def _unwrap_fp(fp):
+    """
+    If fp is a SimpleTextIOWrapper, returns the wrapped fp. Otherwise,
+    passes through 'fp'.
+    """
+    if isinstance(fp, SimpleTextIOWrapper):
+        return fp._wrapped
+    return fp
+
+
 def _is_utf(encoding):
     try:
         u'\u2588\u2589'.encode(encoding)


### PR DESCRIPTION
This fixes issue #727 by unwrapping file objects before comparing them
for equality. On Python 2.7, this makes text output look reasonable
using the example scripts.