### PR TITLE
MNT: set stack level on warnings

### DIFF
--- a/tqdm/_main.py
+++ b/tqdm/_main.py
@@ -4,4 +4,4 @@ from .std import TqdmDeprecationWarning
 from warnings import warn
 warn("This function will be removed in tqdm==5.0.0\n"
      "Please use `tqdm.cli.*` instead of `tqdm._main.*`",
-     TqdmDeprecationWarning)
+     TqdmDeprecationWarning, stacklevel=2)

--- a/tqdm/_tqdm_gui.py
+++ b/tqdm/_tqdm_gui.py
@@ -4,4 +4,4 @@ from .std import TqdmDeprecationWarning
 from warnings import warn
 warn("This function will be removed in tqdm==5.0.0\n"
      "Please use `tqdm.gui.*` instead of `tqdm._tqdm_gui.*`",
-     TqdmDeprecationWarning)
+     TqdmDeprecationWarning, stacklevel=2)

--- a/tqdm/_tqdm_notebook.py
+++ b/tqdm/_tqdm_notebook.py
@@ -4,4 +4,4 @@ from .std import TqdmDeprecationWarning
 from warnings import warn
 warn("This function will be removed in tqdm==5.0.0\n"
      "Please use `tqdm.notebook.*` instead of `tqdm._tqdm_notebook.*`",
-     TqdmDeprecationWarning)
+     TqdmDeprecationWarning, stacklevel=2)

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -3,4 +3,4 @@ from .std import TqdmDeprecationWarning
 from warnings import warn
 warn("This function will be removed in tqdm==5.0.0\n"
      "Please use `tqdm.utils.*` instead of `tqdm._utils.*`",
-     TqdmDeprecationWarning)
+     TqdmDeprecationWarning, stacklevel=2)


### PR DESCRIPTION
- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
- [x] If applicable, I have mentioned the relevant/related issue(s)

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=

This makes it much easier to find where in client code needs to be
fixed.

Adds stacklevel kwarg to warnings added in 4.36.0