### PR TITLE
added a missing import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -584,7 +584,7 @@ with the ``desc`` and ``postfix`` arguments:
 
 .. code:: python
 
-    from tqdm import trange
+    from tqdm import tqdm, trange
     from random import random, randint
     from time import sleep
 


### PR DESCRIPTION
added from tqdm import tqdm in the first example of Description and additional stats. Required import for working of second part of code.

- [ ] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] visual output fix
    + [x] documentation modification
    + [ ] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [ ] I have visited the [source website], and in particular
  read the [known issues]
- [ ] I have searched through the [issue tracker] for duplicates
- [ ] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
