### PR TITLE
Fix #740

### DIFF
--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -253,16 +253,6 @@ class tqdm_notebook(tqdm):
         # void -> avoid extraneous `\n` in IPython output cell
         return
 
-    def set_description(self, desc=None, **_):
-        """
-        Set/modify description of the progress bar.
-
-        Parameters
-        ----------
-        desc  : str, optional
-        """
-        self.sp(desc=desc)
-
 
 def tnrange(*args, **kwargs):
     """


### PR DESCRIPTION
Verified that this doesn't break the notebook widget:

![image](https://user-images.githubusercontent.com/15881001/57577331-4b75c000-7429-11e9-8147-6cc0a2831e14.png)

Not sure exactly what changed between https://github.com/tqdm/tqdm/issues/345 and now, however the overridden `set_description` no longer seems necessary.

fixes #740