### PR TITLE
Provide itertools wrappers that know about their length.

### DIFF
--- a/tqdm/itertools.py
+++ b/tqdm/itertools.py
@@ -1,0 +1,49 @@
+"""
+Itertools wrappers that know about their length if possible
+"""
+
+import functools as _functools
+import itertools as _itertools
+import operator as _operator
+from itertools import *
+
+
+class _Base:
+    # Subclasses must define _base_iterator and _get_length.
+
+    def __init__(self, *args, **kwargs):
+        self._iterator = type(self)._base_iterator(*args, **kwargs)
+        try:
+            self._length = type(self)._get_length(*args, **kwargs)
+        except TypeError:
+            self._length = None
+
+    def __iter__(self):
+        return self._iterator
+
+    def __len__(self):
+        return self._length
+
+
+class zip(_Base):
+    _base_iterator = zip
+
+    @staticmethod
+    def _get_length(*args):
+        return min(map(len, args))
+
+
+class product(_Base):
+    _base_iterator = _itertools.product
+
+    @staticmethod
+    def _get_length(*args, repeat=1):
+        return _functools.reduce(_operator.mul, map(len, args)) ** repeat
+
+
+class zip_longest(_Base):
+    _base_iterator = zip_longest
+
+    @staticmethod
+    def _get_length(*args):
+        return max(map(len, args))

--- a/tqdm/tests/tests_itertools.py
+++ b/tqdm/tests/tests_itertools.py
@@ -1,0 +1,34 @@
+import itertools
+
+from tqdm import itertools as it
+
+import pytest
+
+
+_lengthless_generator = (i for i in range(5))
+
+
+def test_zip():
+    for args in [(range(5), range(5)),
+                 (range(5), range(10))]:
+        assert len(it.zip(*args)) == len(list(zip(*args)))
+    with pytest.raises(TypeError):
+        len(it.zip(range(5), _lengthless_generator))
+
+
+def test_product():
+    for args, kwargs in [((range(5), range(10)), {}),
+                         ((range(5), range(10)), {"repeat": 2})]:
+        assert len(it.product(*args, **kwargs)) \
+            == len(list(itertools.product(*args, **kwargs)))
+    with pytest.raises(TypeError):
+        len(it.product(range(5), _lengthless_generator))
+
+
+def test_zip_longest():
+    for args in [(range(5), range(5)),
+                 (range(5), range(10))]:
+        assert len(it.zip_longest(*args)) \
+            == len(list(itertools.zip_longest(*args)))
+    with pytest.raises(TypeError):
+        len(it.zip_longest(range(5), _lengthless_generator))


### PR DESCRIPTION
A proof of concept for https://github.com/tqdm/tqdm/issues/225#issuecomment-490171284 (see discussion there); needs to be extended to more itertools iterators, needs docs.