### PR TITLE
Fix tqdm._instances race and lock assignments to tqdm class variables

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -839,16 +839,18 @@ class tqdm(Comparable):
         if disable:
             self.iterable = iterable
             self.disable = disable
-            self.pos = self._get_free_pos(self)
-            self._instances.remove(self)
+            with self._lock:
+                self.pos = self._get_free_pos(self)
+                self._instances.remove(self)
             self.n = initial
             self.total = total
             return
 
         if kwargs:
             self.disable = True
-            self.pos = self._get_free_pos(self)
-            self._instances.remove(self)
+            with self._lock:
+                self.pos = self._get_free_pos(self)
+                self._instances.remove(self)
             from textwrap import dedent
             raise (TqdmDeprecationWarning(dedent("""\
                        `nested` is deprecated and automated.

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -459,22 +459,22 @@ class tqdm(Comparable):
     def __new__(cls, *args, **kwargs):
         # Create a new instance
         instance = object.__new__(cls)
-        # Add to the list of instances
-        if not hasattr(cls, '_instances'):
-            cls._instances = WeakSet()
         # Construct the lock if it does not exist
         with cls.get_lock():
+            # Add to the list of instances
+            if not hasattr(cls, '_instances'):
+                cls._instances = WeakSet()
             cls._instances.add(instance)
-        # Create the monitoring thread
-        if cls.monitor_interval and (cls.monitor is None or not
-                                     cls.monitor.report()):
-            try:
-                cls.monitor = TMonitor(cls, cls.monitor_interval)
-            except Exception as e:  # pragma: nocover
-                warn("tqdm:disabling monitor support"
-                     " (monitor_interval = 0) due to:\n" + str(e),
-                     TqdmMonitorWarning)
-                cls.monitor_interval = 0
+            # Create the monitoring thread
+            if cls.monitor_interval and (cls.monitor is None or not
+                                         cls.monitor.report()):
+                try:
+                    cls.monitor = TMonitor(cls, cls.monitor_interval)
+                except Exception as e:  # pragma: nocover
+                    warn("tqdm:disabling monitor support"
+                         " (monitor_interval = 0) due to:\n" + str(e),
+                         TqdmMonitorWarning)
+                    cls.monitor_interval = 0
         # Return the instance
         return instance
 
@@ -505,15 +505,15 @@ class tqdm(Comparable):
                     if hasattr(inst, "pos") and inst.pos > abs(instance.pos):
                         inst.pos -= 1
                         # TODO: check this doesn't overwrite another fixed bar
-        # Kill monitor if no instances are left
-        if not cls._instances and cls.monitor:
-            try:
-                cls.monitor.exit()
-                del cls.monitor
-            except AttributeError:  # pragma: nocover
-                pass
-            else:
-                cls.monitor = None
+            # Kill monitor if no instances are left
+            if not cls._instances and cls.monitor:
+                try:
+                    cls.monitor.exit()
+                    del cls.monitor
+                except AttributeError:  # pragma: nocover
+                    pass
+                else:
+                    cls.monitor = None
 
     @classmethod
     def write(cls, s, file=None, end="\n", nolock=False):


### PR DESCRIPTION
This PR superesedes #700. I have tested it against the current `master`.

It fixes the race for `tqdm._instances` between `__init__` and other methods that causes the error `Set changed size during iteration`.

It improves locking around assignments and deletions to `tqdm` class variables. Even though Python guarantees atomicity of individual assignments and deletions, they may be interleaved between threads leading to undesirable results detailed in the second commit message.

---

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
