### PR TITLE
add Bar.__format__ helper

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -243,25 +243,29 @@ of a neat one-line progress bar.
 
 - Consoles in general: require support for carriage return (``CR``, ``\r``).
 - Nested progress bars:
-    * Consoles in general: require support for moving cursors up to the
-      previous line. For example,
-      `IDLE <https://github.com/tqdm/tqdm/issues/191#issuecomment-230168030>`__,
-      `ConEmu <https://github.com/tqdm/tqdm/issues/254>`__ and
-      `PyCharm <https://github.com/tqdm/tqdm/issues/203>`__ (also
-      `here <https://github.com/tqdm/tqdm/issues/208>`__,
-      `here <https://github.com/tqdm/tqdm/issues/307>`__, and
-      `here <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__)
-      lack full support.
-    * Windows: additionally may require the Python module ``colorama``
-      to ensure nested bars stay within their respective lines.
+
+  * Consoles in general: require support for moving cursors up to the
+    previous line. For example,
+    `IDLE <https://github.com/tqdm/tqdm/issues/191#issuecomment-230168030>`__,
+    `ConEmu <https://github.com/tqdm/tqdm/issues/254>`__ and
+    `PyCharm <https://github.com/tqdm/tqdm/issues/203>`__ (also
+    `here <https://github.com/tqdm/tqdm/issues/208>`__,
+    `here <https://github.com/tqdm/tqdm/issues/307>`__, and
+    `here <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__)
+    lack full support.
+  * Windows: additionally may require the Python module ``colorama``
+    to ensure nested bars stay within their respective lines.
+
 - Unicode:
-    * Environments which report that they support unicode will have solid smooth
-      progressbars. The fallback is an ```ascii``-only bar.
-    * Windows consoles often only partially support unicode and thus
-      `often require explicit ascii=True <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__
-      (also `here <https://github.com/tqdm/tqdm/issues/499>`__). This is due to
-      either normal-width unicode characters being incorrectly displayed as
-      "wide", or some unicode characters not rendering.
+
+  * Environments which report that they support unicode will have solid smooth
+    progressbars. The fallback is an ```ascii``-only bar.
+  * Windows consoles often only partially support unicode and thus
+    `often require explicit ascii=True <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__
+    (also `here <https://github.com/tqdm/tqdm/issues/499>`__). This is due to
+    either normal-width unicode characters being incorrectly displayed as
+    "wide", or some unicode characters not rendering.
+
 - Wrapping enumerated iterables: use ``enumerate(tqdm(...))`` instead of
   ``tqdm(enumerate(...))``. The same applies to ``numpy.ndenumerate``.
   This is because enumerate functions tend to hide the length of iterables.
@@ -368,9 +372,11 @@ Examples and Advanced Usage
   folder;
 - import the module and run ``help()``;
 - consult the `wiki <https://github.com/tqdm/tqdm/wiki>`__;
-    - this has an
+
+    * this has an
       `excellent article <https://github.com/tqdm/tqdm/wiki/How-to-make-a-great-Progress-Bar>`__
       on how to make a **great** progressbar;
+
 - run the |notebook-demo| or |binder-demo|, or
 - check out the `slides from PyData London <https://tqdm.github.io/PyData2019/slides.html>`__.
 
@@ -434,6 +440,23 @@ Additional ``bar_format`` parameters may also be defined by overriding
 .. code::
 
     00:01 in total: 40%|000o     | 4/10 [00:00<00:00,  9.96it/s]
+
+Note that ``{bar}`` also supports a format specifier ``[width][type]``.
+
+- ``width``
+
+  * unspecified (default): automatic to fill ``ncols``
+  * ``int >= 0``: fixed width overriding ``ncols`` logic
+  * ``int < 0``: subtract from the automatic default
+
+- ``type``
+
+  * ``a``: ascii (``ascii=True`` override)
+  * ``u``: unicode (``ascii=False`` override)
+  * ``b``: blank (``ascii="  "`` override)
+
+This means a fixed bar with right-justified text may be created by using:
+``bar_format="{l_bar}{bar:10}|{bar:-10b}right-justified"``
 
 Nested progress bars
 ~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -243,25 +243,29 @@ of a neat one-line progress bar.
 
 - Consoles in general: require support for carriage return (``CR``, ``\r``).
 - Nested progress bars:
-    * Consoles in general: require support for moving cursors up to the
-      previous line. For example,
-      `IDLE <https://github.com/tqdm/tqdm/issues/191#issuecomment-230168030>`__,
-      `ConEmu <https://github.com/tqdm/tqdm/issues/254>`__ and
-      `PyCharm <https://github.com/tqdm/tqdm/issues/203>`__ (also
-      `here <https://github.com/tqdm/tqdm/issues/208>`__,
-      `here <https://github.com/tqdm/tqdm/issues/307>`__, and
-      `here <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__)
-      lack full support.
-    * Windows: additionally may require the Python module ``colorama``
-      to ensure nested bars stay within their respective lines.
+
+  * Consoles in general: require support for moving cursors up to the
+    previous line. For example,
+    `IDLE <https://github.com/tqdm/tqdm/issues/191#issuecomment-230168030>`__,
+    `ConEmu <https://github.com/tqdm/tqdm/issues/254>`__ and
+    `PyCharm <https://github.com/tqdm/tqdm/issues/203>`__ (also
+    `here <https://github.com/tqdm/tqdm/issues/208>`__,
+    `here <https://github.com/tqdm/tqdm/issues/307>`__, and
+    `here <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__)
+    lack full support.
+  * Windows: additionally may require the Python module ``colorama``
+    to ensure nested bars stay within their respective lines.
+
 - Unicode:
-    * Environments which report that they support unicode will have solid smooth
-      progressbars. The fallback is an ```ascii``-only bar.
-    * Windows consoles often only partially support unicode and thus
-      `often require explicit ascii=True <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__
-      (also `here <https://github.com/tqdm/tqdm/issues/499>`__). This is due to
-      either normal-width unicode characters being incorrectly displayed as
-      "wide", or some unicode characters not rendering.
+
+  * Environments which report that they support unicode will have solid smooth
+    progressbars. The fallback is an ```ascii``-only bar.
+  * Windows consoles often only partially support unicode and thus
+    `often require explicit ascii=True <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__
+    (also `here <https://github.com/tqdm/tqdm/issues/499>`__). This is due to
+    either normal-width unicode characters being incorrectly displayed as
+    "wide", or some unicode characters not rendering.
+
 - Wrapping enumerated iterables: use ``enumerate(tqdm(...))`` instead of
   ``tqdm(enumerate(...))``. The same applies to ``numpy.ndenumerate``.
   This is because enumerate functions tend to hide the length of iterables.
@@ -315,7 +319,6 @@ Parameters
 * leave  : bool, optional  
     If [default: True], keeps all traces of the progressbar
     upon termination of iteration.
-    If ``None``, will leave only if ``position`` is ``0``.
 * file  : ``io.TextIOWrapper`` or ``io.StringIO``, optional  
     Specifies where to output the progress messages
     (default: sys.stderr). Uses ``file.write(str)`` and ``file.flush()``
@@ -533,9 +536,11 @@ Examples and Advanced Usage
   folder;
 - import the module and run ``help()``;
 - consult the `wiki <https://github.com/tqdm/tqdm/wiki>`__;
-    - this has an
+
+    * this has an
       `excellent article <https://github.com/tqdm/tqdm/wiki/How-to-make-a-great-Progress-Bar>`__
       on how to make a **great** progressbar;
+
 - run the |notebook-demo| or |binder-demo|, or
 - check out the `slides from PyData London <https://tqdm.github.io/PyData2019/slides.html>`__.
 
@@ -599,6 +604,23 @@ Additional ``bar_format`` parameters may also be defined by overriding
 .. code::
 
     00:01 in total: 40%|000o     | 4/10 [00:00<00:00,  9.96it/s]
+
+Note that ``{bar}`` also supports a format specifier ``[width][type]``.
+
+- ``width``
+
+  * unspecified (default): automatic to fill ``ncols``
+  * ``int >= 0``: fixed width overriding ``ncols`` logic
+  * ``int < 0``: subtract from the automatic default
+
+- ``type``
+
+  * ``a``: ascii (``ascii=True`` override)
+  * ``u``: unicode (``ascii=False`` override)
+  * ``b``: blank (``ascii="  "`` override)
+
+This means a fixed bar with right-justified text may be created by using:
+``bar_format="{l_bar}{bar:10}|{bar:-10b}right-justified"``
 
 Nested progress bars
 ~~~~~~~~~~~~~~~~~~~~

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -132,6 +132,9 @@ class Bar(object):
 
     >>> "{:6a}".format(Bar(0.5))
     '###   '
+
+    >>> "{:-6}".format(Bar(0.5, 10))  # 6 less than default width
+    '##  '
     """
     ASCII = " 123456789#"
     UTF = u" " + u''.join(map(_unich, range(0x258F, 0x2587, -1)))
@@ -152,7 +155,12 @@ class Bar(object):
                 charset = self.charset
             else:
                 format_spec = format_spec[:-1]
-            N_BARS = int(format_spec) if format_spec else self.default_len
+            if format_spec:
+                N_BARS = int(format_spec)
+                if N_BARS < 0:
+                    N_BARS += self.default_len
+            else:
+                N_BARS = self.default_len
         else:
             charset = self.charset
             N_BARS = self.default_len
@@ -461,7 +469,7 @@ class tqdm(Comparable):
                 frac,
                 max(1, ncols - len(RE_ANSI.sub('', nobar))) if ncols else 10,
                 charset=Bar.ASCII if ascii is True else ascii or Bar.UTF)
-            return _unicode(bar_format).format(bar=full_bar, **format_dict)
+            return bar_format.format(bar=full_bar, **format_dict)
 
         elif bar_format:
             # user-specified bar_format but no total
@@ -899,14 +907,10 @@ class tqdm(Comparable):
                 dynamic_ncols = _environ_cols_wrapper()
                 if dynamic_ncols:
                     ncols = dynamic_ncols(file)
-                # elif ncols is not None:
-                #     ncols = 79
             else:
                 _dynamic_ncols = _environ_cols_wrapper()
                 if _dynamic_ncols:
                     ncols = _dynamic_ncols(file)
-                # else:
-                #     ncols = 79
 
         if miniters is None:
             miniters = 0

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -470,6 +470,8 @@ class tqdm(Comparable):
                 frac,
                 max(1, ncols - len(RE_ANSI.sub('', nobar))) if ncols else 10,
                 charset=Bar.ASCII if ascii is True else ascii or Bar.UTF)
+            if not _is_ascii(full_bar.charset) and _is_ascii(bar_format):
+                bar_format = _unicode(bar_format)
             return bar_format.format(bar=full_bar, **format_dict)
 
         elif bar_format:

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -13,7 +13,7 @@ from __future__ import division
 # compatibility functions and utilities
 from ._utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
-    Comparable, RE_ANSI, _is_ascii, SimpleTextIOWrapper
+    Comparable, RE_ANSI, _is_ascii, SimpleTextIOWrapper, FormatReplace
 from ._monitor import TMonitor
 # native libraries
 import sys
@@ -124,15 +124,6 @@ class TqdmDefaultWriteLock(object):
 # Do not create the multiprocessing lock because it sets the multiprocessing
 # context and does not allow the user to use 'spawn' or 'forkserver' methods.
 TqdmDefaultWriteLock.create_th_lock()
-
-
-class EmptyFormat(object):
-    def __init__(self):
-        self.format_called = 0
-
-    def __format__(self, _):
-        self.format_called += 1
-        return ""
 
 
 class Bar(object):
@@ -459,7 +450,7 @@ class tqdm(Comparable):
             else:
                 bar_format = "{l_bar}{bar}{r_bar}"
 
-            full_bar = EmptyFormat()
+            full_bar = FormatReplace()
             nobar = bar_format.format(bar=full_bar, **format_dict)
             if not full_bar.format_called:
                 # no {bar}, we can just format and return

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -128,13 +128,16 @@ TqdmDefaultWriteLock.create_th_lock()
 
 class Bar(object):
     """
-    `str.format`-able bar
+    `str.format`-able bar with format specifiers: `[width][type]`
 
-    >>> "{:6a}".format(Bar(0.5))
-    '###   '
-
-    >>> "{:-6}".format(Bar(0.5, 10))  # 6 less than default width
-    '##  '
+    - `width`
+      + unspecified (default): use `self.default_len`
+      + `int >= 0`: overrides `self.default_len`
+      + `int < 0`: subtract from `self.default_len`
+    - `type`
+      + `a`: ascii (`charset=self.ASCII` override)
+      + `u`: unicode (`charset=self.UTF` override)
+      + `b`: blank (`charset="  "` override)
     """
     ASCII = " 123456789#"
     UTF = u" " + u''.join(map(_unich, range(0x258F, 0x2587, -1)))

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -138,6 +138,7 @@ class Bar(object):
     """
     ASCII = " 123456789#"
     UTF = u" " + u''.join(map(_unich, range(0x258F, 0x2587, -1)))
+    BLANK = "  "
 
     def __init__(self, frac, default_len=10, charset=UTF):
         assert 0 <= frac <= 1
@@ -150,7 +151,7 @@ class Bar(object):
         if format_spec:
             _type = format_spec[-1].lower()
             try:
-                charset = dict(a=self.ASCII, u=self.UTF)[_type]
+                charset = dict(a=self.ASCII, u=self.UTF, b=self.BLANK)[_type]
             except KeyError:
                 charset = self.charset
             else:

--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -144,6 +144,7 @@ class Bar(object):
     """
     ASCII = " 123456789#"
     UTF = u" " + u''.join(map(_unich, range(0x258F, 0x2587, -1)))
+
     def __init__(self, frac, default_len=10, charset=UTF):
         assert 0 <= frac <= 1
         assert default_len > 0

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -121,6 +121,21 @@ if True:  # pragma: no cover
                     return d
 
 
+class FormatReplace(object):
+    """
+    >>> a = FormatReplace('something')
+    >>> "{:5d}".format(a)
+    'something'
+    """
+    def __init__(self, replace=''):
+        self.replace = replace
+        self.format_called = 0
+
+    def __format__(self, _):
+        self.format_called += 1
+        return self.replace
+
+
 class Comparable(object):
     """Assumes child has self._comparable attr/@property"""
     def __lt__(self, other):

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -191,7 +191,7 @@ def test_iter_overhead():
                 a += i
                 our_file.write(a)
 
-    assert_performance(9, 'trange', time_tqdm(), 'range', time_bench())
+    assert_performance(6, 'trange', time_tqdm(), 'range', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -215,7 +215,7 @@ def test_manual_overhead():
                 a += i
                 our_file.write(a)
 
-    assert_performance(10, 'tqdm', time_tqdm(), 'range', time_bench())
+    assert_performance(6, 'tqdm', time_tqdm(), 'range', time_bench())
 
 @with_setup(pretest, posttest)
 @retry_on_except()
@@ -239,7 +239,7 @@ def test_iter_overhead_hard():
                 a += i
                 our_file.write(("%i" % a) * 40)
 
-    assert_performance(60, 'trange', time_tqdm(), 'range', time_bench())
+    assert_performance(85, 'trange', time_tqdm(), 'range', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -264,7 +264,7 @@ def test_manual_overhead_hard():
                 a += i
                 our_file.write(("%i" % a) * 40)
 
-    assert_performance(100, 'tqdm', time_tqdm(), 'range', time_bench())
+    assert_performance(85, 'tqdm', time_tqdm(), 'range', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -291,7 +291,7 @@ def test_iter_overhead_simplebar_hard():
                 a += i
 
     assert_performance(
-        3.5, 'trange', time_tqdm(), 'simple_progress', time_bench())
+        5, 'trange', time_tqdm(), 'simple_progress', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -320,4 +320,4 @@ def test_manual_overhead_simplebar_hard():
                 simplebar_update(10)
 
     assert_performance(
-        3.5, 'tqdm', time_tqdm(), 'simple_progress', time_bench())
+        5, 'tqdm', time_tqdm(), 'simple_progress', time_bench())

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -159,6 +159,17 @@ def simple_progress(iterable=None, total=None, file=sys.stdout, desc='',
         return update_and_print
 
 
+def assert_performance(thresh, name_left, time_left, name_right, time_right):
+    if time_left > thresh * time_right:
+        raise ValueError(
+            ('{name[0]}: {time[0]:f}, '
+             '{name[1]}: {time[0]:f}, '
+             'ratio {ratio:f} > {thresh:f}').format(
+                name=(name_left, name_right),
+                time=(time_left, time_right),
+                ratio=time_left / time_right, thresh=thresh))
+
+
 @with_setup(pretest, posttest)
 @retry_on_except()
 def test_iter_overhead():
@@ -180,10 +191,7 @@ def test_iter_overhead():
                 a += i
                 our_file.write(a)
 
-    # Compute relative overhead of tqdm against native range()
-    if time_tqdm() > 9 * time_bench():
-        raise AssertionError('trange(%g): %f, range(%g): %f' %
-                             (total, time_tqdm(), total, time_bench()))
+    assert_performance(9, 'trange', time_tqdm(), 'range', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -207,11 +215,7 @@ def test_manual_overhead():
                 a += i
                 our_file.write(a)
 
-    # Compute relative overhead of tqdm against native range()
-    if time_tqdm() > 10 * time_bench():
-        raise AssertionError('tqdm(%g): %f, range(%g): %f' %
-                             (total, time_tqdm(), total, time_bench()))
-
+    assert_performance(10, 'tqdm', time_tqdm(), 'range', time_bench())
 
 @with_setup(pretest, posttest)
 @retry_on_except()
@@ -235,12 +239,7 @@ def test_iter_overhead_hard():
                 a += i
                 our_file.write(("%i" % a) * 40)
 
-    # Compute relative overhead of tqdm against native range()
-    try:
-        assert time_tqdm() < 60 * time_bench()
-    except AssertionError:
-        raise AssertionError('trange(%g): %f, range(%g): %f' %
-                             (total, time_tqdm(), total, time_bench()))
+    assert_performance(60, 'trange', time_tqdm(), 'range', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -265,12 +264,7 @@ def test_manual_overhead_hard():
                 a += i
                 our_file.write(("%i" % a) * 40)
 
-    # Compute relative overhead of tqdm against native range()
-    try:
-        assert time_tqdm() < 100 * time_bench()
-    except AssertionError:
-        raise AssertionError('tqdm(%g): %f, range(%g): %f' %
-                             (total, time_tqdm(), total, time_bench()))
+    assert_performance(100, 'tqdm', time_tqdm(), 'range', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -296,12 +290,8 @@ def test_iter_overhead_simplebar_hard():
             for i in s:
                 a += i
 
-    # Compute relative overhead of tqdm against native range()
-    try:
-        assert time_tqdm() < 3.5 * time_bench()
-    except AssertionError:
-        raise AssertionError('trange(%g): %f, simple_progress(%g): %f' %
-                             (total, time_tqdm(), total, time_bench()))
+    assert_performance(
+        3.5, 'trange', time_tqdm(), 'simple_progress', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -329,9 +319,5 @@ def test_manual_overhead_simplebar_hard():
                 a += i
                 simplebar_update(10)
 
-    # Compute relative overhead of tqdm against native range()
-    try:
-        assert time_tqdm() < 3.5 * time_bench()
-    except AssertionError:
-        raise AssertionError('tqdm(%g): %f, simple_progress(%g): %f' %
-                             (total, time_tqdm(), total, time_bench()))
+    assert_performance(
+        3.5, 'tqdm', time_tqdm(), 'simple_progress', time_bench())

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -160,6 +160,7 @@ def simple_progress(iterable=None, total=None, file=sys.stdout, desc='',
 
 
 def assert_performance(thresh, name_left, time_left, name_right, time_right):
+    """raises if time_left > thresh * time_right"""
     if time_left > thresh * time_right:
         raise ValueError(
             ('{name[0]}: {time[0]:f}, '
@@ -216,6 +217,7 @@ def test_manual_overhead():
                 our_file.write(a)
 
     assert_performance(6, 'tqdm', time_tqdm(), 'range', time_bench())
+
 
 @with_setup(pretest, posttest)
 @retry_on_except()

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -332,9 +332,9 @@ def test_si_format():
 
 def test_bar_formatspec():
     """Test Bar.__format__ spec"""
-    assert "{:5a}".format(Bar(0.3)) == "#5   "
-    assert "{:2}".format(Bar(0.5, charset=" .oO0")) == "0 "
-    assert "{:2a}".format(Bar(0.5, charset=" .oO0")) == "# "
+    assert "{0:5a}".format(Bar(0.3)) == "#5   "
+    assert "{0:2}".format(Bar(0.5, charset=" .oO0")) == "0 "
+    assert "{0:2a}".format(Bar(0.5, charset=" .oO0")) == "# "
 
 
 @with_setup(pretest, posttest)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -335,8 +335,8 @@ def test_bar_formatspec():
     assert "{0:5a}".format(Bar(0.3)) == "#5   "
     assert "{0:2}".format(Bar(0.5, charset=" .oO0")) == "0 "
     assert "{0:2a}".format(Bar(0.5, charset=" .oO0")) == "# "
-    assert "{0:-6a}".format(Bar(0.5, 10))  == '##  '
-    assert "{0:2b}".format(Bar(0.5, 10))  == '  '
+    assert "{0:-6a}".format(Bar(0.5, 10)) == '##  '
+    assert "{0:2b}".format(Bar(0.5, 10)) == '  '
 
 
 @with_setup(pretest, posttest)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -335,6 +335,7 @@ def test_bar_formatspec():
     assert "{0:5a}".format(Bar(0.3)) == "#5   "
     assert "{0:2}".format(Bar(0.5, charset=" .oO0")) == "0 "
     assert "{0:2a}".format(Bar(0.5, charset=" .oO0")) == "# "
+    assert "{0:-6a}".format(Bar(0.5, 10))  == '##  '
 
 
 @with_setup(pretest, posttest)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from tqdm import tqdm
 from tqdm import trange
 from tqdm import TqdmDeprecationWarning
+from tqdm._tqdm import Bar
 
 try:
     from StringIO import StringIO
@@ -327,6 +328,13 @@ def test_si_format():
                                      unit_scale=True)
     assert '1000.0Y ' in format_meter(1, 999999999999999999999999999, 1,
                                       unit_scale=True)
+
+
+def test_bar_formatspec():
+    """Test Bar.__format__ spec"""
+    assert "{:5a}".format(Bar(0.3)) == "#5   "
+    assert "{:2}".format(Bar(0.5, charset=" .oO0")) == "0 "
+    assert "{:2a}".format(Bar(0.5, charset=" .oO0")) == "# "
 
 
 @with_setup(pretest, posttest)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -336,6 +336,7 @@ def test_bar_formatspec():
     assert "{0:2}".format(Bar(0.5, charset=" .oO0")) == "0 "
     assert "{0:2a}".format(Bar(0.5, charset=" .oO0")) == "# "
     assert "{0:-6a}".format(Bar(0.5, 10))  == '##  '
+    assert "{0:2b}".format(Bar(0.5, 10))  == '  '
 
 
 @with_setup(pretest, posttest)


### PR DESCRIPTION
- [x] support e.g. `{bar:[width][type]}` in `bar_format` string
- [x] document
  + `width` := `>0` (fixed), unspecified (auto), `<0` (subtract from auto)
  + `type` := `a` (ascii), `u` (unicode), `b` (blank)
  + takes precedence over `ncols` and `ascii` options
- [x] add tests
- fixes #623

e.g. for fixed bar width of 10 and right-justified text:

```python
bar_format='{l_bar}{bar:10}|{bar:-10b}some text'
```