### PR TITLE
add `wrapattr`

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -610,6 +610,10 @@ down to:
 
 .. code:: python
 
+    import urllib, os
+    from tqdm import tqdm
+
+    eg_link = "https://caspersci.uk.to/matryoshka.zip"
     with tqdm.wrapattr(open(os.devnull, "wb"), "write",
                        miniters=1, desc=eg_link.split('/')[-1]) as fout:
         for chunk in urllib.urlopen(eg_link):

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -541,7 +541,7 @@ Hooks and callbacks
 ``tqdm`` can easily support callbacks/hooks and manual updates.
 Here's an example with ``urllib``:
 
-**urllib.urlretrieve documentation**
+**``urllib.urlretrieve`` documentation**
 
     | [...]
     | If present, the hook function will be called once
@@ -583,6 +583,34 @@ Functional alternative in
 It is recommend to use ``miniters=1`` whenever there is potentially
 large differences in iteration speed (e.g. downloading a file over
 a patchy connection).
+
+**Wrapping read/write methods**
+
+To measure throughput through a file-like object's ``read`` or ``write``
+methods, use ``CallbackIOWrapper``:
+
+.. code:: python
+
+    from tqdm import tqdm
+    from tqdm.utils import CallbackIOWrapper
+
+    with tqdm(total=file_obj.size,
+              unit='B', unit_scale=True, unit_divisor=1024) as t:
+        fobj = CallbackIOWrapper(t.update, file_obj, "read")
+        while True:
+            chunk = fobj.read(chunk_size)
+            if not chunk:
+                break
+        t.reset()
+        # ... continue to use `t` for something else
+
+Alternatively, use the even simpler ``wrapattr`` convenience function:
+
+.. code:: python
+
+    with tqdm.wrapattr(file_obj, "write", total=data.size) as fobj:
+        for chunk in data:
+            fobj.write(chunk)
 
 Pandas Integration
 ~~~~~~~~~~~~~~~~~~

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -769,20 +769,8 @@ A reusable canonical example is given below:
     import contextlib
     import sys
     from tqdm import tqdm
+    from tqdm.utils import DummyTqdmFile  # write to tqdm
 
-    class DummyTqdmFile(object):
-        """Dummy file-like that will write to tqdm"""
-        file = None
-        def __init__(self, file):
-            self.file = file
-
-        def write(self, x):
-            # Avoid print() second call (useless \n)
-            if len(x.rstrip()) > 0:
-                tqdm.write(x, file=self.file)
-
-        def flush(self):
-            return getattr(self.file, "flush", lambda: None)()
 
     @contextlib.contextmanager
     def std_out_err_redirect_tqdm():

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -604,13 +604,16 @@ methods, use ``CallbackIOWrapper``:
         t.reset()
         # ... continue to use `t` for something else
 
-Alternatively, use the even simpler ``wrapattr`` convenience function:
+Alternatively, use the even simpler ``wrapattr`` convenience function,
+which would condense both the ``urllib`` and ``CallbackIOWrapper`` examples
+down to:
 
 .. code:: python
 
-    with tqdm.wrapattr(file_obj, "write", total=data.size) as fobj:
-        for chunk in data:
-            fobj.write(chunk)
+    with tqdm.wrapattr(open(os.devnull, "wb"), "write",
+                       miniters=1, desc=eg_link.split('/')[-1]) as fout:
+        for chunk in urllib.urlopen(eg_link):
+            fout.write(chunk)
 
 Pandas Integration
 ~~~~~~~~~~~~~~~~~~

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -769,7 +769,7 @@ A reusable canonical example is given below:
     import contextlib
     import sys
     from tqdm import tqdm
-    from tqdm.utils import DummyTqdmFile  # write to tqdm
+    from tqdm.contrib import DummyTqdmFile
 
 
     @contextlib.contextmanager

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,9 @@ include logo.png
 include Makefile
 include tox.ini
 
+# Non-std submodules
+recursive-include tqdm/contrib *.py
+
 # Test suite
 recursive-include tqdm/tests *.py
 include requirements-dev.txt

--- a/README.rst
+++ b/README.rst
@@ -790,6 +790,10 @@ down to:
 
 .. code:: python
 
+    import urllib, os
+    from tqdm import tqdm
+
+    eg_link = "https://caspersci.uk.to/matryoshka.zip"
     with tqdm.wrapattr(open(os.devnull, "wb"), "write",
                        miniters=1, desc=eg_link.split('/')[-1]) as fout:
         for chunk in urllib.urlopen(eg_link):

--- a/README.rst
+++ b/README.rst
@@ -949,7 +949,7 @@ A reusable canonical example is given below:
     import contextlib
     import sys
     from tqdm import tqdm
-    from tqdm.utils import DummyTqdmFile  # write to tqdm
+    from tqdm.contrib import DummyTqdmFile
 
 
     @contextlib.contextmanager

--- a/README.rst
+++ b/README.rst
@@ -721,7 +721,7 @@ Hooks and callbacks
 ``tqdm`` can easily support callbacks/hooks and manual updates.
 Here's an example with ``urllib``:
 
-**urllib.urlretrieve documentation**
+**``urllib.urlretrieve`` documentation**
 
     | [...]
     | If present, the hook function will be called once
@@ -763,6 +763,34 @@ Functional alternative in
 It is recommend to use ``miniters=1`` whenever there is potentially
 large differences in iteration speed (e.g. downloading a file over
 a patchy connection).
+
+**Wrapping read/write methods**
+
+To measure throughput through a file-like object's ``read`` or ``write``
+methods, use ``CallbackIOWrapper``:
+
+.. code:: python
+
+    from tqdm import tqdm
+    from tqdm.utils import CallbackIOWrapper
+
+    with tqdm(total=file_obj.size,
+              unit='B', unit_scale=True, unit_divisor=1024) as t:
+        fobj = CallbackIOWrapper(t.update, file_obj, "read")
+        while True:
+            chunk = fobj.read(chunk_size)
+            if not chunk:
+                break
+        t.reset()
+        # ... continue to use `t` for something else
+
+Alternatively, use the even simpler ``wrapattr`` convenience function:
+
+.. code:: python
+
+    with tqdm.wrapattr(file_obj, "write", total=data.size) as fobj:
+        for chunk in data:
+            fobj.write(chunk)
 
 Pandas Integration
 ~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -949,20 +949,8 @@ A reusable canonical example is given below:
     import contextlib
     import sys
     from tqdm import tqdm
+    from tqdm.utils import DummyTqdmFile  # write to tqdm
 
-    class DummyTqdmFile(object):
-        """Dummy file-like that will write to tqdm"""
-        file = None
-        def __init__(self, file):
-            self.file = file
-
-        def write(self, x):
-            # Avoid print() second call (useless \n)
-            if len(x.rstrip()) > 0:
-                tqdm.write(x, file=self.file)
-
-        def flush(self):
-            return getattr(self.file, "flush", lambda: None)()
 
     @contextlib.contextmanager
     def std_out_err_redirect_tqdm():

--- a/README.rst
+++ b/README.rst
@@ -784,13 +784,16 @@ methods, use ``CallbackIOWrapper``:
         t.reset()
         # ... continue to use `t` for something else
 
-Alternatively, use the even simpler ``wrapattr`` convenience function:
+Alternatively, use the even simpler ``wrapattr`` convenience function,
+which would condense both the ``urllib`` and ``CallbackIOWrapper`` examples
+down to:
 
 .. code:: python
 
-    with tqdm.wrapattr(file_obj, "write", total=data.size) as fobj:
-        for chunk in data:
-            fobj.write(chunk)
+    with tqdm.wrapattr(open(os.devnull, "wb"), "write",
+                       miniters=1, desc=eg_link.split('/')[-1]) as fout:
+        for chunk in urllib.urlopen(eg_link):
+            fout.write(chunk)
 
 Pandas Integration
 ~~~~~~~~~~~~~~~~~~

--- a/examples/redirect_print.py
+++ b/examples/redirect_print.py
@@ -15,7 +15,7 @@ from time import sleep
 import contextlib
 import sys
 from tqdm import tqdm
-from tqdm.utils import DummyTqdmFile
+from tqdm.contrib import DummyTqdmFile
 
 
 @contextlib.contextmanager

--- a/examples/redirect_print.py
+++ b/examples/redirect_print.py
@@ -15,22 +15,7 @@ from time import sleep
 import contextlib
 import sys
 from tqdm import tqdm
-
-
-class DummyTqdmFile(object):
-    """Dummy file-like that will write to tqdm"""
-    file = None
-
-    def __init__(self, file):
-        self.file = file
-
-    def write(self, x):
-        # Avoid print() second call (useless \n)
-        if len(x.rstrip()) > 0:
-            tqdm.write(x, file=self.file)
-
-    def flush(self):
-        return getattr(self.file, "flush", lambda: None)()
+from tqdm.utils import DummyTqdmFile
 
 
 @contextlib.contextmanager

--- a/examples/tqdm_wget.py
+++ b/examples/tqdm_wget.py
@@ -95,3 +95,9 @@ with TqdmUpTo(unit='B', unit_scale=True, unit_divisor=1024, miniters=1,
               desc=eg_file) as t:  # all optional kwargs
     urllib.urlretrieve(eg_link, filename=eg_out, reporthook=t.update_to,
                        data=None)
+
+# Even simpler progress by wrapping the output file's `write()`
+with tqdm.wrapattr(open(eg_out, "wb"), "write",
+                   miniters=1, desc=eg_file) as fout:
+    for chunk in urllib.urlopen(eg_link):
+        fout.write(chunk)

--- a/tqdm/contrib/__init__.py
+++ b/tqdm/contrib/__init__.py
@@ -1,0 +1,10 @@
+from tqdm import tqdm
+from tqdm.utils import ObjectWrapper
+
+
+class DummyTqdmFile(ObjectWrapper):
+    """Dummy file-like that will write to tqdm"""
+    def write(self, x, nolock=False):
+        # Avoid print() second call (useless \n)
+        if len(x.rstrip()) > 0:
+            tqdm.write(x, file=self._wrapped, nolock=nolock)

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -142,16 +142,16 @@ class CallbackIOWrapper(object):
         object.__setattr__(self, '_wrapped', stream)
         func = getattr(stream, method)
         if method == "write":
-            @wraps(stream.write)
+            @wraps(func)
             def write(data, *args, **kwargs):
-                res = stream.write(data, *args, **kwargs)
+                res = func(data, *args, **kwargs)
                 callback(len(data))
                 return res
             object.__setattr__(self, 'write', write)
         elif method == "read":
-            @wraps(stream.read)
+            @wraps(func)
             def read(*args, **kwargs):
-                data = stream.read(*args, **kwargs)
+                data = func(*args, **kwargs)
                 callback(len(data))
                 return data
             object.__setattr__(self, 'read', read)

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1457,7 +1457,7 @@ class tqdm(Comparable):
 
     @classmethod
     @contextmanager
-    def wrapattr(tclass, stream, method, total=None, **tkwargs):
+    def wrapattr(tclass, stream, method, total=None, bytes=True, **tkwargs):
         """
         stream  : file-like object.
         method  : str, "read" or "write". The result of `read()` and
@@ -1470,6 +1470,10 @@ class tqdm(Comparable):
         ...             break
         """
         with tclass(total=total, **tkwargs) as t:
+            if bytes:
+                t.unit = "B"
+                t.unit_scale = True
+                t.unit_divisor = 1024
             yield CallbackIOWrapper(t.update, stream, method)
 
 

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1455,32 +1455,6 @@ class tqdm(Comparable):
         if pos:
             self.moveto(-pos)
 
-    @contextmanager
-    def self_wrapattr(self, stream, method, close=True):
-        """
-        stream  : file-like object.
-        method  : str, "read" or "write". The result of `read()` and
-            the first argument of `write()` should have a `len()`.
-        close  : bool. optional. If [default: True], calls `self.close()`
-            on exit. Avoids having to use `with` on the `tqdm` object.
-            Does not affect the `stream`.
-            Consider combining `close=False` with `reset()`.
-            Otherwise, consider using `wrapattr()`.
-
-        >>> pbar = tqdm(total=file_obj.size)
-        >>> with pbar.self_wrapattr(file_obj, "read") as fobj:
-        ...     while True:
-        ...         chunk = fobj.read(chunk_size)
-        ...         if not chunk:
-        ...             break
-        """
-        try:
-            wrapped = CallbackIOWrapper(self.update, stream, method)
-            yield wrapped
-        finally:
-            if close:
-                self.close()
-
     @classmethod
     @contextmanager
     def wrapattr(tclass, stream, method, total=None, **tkwargs):
@@ -1496,8 +1470,7 @@ class tqdm(Comparable):
         ...             break
         """
         with tclass(total=total, **tkwargs) as t:
-            with t.self_wrapattr(stream, method, False) as wrapped:
-                yield wrapped
+            yield CallbackIOWrapper(t.update, stream, method)
 
 
 def trange(*args, **kwargs):

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1809,9 +1809,18 @@ def test_wrapattr():
 
     with closing(StringIO()) as our_file:
         with closing(StringIO()) as writer:
-            with tqdm.wrapattr(writer, "write", file=our_file) as wrap:
+            with tqdm.wrapattr(
+                    writer, "write", file=our_file, bytes=True) as wrap:
                 wrap.write(data)
             res = writer.getvalue()
             assert data == res
         res = our_file.getvalue()
-        assert str(len(data)) in res
+        assert ('%.1fB [' % len(data)) in res
+
+    with closing(StringIO()) as our_file:
+        with closing(StringIO()) as writer:
+            with tqdm.wrapattr(
+                    writer, "write", file=our_file, bytes=False) as wrap:
+                wrap.write(data)
+        res = our_file.getvalue()
+        assert ('%dit [' % len(data)) in res

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1800,3 +1800,18 @@ def test_auto():
     from tqdm import autonotebook, auto
     backendCheck(autonotebook)
     backendCheck(auto)
+
+
+@with_setup(pretest, posttest)
+def test_wrapattr():
+    """Test wrapping file-like objects"""
+    data = "a twenty-char string"
+
+    with closing(StringIO()) as our_file:
+        with closing(StringIO()) as writer:
+            with tqdm.wrapattr(writer, "write", file=our_file) as wrap:
+                wrap.write(data)
+            res = writer.getvalue()
+            assert data == res
+        res = our_file.getvalue()
+        assert str(len(data)) in res

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 from tqdm import trange
 from tqdm import TqdmDeprecationWarning
 from tqdm.std import Bar
-from tqdm.utils import DummyTqdmFile
+from tqdm.contrib import DummyTqdmFile
 
 try:
     from StringIO import StringIO

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 from tqdm import trange
 from tqdm import TqdmDeprecationWarning
 from tqdm.std import Bar
+from tqdm.utils import DummyTqdmFile
 
 try:
     from StringIO import StringIO
@@ -1665,19 +1666,6 @@ def test_postfix_direct():
         assert "h  6.00" in res
         assert "h  8.00" in res
         assert "j  8.00" in res
-
-
-class DummyTqdmFile(object):
-    """Dummy file-like that will write to tqdm"""
-    file = None
-
-    def __init__(self, file):
-        self.file = file
-
-    def write(self, x):
-        # Avoid print() second call (useless \n)
-        if len(x.rstrip()) > 0:
-            tqdm.write(x, file=self.file, nolock=True)
 
 
 @contextmanager

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -1,7 +1,8 @@
+from functools import wraps
 import os
-import subprocess
 from platform import system as _curos
 import re
+import subprocess
 CUR_OS = _curos()
 IS_WIN = CUR_OS in ['Windows', 'cli']
 IS_NIX = (not IS_WIN) and any(
@@ -161,28 +162,81 @@ class Comparable(object):
         return not self < other
 
 
-class SimpleTextIOWrapper(object):
+class ObjectWrapper(object):
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+    def __setattr__(self, name, value):
+        return setattr(self._wrapped, name, value)
+
+    def wrapper_getattr(self, name):
+        """Actual `self.getattr` rather than self._wrapped.getattr"""
+        try:
+            return object.__getattr__(self, name)
+        except AttributeError:  # py2
+            return getattr(self, name)
+
+    def wrapper_setattr(self, name, value):
+        """Actual `self.setattr` rather than self._wrapped.setattr"""
+        return object.__setattr__(self, name, value)
+
+    def __init__(self, wrapped):
+        """
+        Thin wrapper around a given object
+        """
+        self.wrapper_setattr('_wrapped', wrapped)
+
+
+class DummyTqdmFile(ObjectWrapper):
+    """Dummy file-like that will write to tqdm"""
+    def write(self, x, nolock=False):
+        from tqdm import tqdm
+        # Avoid print() second call (useless \n)
+        if len(x.rstrip()) > 0:
+            tqdm.write(x, file=self._wrapped, nolock=nolock)
+
+
+class SimpleTextIOWrapper(ObjectWrapper):
     """
     Change only `.write()` of the wrapped object by encoding the passed
     value and passing the result to the wrapped object's `.write()` method.
     """
     # pylint: disable=too-few-public-methods
     def __init__(self, wrapped, encoding):
-        object.__setattr__(self, '_wrapped', wrapped)
-        object.__setattr__(self, 'encoding', encoding)
+        super(SimpleTextIOWrapper, self).__init__(wrapped)
+        self.wrapper_setattr('encoding', encoding)
 
     def write(self, s):
         """
         Encode `s` and pass to the wrapped object's `.write()` method.
         """
-        return getattr(self, '_wrapped').write(s.encode(getattr(
-            self, 'encoding')))
+        return self._wrapped.write(s.encode(self.wrapper_getattr('encoding')))
 
-    def __getattr__(self, name):
-        return getattr(self._wrapped, name)
 
-    def __setattr__(self, name, value):  # pragma: no cover
-        return setattr(self._wrapped, name, value)
+class CallbackIOWrapper(ObjectWrapper):
+    def __init__(self, callback, stream, method="read"):
+        """
+        Wrap a given `file`-like object's `read()` or `write()` to report
+        lengths to the given `callback`
+        """
+        super(CallbackIOWrapper, self).__init__(stream)
+        func = getattr(stream, method)
+        if method == "write":
+            @wraps(func)
+            def write(data, *args, **kwargs):
+                res = func(data, *args, **kwargs)
+                callback(len(data))
+                return res
+            self.wrapper_setattr('write', write)
+        elif method == "read":
+            @wraps(func)
+            def read(*args, **kwargs):
+                data = func(*args, **kwargs)
+                callback(len(data))
+                return data
+            self.wrapper_setattr('read', read)
+        else:
+            raise KeyError("Can only wrap read/write methods")
 
 
 def _is_utf(encoding):

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -187,15 +187,6 @@ class ObjectWrapper(object):
         self.wrapper_setattr('_wrapped', wrapped)
 
 
-class DummyTqdmFile(ObjectWrapper):
-    """Dummy file-like that will write to tqdm"""
-    def write(self, x, nolock=False):
-        from tqdm import tqdm
-        # Avoid print() second call (useless \n)
-        if len(x.rstrip()) > 0:
-            tqdm.write(x, file=self._wrapped, nolock=nolock)
-
-
 class SimpleTextIOWrapper(ObjectWrapper):
     """
     Change only `.write()` of the wrapped object by encoding the passed


### PR DESCRIPTION
```python
# basic use
with tqdm.wrapattr(file_obj, "read", total=file_obj.size) as fobj:
    while True:
        chunk = fobj.read(chunk_size)
        if not chunk:
            break

# more bar control
from tqdm.utils import CallbackIOWrapper
with tqdm(total=file_obj.size) as t:
    fobj = CallbackIOWrapper(t.update, file_obj, "read")
    while True:
        chunk = fobj.read(chunk_size)
        if not chunk:
            break
    t.reset()
    # ... continue to use `t` for something else
```

- [x] provide class-level `wrapattr` context manager for patching `.read()` and `.write()` methods of objects
- [x] add `bytes=True` similar to CLI (`unit="B", unit_scale=True, unit_divisor=1024` but not `miniters=1`)
- [ ] document
  + [x] inline
  + [ ] readme
- [x] add tests
- [x] replace self.method
```python
pbar = tqdm(total=file_obj.size)
with pbar.self_wrapattr(file_obj, "read") as fobj:
```
with class.method
```python
with tqdm.wrapattr(file_obj, "read", total=file_obj.size) as fobj:
```
- [x] perhaps avoid `setattr` on external objects (return a new object, `CallbackIOWrapper`)?
- [x] expose `CallbackIOWrapper`
- [x] patch `DummyTqdmFile` (related to #713)
- fixes #84