### PR TITLE
Replace dedent calls by dedented strings.

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -923,11 +923,10 @@ class tqdm(Comparable):
             with self._lock:
                 self.pos = self._get_free_pos(self)
                 self._instances.remove(self)
-            from textwrap import dedent
-            raise (TqdmDeprecationWarning(dedent("""\
-                       `nested` is deprecated and automated.
-                       Use `position` instead for manual control.
-                       """), fp_write=getattr(file, 'write', sys.stderr.write))
+            raise (TqdmDeprecationWarning(
+                       "`nested` is deprecated and automated.\n"
+                       "Use `position` instead for manual control.\n",
+                       fp_write=getattr(file, 'write', sys.stderr.write))
                    if "nested" in kwargs else
                    TqdmKeyError("Unknown argument(s): " + str(kwargs)))
 
@@ -1083,10 +1082,10 @@ class tqdm(Comparable):
         time = self._time
 
         if not hasattr(self, 'sp'):
-            from textwrap import dedent
-            raise TqdmDeprecationWarning(dedent("""\
-            Please use `tqdm.gui.tqdm(...)` instead of `tqdm(..., gui=True)`
-            """), fp_write=getattr(self.fp, 'write', sys.stderr.write))
+            raise TqdmDeprecationWarning(
+                "Please use `tqdm.gui.tqdm(...)` instead of"
+                " `tqdm(..., gui=True)`\n",
+                fp_write=getattr(self.fp, 'write', sys.stderr.write))
 
         for obj in iterable:
             yield obj


### PR DESCRIPTION
The strings are so short that just using plain dedented literal strings
is just as readable (if not more) than going through dedent(), and this
change saves a call to a not-so-trivial function.

- [X] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [X] I have visited the [source website], and in particular
  read the [known issues]
- [X] I have searched through the [issue tracker] for duplicates
- [X] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```

  ```
  4.37.0 3.7.5 (default, Oct 25 2019, 15:51:11) 
  [GCC 7.3.0] linux
  ```

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
