### PR TITLE
Adds check for VSCODE_PID environment variable

### DIFF
--- a/tqdm/autonotebook/__init__.py
+++ b/tqdm/autonotebook/__init__.py
@@ -1,7 +1,11 @@
+import os
+
 try:
     from IPython import get_ipython
     if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover
         raise ImportError("console")
+    if 'VSCODE_PID' in os.environ:  # pragma: no cover
+        raise ImportError("vscode")
 except:
     from .._tqdm import tqdm, trange
 else:  # pragma: no cover


### PR DESCRIPTION
If VSCODE_PID environment variable exists, then autonotebook is not loaded.
Fixes #747 
