### PR TITLE
Fix tqdm_notebook red block on explicit file=None

### DIFF
--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -191,7 +191,8 @@ class tqdm_notebook(tqdm):
 
     def __init__(self, *args, **kwargs):
         # Setup default output
-        if kwargs.get('file', sys.stderr) is sys.stderr:
+        file_kwarg = kwargs.get('file', sys.stderr)
+        if file_kwarg is sys.stderr or file_kwarg is None:
             kwargs['file'] = sys.stdout  # avoid the red block in IPython
 
         # Initialize parent class + avoid printing by using gui=True


### PR DESCRIPTION
Based on the [documentation](https://github.com/tqdm/tqdm/#parameters), the default value for `file` is `None`. However, if you explicitly provide that as `tqdm_notebook(iterable, file=None)`, you get the "red block". This is a quick little fix for that.

Illustration of problem:
![image](https://user-images.githubusercontent.com/8178546/62819344-33126000-bb54-11e9-961c-f425aee11e00.png)

The changes here get rid of that red block.

---

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
```
4.33.0 3.7.3 | packaged by conda-forge | (default, Jul  1 2019, 14:38:56) 
[Clang 4.0.1 (tags/RELEASE_401/final)] darwin
```
- [x] If applicable, I have mentioned the relevant/related issue(s)

(Didn't see any relevant issues; the fix was so easy that I just made a PR instead of an issue.)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
