### PR TITLE
Recognize wide characters when calculating bar size

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -13,7 +13,8 @@ from __future__ import division
 # compatibility functions and utilities
 from ._utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
-    Comparable, RE_ANSI, _is_ascii, SimpleTextIOWrapper, FormatReplace
+    Comparable, RE_ANSI, _is_ascii, SimpleTextIOWrapper, FormatReplace, \
+    _text_width
 from ._monitor import TMonitor
 # native libraries
 import sys
@@ -300,7 +301,7 @@ class tqdm(Comparable):
         last_len = [0]
 
         def print_status(s):
-            len_s = len(s)
+            len_s = _text_width(s)
             fp_write('\r' + s + (' ' * max(last_len[0] - len_s, 0)))
             last_len[0] = len_s
 
@@ -469,9 +470,10 @@ class tqdm(Comparable):
                 return nobar
 
             # Formatting progress bar space available for bar's display
+            bar_size = max(1, ncols - _text_width(RE_ANSI.sub('', nobar))) \
+                if ncols else 10
             full_bar = Bar(
-                frac,
-                max(1, ncols - len(RE_ANSI.sub('', nobar))) if ncols else 10,
+                frac, bar_size,
                 charset=Bar.ASCII if ascii is True else ascii or Bar.UTF)
             if not _is_ascii(full_bar.charset) and _is_ascii(bar_format):
                 bar_format = _unicode(bar_format)

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -283,3 +283,17 @@ def _environ_cols_linux(fp):  # pragma: no cover
 
 def _term_move_up():  # pragma: no cover
     return '' if (os.name == 'nt') and (colorama is None) else '\x1b[A'
+
+
+def _text_width(s):  # pragma: no cover
+    # TODO consider using wcswidth third-party package for 0-width characters
+    try:
+        from unicodedata import east_asian_width
+    except ImportError:
+        return len(s)
+    else:
+        try:
+            return len(s) + sum(east_asian_width(ch) in 'FW' for ch in s)
+        except TypeError:  # Py2
+            s = s.decode('utf-8')
+            return len(s) + sum(east_asian_width(ch) in 'FW' for ch in s)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Advice: use repr(our_file.read()) to print the full output of tqdm
 # (else '\r' will replace the previous lines and you'll see only the latest.
 
@@ -277,6 +278,12 @@ def test_format_meter():
     assert format_meter(20, 100, 12, ncols=14, rate=8.1,
                         bar_format=r'{l_bar}{bar}|{n_fmt}/{total_fmt}') == \
         " 20%|" + unich(0x258d) + " |20/100"
+    # Check wide characters
+    if sys.version_info >= (3,):
+        assert format_meter(0, 1000, 13, ncols=68, prefix='ｆｕｌｌｗｉｄｔｈ: ') == \
+            "ｆｕｌｌｗｉｄｔｈ:   0%|                  | 0/1000 [00:13<?, ?it/s]"
+        assert format_meter(0, 1000, 13, ncols=68, prefix='ニッポン [ﾆｯﾎﾟﾝ]: ') == \
+            "ニッポン [ﾆｯﾎﾟﾝ]:   0%|                    | 0/1000 [00:13<?, ?it/s]"
     # Check that bar_format can print only {bar} or just one side
     assert format_meter(20, 100, 12, ncols=2, rate=8.1,
                         bar_format=r'{bar}') == \


### PR DESCRIPTION
Updated #410 to current master with added (and not failing) tests.

Closes #410. Fixes #803 

I also added a comment regarding using `wcswidth`, but I didn't want to add a dependency in a PR.