### PR TITLE
next release v4.40.0

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -402,7 +402,7 @@ with the ``desc`` and ``postfix`` arguments:
 
 .. code:: python
 
-    from tqdm import trange
+    from tqdm import tqdm, trange
     from random import random, randint
     from time import sleep
 

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -545,7 +545,7 @@ Hooks and callbacks
 ``tqdm`` can easily support callbacks/hooks and manual updates.
 Here's an example with ``urllib``:
 
-**urllib.urlretrieve documentation**
+**``urllib.urlretrieve`` documentation**
 
     | [...]
     | If present, the hook function will be called once
@@ -587,6 +587,41 @@ Functional alternative in
 It is recommend to use ``miniters=1`` whenever there is potentially
 large differences in iteration speed (e.g. downloading a file over
 a patchy connection).
+
+**Wrapping read/write methods**
+
+To measure throughput through a file-like object's ``read`` or ``write``
+methods, use ``CallbackIOWrapper``:
+
+.. code:: python
+
+    from tqdm import tqdm
+    from tqdm.utils import CallbackIOWrapper
+
+    with tqdm(total=file_obj.size,
+              unit='B', unit_scale=True, unit_divisor=1024) as t:
+        fobj = CallbackIOWrapper(t.update, file_obj, "read")
+        while True:
+            chunk = fobj.read(chunk_size)
+            if not chunk:
+                break
+        t.reset()
+        # ... continue to use `t` for something else
+
+Alternatively, use the even simpler ``wrapattr`` convenience function,
+which would condense both the ``urllib`` and ``CallbackIOWrapper`` examples
+down to:
+
+.. code:: python
+
+    import urllib, os
+    from tqdm import tqdm
+
+    eg_link = "https://caspersci.uk.to/matryoshka.zip"
+    with tqdm.wrapattr(open(os.devnull, "wb"), "write",
+                       miniters=1, desc=eg_link.split('/')[-1]) as fout:
+        for chunk in urllib.urlopen(eg_link):
+            fout.write(chunk)
 
 Pandas Integration
 ~~~~~~~~~~~~~~~~~~
@@ -783,20 +818,8 @@ A reusable canonical example is given below:
     import contextlib
     import sys
     from tqdm import tqdm
+    from tqdm.contrib import DummyTqdmFile
 
-    class DummyTqdmFile(object):
-        """Dummy file-like that will write to tqdm"""
-        file = None
-        def __init__(self, file):
-            self.file = file
-
-        def write(self, x):
-            # Avoid print() second call (useless \n)
-            if len(x.rstrip()) > 0:
-                tqdm.write(x, file=self.file)
-
-        def flush(self):
-            return getattr(self.file, "flush", lambda: None)()
 
         def isatty(self):
             return getattr(self.file, "isatty", lambda: False)()

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -821,9 +821,6 @@ A reusable canonical example is given below:
     from tqdm.contrib import DummyTqdmFile
 
 
-        def isatty(self):
-            return getattr(self.file, "isatty", lambda: False)()
-
     @contextlib.contextmanager
     def std_out_err_redirect_tqdm():
         orig_out_err = sys.stdout, sys.stderr

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -102,9 +102,13 @@ Latest Snapcraft release
 
 |Snapcraft|
 
+There are 3 channels to choose from:
+
 .. code:: sh
 
-    snap install tqdm
+    snap install tqdm  # implies --stable, i.e. latest tagged release
+    snap install tqdm  --candidate  # master branch
+    snap install tqdm  --edge  # devel branch
 
 Latest Docker release
 ~~~~~~~~~~~~~~~~~~~~~

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,13 @@ jobs:
     deploy:
     - provider: snap
       snap: tqdm*.snap
-      channel: ${SOURCE_TAG:+stable}${SOURCE_TAG:-candidate}
+      channel: stable
+      skip_cleanup: true
+      on:
+        tags: true
+    - provider: snap
+      snap: tqdm*.snap
+      channel: candidate
       skip_cleanup: true
     - provider: snap
       snap: tqdm*.snap

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,7 +334,7 @@ For experienced devs, once happy with local master:
     a) `make -B docker`
     b) `docker push tqdm/tqdm:latest`
     c) `docker push tqdm/tqdm:$(docker run -i --rm tqdm/tqdm -v)`
-11. upload to snapcraft:
+11. **`[AUTO:TravisCI]`** upload to snapcraft:
     a) `make snap`, and
     b) `snapcraft push tqdm*.snap --release stable`
 12. Wait for travis to draft a new release on <https://github.com/tqdm/tqdm/releases>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,9 @@ include logo.png
 include Makefile
 include tox.ini
 
+# Non-std submodules
+recursive-include tqdm/contrib *.py
+
 # Test suite
 recursive-include tqdm/tests *.py
 include requirements-dev.txt

--- a/README.rst
+++ b/README.rst
@@ -1003,9 +1003,6 @@ A reusable canonical example is given below:
     from tqdm.contrib import DummyTqdmFile
 
 
-        def isatty(self):
-            return getattr(self.file, "isatty", lambda: False)()
-
     @contextlib.contextmanager
     def std_out_err_redirect_tqdm():
         orig_out_err = sys.stdout, sys.stderr

--- a/README.rst
+++ b/README.rst
@@ -102,9 +102,13 @@ Latest Snapcraft release
 
 |Snapcraft|
 
+There are 3 channels to choose from:
+
 .. code:: sh
 
-    snap install tqdm
+    snap install tqdm  # implies --stable, i.e. latest tagged release
+    snap install tqdm  --candidate  # master branch
+    snap install tqdm  --edge  # devel branch
 
 Latest Docker release
 ~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -322,14 +322,14 @@ Parameters
     Leave blank to manually manage the updates.
 * desc  : str, optional  
     Prefix for the progressbar.
-* total  : int, optional  
+* total  : int or float, optional  
     The number of expected iterations. If unspecified,
     len(iterable) is used if possible. If float("inf") or as a last
     resort, only basic progress statistics are displayed
     (no ETA, no progressbar).
     If ``gui`` is True and this parameter needs subsequent updating,
-    specify an initial arbitrary large positive integer,
-    e.g. int(9e9).
+    specify an initial arbitrary large positive number,
+    e.g. 9e9.
 * leave  : bool, optional  
     If [default: True], keeps all traces of the progressbar
     upon termination of iteration.
@@ -351,7 +351,7 @@ Parameters
     Automatically adjusts ``miniters`` to correspond to ``mininterval``
     after long display update lag. Only works if ``dynamic_miniters``
     or monitor thread is enabled.
-* miniters  : int, optional  
+* miniters  : int or float, optional  
     Minimum progress display update interval, in iterations.
     If 0 and ``dynamic_miniters``, will automatically adjust to equal
     ``mininterval`` (more CPU efficient, good for tight loops).
@@ -394,9 +394,10 @@ Parameters
     remaining, remaining_s.
     Note that a trailing ": " is automatically removed after {desc}
     if the latter is empty.
-* initial  : int, optional  
+* initial  : int or float, optional  
     The initial counter value. Useful when restarting a progress
-    bar [default: 0].
+    bar [default: 0]. If using float, consider specifying ``{n:.3f}``
+    or similar in ``bar_format``, or specifying ``unit_scale``.
 * position  : int, optional  
     Specify the line offset to print this bar (starting from 0)
     Automatic if unspecified.
@@ -455,9 +456,10 @@ Returns
 
           Parameters
           ----------
-          n  : int, optional
+          n  : int or float, optional
               Increment to add to the internal counter of iterations
-              [default: 1].
+              [default: 1]. If using float, consider specifying ``{n:.3f}``
+              or similar in ``bar_format``, or specifying ``unit_scale``.
           """
 
       def close(self):
@@ -491,7 +493,7 @@ Returns
 
           Parameters
           ----------
-          total  : int, optional. Total to use for the new bar.
+          total  : int or float, optional. Total to use for the new bar.
           """
 
       def set_description(self, desc=None, refresh=True):

--- a/README.rst
+++ b/README.rst
@@ -584,7 +584,7 @@ with the ``desc`` and ``postfix`` arguments:
 
 .. code:: python
 
-    from tqdm import trange
+    from tqdm import tqdm, trange
     from random import random, randint
     from time import sleep
 

--- a/README.rst
+++ b/README.rst
@@ -727,7 +727,7 @@ Hooks and callbacks
 ``tqdm`` can easily support callbacks/hooks and manual updates.
 Here's an example with ``urllib``:
 
-**urllib.urlretrieve documentation**
+**``urllib.urlretrieve`` documentation**
 
     | [...]
     | If present, the hook function will be called once
@@ -769,6 +769,41 @@ Functional alternative in
 It is recommend to use ``miniters=1`` whenever there is potentially
 large differences in iteration speed (e.g. downloading a file over
 a patchy connection).
+
+**Wrapping read/write methods**
+
+To measure throughput through a file-like object's ``read`` or ``write``
+methods, use ``CallbackIOWrapper``:
+
+.. code:: python
+
+    from tqdm import tqdm
+    from tqdm.utils import CallbackIOWrapper
+
+    with tqdm(total=file_obj.size,
+              unit='B', unit_scale=True, unit_divisor=1024) as t:
+        fobj = CallbackIOWrapper(t.update, file_obj, "read")
+        while True:
+            chunk = fobj.read(chunk_size)
+            if not chunk:
+                break
+        t.reset()
+        # ... continue to use `t` for something else
+
+Alternatively, use the even simpler ``wrapattr`` convenience function,
+which would condense both the ``urllib`` and ``CallbackIOWrapper`` examples
+down to:
+
+.. code:: python
+
+    import urllib, os
+    from tqdm import tqdm
+
+    eg_link = "https://caspersci.uk.to/matryoshka.zip"
+    with tqdm.wrapattr(open(os.devnull, "wb"), "write",
+                       miniters=1, desc=eg_link.split('/')[-1]) as fout:
+        for chunk in urllib.urlopen(eg_link):
+            fout.write(chunk)
 
 Pandas Integration
 ~~~~~~~~~~~~~~~~~~
@@ -965,20 +1000,8 @@ A reusable canonical example is given below:
     import contextlib
     import sys
     from tqdm import tqdm
+    from tqdm.contrib import DummyTqdmFile
 
-    class DummyTqdmFile(object):
-        """Dummy file-like that will write to tqdm"""
-        file = None
-        def __init__(self, file):
-            self.file = file
-
-        def write(self, x):
-            # Avoid print() second call (useless \n)
-            if len(x.rstrip()) > 0:
-                tqdm.write(x, file=self.file)
-
-        def flush(self):
-            return getattr(self.file, "flush", lambda: None)()
 
         def isatty(self):
             return getattr(self.file, "isatty", lambda: False)()

--- a/examples/redirect_print.py
+++ b/examples/redirect_print.py
@@ -15,22 +15,7 @@ from time import sleep
 import contextlib
 import sys
 from tqdm import tqdm
-
-
-class DummyTqdmFile(object):
-    """Dummy file-like that will write to tqdm"""
-    file = None
-
-    def __init__(self, file):
-        self.file = file
-
-    def write(self, x):
-        # Avoid print() second call (useless \n)
-        if len(x.rstrip()) > 0:
-            tqdm.write(x, file=self.file)
-
-    def flush(self):
-        return getattr(self.file, "flush", lambda: None)()
+from tqdm.contrib import DummyTqdmFile
 
     def isatty(self):
         return getattr(self.file, "isatty", lambda: False)()

--- a/examples/redirect_print.py
+++ b/examples/redirect_print.py
@@ -17,9 +17,6 @@ import sys
 from tqdm import tqdm
 from tqdm.contrib import DummyTqdmFile
 
-    def isatty(self):
-        return getattr(self.file, "isatty", lambda: False)()
-
 
 @contextlib.contextmanager
 def std_out_err_redirect_tqdm():

--- a/examples/tqdm_wget.py
+++ b/examples/tqdm_wget.py
@@ -95,3 +95,9 @@ with TqdmUpTo(unit='B', unit_scale=True, unit_divisor=1024, miniters=1,
               desc=eg_file) as t:  # all optional kwargs
     urllib.urlretrieve(eg_link, filename=eg_out, reporthook=t.update_to,
                        data=None)
+
+# Even simpler progress by wrapping the output file's `write()`
+with tqdm.wrapattr(open(eg_out, "wb"), "write",
+                   miniters=1, desc=eg_file) as fout:
+    for chunk in urllib.urlopen(eg_link):
+        fout.write(chunk)

--- a/tqdm/contrib/__init__.py
+++ b/tqdm/contrib/__init__.py
@@ -1,0 +1,10 @@
+from tqdm import tqdm
+from tqdm.utils import ObjectWrapper
+
+
+class DummyTqdmFile(ObjectWrapper):
+    """Dummy file-like that will write to tqdm"""
+    def write(self, x, nolock=False):
+        # Avoid print() second call (useless \n)
+        if len(x.rstrip()) > 0:
+            tqdm.write(x, file=self._wrapped, nolock=nolock)

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -32,32 +32,25 @@ if True:  # pragma: no cover
         IPY = 32
         import warnings
         with warnings.catch_warnings():
-            ipy_deprecation_msg = "The `IPython.html` package" \
-                                  " has been deprecated"
-            warnings.filterwarnings('error',
-                                    message=".*" + ipy_deprecation_msg + ".*")
+            warnings.filterwarnings(
+                'ignore',
+                message=".*The `IPython.html` package has been deprecated.*")
             try:
                 import IPython.html.widgets as ipywidgets
-            except Warning as e:
-                if ipy_deprecation_msg not in str(e):
-                    raise
-                warnings.simplefilter('ignore')
-                try:
-                    import IPython.html.widgets as ipywidgets  # NOQA
-                except ImportError:
-                    pass
             except ImportError:
                 pass
 
     try:  # IPython 4.x / 3.x
         if IPY == 32:
-            from IPython.html.widgets import IntProgress, HBox, HTML
+            from IPython.html.widgets import FloatProgress as IProgress
+            from IPython.html.widgets import HBox, HTML
             IPY = 3
         else:
-            from ipywidgets import IntProgress, HBox, HTML
+            from ipywidgets import FloatProgress as IProgress
+            from ipywidgets import HBox, HTML
     except ImportError:
         try:  # IPython 2.x
-            from IPython.html.widgets import IntProgressWidget as IntProgress
+            from IPython.html.widgets import FloatProgressWidget as IProgress
             from IPython.html.widgets import ContainerWidget as HBox
             from IPython.html.widgets import HTML
             IPY = 2
@@ -100,15 +93,15 @@ class tqdm_notebook(std_tqdm):
         # Prepare IPython progress bar
         try:
             if total:
-                pbar = IntProgress(min=0, max=total)
+                pbar = IProgress(min=0, max=total)
             else:  # No total? Show info style bar with no progress tqdm status
-                pbar = IntProgress(min=0, max=1)
+                pbar = IProgress(min=0, max=1)
                 pbar.value = 1
                 pbar.bar_style = 'info'
         except NameError:
             # #187 #451 #558
             raise ImportError(
-                "IntProgress not found. Please update jupyter and ipywidgets."
+                "FloatProgress not found. Please update jupyter and ipywidgets."
                 " See https://ipywidgets.readthedocs.io/en/stable"
                 "/user_install.html")
 

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -464,10 +464,11 @@ class tqdm(Comparable):
                 bar_format = "{l_bar}{bar}{r_bar}"
 
             full_bar = FormatReplace()
-            if _is_ascii(bar_format) and any(
-                    not _is_ascii(i) for i in format_dict.values()):
+            try:
+                nobar = bar_format.format(bar=full_bar, **format_dict)
+            except UnicodeEncodeError:
                 bar_format = _unicode(bar_format)
-            nobar = bar_format.format(bar=full_bar, **format_dict)
+                nobar = bar_format.format(bar=full_bar, **format_dict)
             if not full_bar.format_called:
                 # no {bar}, we can just format and return
                 return nobar

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -7,9 +7,7 @@ Usage:
   >>> for i in trange(10): #same as: for i in tqdm(xrange(10))
   ...     ...
 """
-from __future__ import absolute_import
-# integer division / : float, // : int
-from __future__ import division
+from __future__ import absolute_import, division
 # compatibility functions and utilities
 from .utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, _text_width, \
@@ -315,11 +313,11 @@ class tqdm(Comparable):
 
         Parameters
         ----------
-        n  : int
+        n  : int or float
             Number of finished iterations.
-        total  : int
-            The expected total number of iterations. If meaningless (), only
-            basic progress statistics are displayed (no ETA).
+        total  : int or float
+            The expected total number of iterations. If meaningless (None),
+            only basic progress statistics are displayed (no ETA).
         elapsed  : float
             Number of seconds passed since start.
         ncols  : int, optional
@@ -786,14 +784,14 @@ class tqdm(Comparable):
             Leave blank to manually manage the updates.
         desc  : str, optional
             Prefix for the progressbar.
-        total  : int, optional
+        total  : int or float, optional
             The number of expected iterations. If unspecified,
             len(iterable) is used if possible. If float("inf") or as a last
             resort, only basic progress statistics are displayed
             (no ETA, no progressbar).
             If `gui` is True and this parameter needs subsequent updating,
-            specify an initial arbitrary large positive integer,
-            e.g. int(9e9).
+            specify an initial arbitrary large positive number,
+            e.g. 9e9.
         leave  : bool, optional
             If [default: True], keeps all traces of the progressbar
             upon termination of iteration.
@@ -815,7 +813,7 @@ class tqdm(Comparable):
             Automatically adjusts `miniters` to correspond to `mininterval`
             after long display update lag. Only works if `dynamic_miniters`
             or monitor thread is enabled.
-        miniters  : int, optional
+        miniters  : int or float, optional
             Minimum progress display update interval, in iterations.
             If 0 and `dynamic_miniters`, will automatically adjust to equal
             `mininterval` (more CPU efficient, good for tight loops).
@@ -858,9 +856,10 @@ class tqdm(Comparable):
               remaining, remaining_s.
             Note that a trailing ": " is automatically removed after {desc}
             if the latter is empty.
-        initial  : int, optional
+        initial  : int or float, optional
             The initial counter value. Useful when restarting a progress
-            bar [default: 0].
+            bar [default: 0]. If using float, consider specifying `{n:.3f}`
+            or similar in `bar_format`, or specifying `unit_scale`.
         position  : int, optional
             Specify the line offset to print this bar (starting from 0)
             Automatic if unspecified.
@@ -1161,9 +1160,10 @@ class tqdm(Comparable):
 
         Parameters
         ----------
-        n  : int, optional
+        n  : int or float, optional
             Increment to add to the internal counter of iterations
-            [default: 1].
+            [default: 1]. If using float, consider specifying `{n:.3f}`
+            or similar in `bar_format`, or specifying `unit_scale`.
         """
         # N.B.: see __iter__() for more comments.
         if self.disable:
@@ -1315,7 +1315,7 @@ class tqdm(Comparable):
 
         Parameters
         ----------
-        total  : int, optional. Total to use for the new bar.
+        total  : int or float, optional. Total to use for the new bar.
         """
         self.last_print_n = self.n = 0
         self.last_print_t = self.start_t = self._time()

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -464,6 +464,9 @@ class tqdm(Comparable):
                 bar_format = "{l_bar}{bar}{r_bar}"
 
             full_bar = FormatReplace()
+            if _is_ascii(bar_format) and any(
+                    not _is_ascii(i) for i in format_dict.values()):
+                bar_format = _unicode(bar_format)
             nobar = bar_format.format(bar=full_bar, **format_dict)
             if not full_bar.format_called:
                 # no {bar}, we can just format and return

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -370,7 +370,7 @@ class tqdm(Comparable):
         """
 
         # sanity check: total
-        if total and n > total:
+        if total and n >= (total + 0.5):  # allow float imprecision (#849)
             total = None
 
         # apply custom scale if necessary

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 from tqdm import trange
 from tqdm import TqdmDeprecationWarning
 from tqdm.std import Bar
+from tqdm.contrib import DummyTqdmFile
 
 try:
     from StringIO import StringIO
@@ -1672,19 +1673,6 @@ def test_postfix_direct():
         assert "j  8.00" in res
 
 
-class DummyTqdmFile(object):
-    """Dummy file-like that will write to tqdm"""
-    file = None
-
-    def __init__(self, file):
-        self.file = file
-
-    def write(self, x):
-        # Avoid print() second call (useless \n)
-        if len(x.rstrip()) > 0:
-            tqdm.write(x, file=self.file, nolock=True)
-
-
 @contextmanager
 def std_out_err_redirect_tqdm(tqdm_file=sys.stderr):
     orig_out_err = sys.stdout, sys.stderr
@@ -1805,3 +1793,27 @@ def test_auto():
     from tqdm import autonotebook, auto
     backendCheck(autonotebook)
     backendCheck(auto)
+
+
+@with_setup(pretest, posttest)
+def test_wrapattr():
+    """Test wrapping file-like objects"""
+    data = "a twenty-char string"
+
+    with closing(StringIO()) as our_file:
+        with closing(StringIO()) as writer:
+            with tqdm.wrapattr(
+                    writer, "write", file=our_file, bytes=True) as wrap:
+                wrap.write(data)
+            res = writer.getvalue()
+            assert data == res
+        res = our_file.getvalue()
+        assert ('%.1fB [' % len(data)) in res
+
+    with closing(StringIO()) as our_file:
+        with closing(StringIO()) as writer:
+            with tqdm.wrapattr(
+                    writer, "write", file=our_file, bytes=False) as wrap:
+                wrap.write(data)
+        res = our_file.getvalue()
+        assert ('%dit [' % len(data)) in res

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1314,6 +1314,11 @@ def test_set_description():
             assert t.desc == ''
         assert "World" not in our_file.getvalue()
 
+    # unicode
+    with closing(StringIO()) as our_file:
+        with tqdm(total=10, file=our_file) as t:
+            t.set_description(u"\xe1\xe9\xed\xf3\xfa")
+
 
 @with_setup(pretest, posttest)
 def test_deprecated_gui():


### PR DESCRIPTION
- officially support `float` for `n` and `total` (#802)
  + `notebook`: use `FloatProgress` <= `IntProgress` (#471, #456)
  + allow imprecision (`n <= total + epsilon`) (#849)
- fix unicode bar format arguments (#803 -> #851)
- add `contrib` submodule (#815)
- add `wrapattr`, `utils.CallbackIOWrapper`, `contrib.DummyTqdmFile` (#84 -> #844)
- update tests
- update documentation
- tidy automatic `snap` deployments
- minor doc update (#854)