### PR TITLE
Fix 753

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -1189,14 +1189,12 @@ class tqdm(Comparable):
                 if not pos:
                     fp_write('\r')
 
-        """
-        If the bars changed position,
-        they will only be redrawn on the next iteration, which looks bad, so we redraw them now.
-        """
-        for bar in self._instances:
-            if bar._should_refresh:
-                bar.refresh()
-                bar._should_refresh = False
+        """If the bars changed position,
+        they will only be redrawn on the next iteration, which looks bad, so we redraw them now."""
+        for inst in self._instances:
+            if inst._should_refresh:
+                inst.refresh()
+                inst._should_refresh = False
 
     def clear(self, nolock=False):
         """Clear current bar display."""

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -514,6 +514,7 @@ class tqdm(Comparable):
                             # Clear the bar from its current position before moving it up
                             inst.clear()
                             inst.pos = first_free_pos
+                            inst._should_refresh = True
         # Kill monitor if no instances are left
         if not cls._instances and cls.monitor:
             cls._closed_taken_positions.clear()
@@ -957,6 +958,8 @@ class tqdm(Comparable):
         # NB: Avoid race conditions by setting start_t at the very end of init
         self.start_t = self.last_print_t
 
+        self._should_refresh = False
+
     def __len__(self):
         return self.total if self.iterable is None else \
             (self.iterable.shape[0] if hasattr(self.iterable, "shape")
@@ -1191,7 +1194,9 @@ class tqdm(Comparable):
         they will only be redrawn on the next iteration, which looks bad, so we redraw them now.
         """
         for bar in self._instances:
-            bar.refresh()
+            if bar._should_refresh:
+                bar.refresh()
+                bar._should_refresh = False
 
     def clear(self, nolock=False):
         """Clear current bar display."""

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -462,7 +462,8 @@ class tqdm(Comparable):
         # Add to the list of instances
         if not hasattr(cls, '_instances'):
             cls._instances = WeakSet()
-        if not hasattr(cls, '_closed_taken_positions'):  # For positions that are still taken, but their instances were closed
+        # For positions that are still taken, but their instances were closed
+        if not hasattr(cls, '_closed_taken_positions'):
             cls._closed_taken_positions = set()
         # Construct the lock if it does not exist
         with cls.get_lock():


### PR DESCRIPTION
**TESTS ARE NOT PASSING YET**

Pr to fix #753 , (scripts are not the exact same, I only tweaked the timing of the bars)
before the fix: https://asciinema.org/a/7BCaYxPnRn4D62nj1iHDivlED
after the fix: https://asciinema.org/a/8YPmXvxVnpVU68VEMPywFt0Zx

What was fixed:
1. When instances move up, move them to the first free position, not blindly to one above them, it is possible that there is a bar above them that didn't finish yet (or was on a fixed position), that way both bars are on the same position

2. When changing the position of a bar, clear the bar from its old position, this is basically the main fix for the issues showed in #753 

3. Fixed _get_free_position. This method did not take into consideration instances with leave=True that was already closed. Their position was taken, but they didn't exist in the _instances set so you couldn't know. I added another set to keep track of them. 

Ps. now also refresh all bars after closing a bar

Tests:
**Not passing**, the test "test_position" (specifically line 1250) no longer passes. Since we now clear/refresh the bars when a bar closes, there are more lines written. However since a WeakSet is unordered, I can't predict the order which the objects are iterated at, so I can't predict the exact output.

To be clear, the output for this test looks ok visually, but going "frame by frame" will show the bars getting drawn at a different order (but at the right position)

It would be great if you can figure out what can be done with this test :)
(Only way I can think of is to write all possible combinations and try to get one success)

Ps. I get codestyle errors on multiline comments, are these not ok?