### PR TITLE
next release v4.41.0

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -378,6 +378,8 @@ Returns
     def tqdm.notebook.trange(*args, **kwargs):
         """Experimental IPython/Jupyter Notebook widget version of trange"""
 
+    class tqdm.keras.TqdmCallback(keras.callbacks.Callback):
+        """`keras` callback for epoch and batch progress"""
 
 Examples and Advanced Usage
 ---------------------------
@@ -651,6 +653,19 @@ In case you're interested in how this works (and how to modify it for your
 own callbacks), see the
 `examples <https://github.com/tqdm/tqdm/tree/master/examples>`__
 folder or import the module and run ``help()``.
+
+Keras Integration
+~~~~~~~~~~~~~~~~~
+
+A ``keras`` callback is also available:
+
+.. code:: python
+
+    from tqdm.keras import TqdmCallback
+
+    ...
+
+    model.fit(..., callbacks=[TqdmCallback()])
 
 IPython/Jupyter Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -675,6 +675,9 @@ light blue: no ETA); as demonstrated below.
 |Screenshot-Jupyter2|
 |Screenshot-Jupyter3|
 
+The ``notebook`` version supports percentage or pixels for overall width
+(e.g.: ``ncols='100%'`` or ``ncols='480px'``).
+
 It is also possible to let ``tqdm`` automatically choose between
 console or notebook versions by using the ``autonotebook`` submodule:
 

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -665,7 +665,7 @@ A ``keras`` callback is also available:
 
     ...
 
-    model.fit(..., callbacks=[TqdmCallback()])
+    model.fit(..., verbose=0, callbacks=[TqdmCallback()])
 
 IPython/Jupyter Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ stages:
 - name: deploy
   if: repo = tqdm/tqdm
 jobs:
+  allow_failures:
+  - os: windows
+  - os: osx
   include:
   - stage: test
     name: py2.6
@@ -50,6 +53,41 @@ jobs:
   - name: pypy3.5
     python: pypy3.5-5.10.0
     env: TOXENV=pypy3
+  - name: py2.7-win
+    os: windows
+    language: shell
+    env: TOXENV=py27
+    before_install: &before_install_win
+    - |
+      if [[ "$TOXENV" == "py37" ]]; then
+        choco install python --version 3.7.4
+        export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+      else
+        choco install python2
+        export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
+      fi
+    - python -m pip install -U pip setuptools wheel
+    install: &install_win
+    - python -m pip install tox
+    - python -m pip install .
+    script: &script_win
+    - python -m tox
+  - name: py3.7-win
+    os: windows
+    language: shell
+    env: TOXENV=py37
+    before_install: *before_install_win
+    install: *install_win
+    script: *script_win
+  - name: py2.7-osx
+    os: osx
+    language: shell
+    env: TOXENV=py27
+  - name: py3.7-osx
+    os: osx
+    osx_image: xcode11.2  # py3.7
+    language: shell
+    env: TOXENV=py37
   - stage: check
     name: style
     python: 3.7

--- a/README.rst
+++ b/README.rst
@@ -560,6 +560,8 @@ Returns
     def tqdm.notebook.trange(*args, **kwargs):
         """Experimental IPython/Jupyter Notebook widget version of trange"""
 
+    class tqdm.keras.TqdmCallback(keras.callbacks.Callback):
+        """`keras` callback for epoch and batch progress"""
 
 Examples and Advanced Usage
 ---------------------------
@@ -833,6 +835,19 @@ In case you're interested in how this works (and how to modify it for your
 own callbacks), see the
 `examples <https://github.com/tqdm/tqdm/tree/master/examples>`__
 folder or import the module and run ``help()``.
+
+Keras Integration
+~~~~~~~~~~~~~~~~~
+
+A ``keras`` callback is also available:
+
+.. code:: python
+
+    from tqdm.keras import TqdmCallback
+
+    ...
+
+    model.fit(..., callbacks=[TqdmCallback()])
 
 IPython/Jupyter Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -847,7 +847,7 @@ A ``keras`` callback is also available:
 
     ...
 
-    model.fit(..., callbacks=[TqdmCallback()])
+    model.fit(..., verbose=0, callbacks=[TqdmCallback()])
 
 IPython/Jupyter Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -857,6 +857,9 @@ light blue: no ETA); as demonstrated below.
 |Screenshot-Jupyter2|
 |Screenshot-Jupyter3|
 
+The ``notebook`` version supports percentage or pixels for overall width
+(e.g.: ``ncols='100%'`` or ``ncols='480px'``).
+
 It is also possible to let ``tqdm`` automatically choose between
 console or notebook versions by using the ``autonotebook`` submodule:
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,8 @@ deps =
     cython
     numpy
     pandas
+    tensorflow
+    keras
 commands = {[extra]commands}
 
 # no cython/numpy/pandas for py{py,py3,26,33,34}

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -1,0 +1,82 @@
+from __future__ import absolute_import
+from .auto import tqdm as tqdm_auto
+from copy import deepcopy
+from keras.callbacks import Callback
+
+
+class TqdmCallback(Callback):
+    """`keras` callback for epoch and batch progress"""
+    @staticmethod
+    def bar2callback(bar, pop=None, delta=(lambda logs: 1)):
+        def callback(_, logs=None):
+            if logs:
+                if pop:
+                    logs = deepcopy(logs)
+                    [logs.pop(i) for i in pop]
+                bar.set_postfix(logs, refresh=False)
+            bar.update(delta(logs))
+
+        return callback
+
+    def __init__(self, epochs=None, data_size=None, batch_size=None, verbose=1,
+                 tqdm_class=tqdm_auto):
+        """
+        Parameters
+        ----------
+        epochs  : int, optional
+        data_size  : int, optional
+            Number of training pairs.
+        batch_size  : int, optional
+            Number of training pairs per batch.
+        verbose  : int
+            0: epoch, 1: batch (transient), 2: batch. [default: 1].
+            Will be set to `0` unless both `data_size` and `batch_size`
+            are given.
+        tqdm_class : optional
+            `tqdm` class to use for bars [default: `tqdm.auto.tqdm`].
+        """
+        self.tqdm_class = tqdm_class
+        self.epoch_bar = tqdm_class(total=epochs, unit='epoch')
+        self.on_epoch_end = self.bar2callback(self.epoch_bar)
+        if data_size and batch_size:
+            self.batches = batches = (data_size + batch_size - 1) // batch_size
+        else:
+            self.batches = batches = None
+        self.verbose = verbose
+        if verbose == 1:
+            self.batch_bar = tqdm_class(total=batches, unit='batch',
+                                        leave=False)
+            self.on_batch_end = self.bar2callback(
+                self.batch_bar,
+                pop=['batch'],
+                delta=lambda logs: logs.get('size', 1))
+
+    def on_train_begin(self, *_, **__):
+        params = self.params.get
+        auto_total = params('epochs', params('nb_epoch', None))
+        if auto_total is not None:
+            self.epoch_bar.reset(total=auto_total)
+
+    def on_epoch_begin(self, *_, **__):
+        if self.verbose:
+            params = self.params.get
+            total = params('samples', params(
+                'nb_sample', params('steps', None))) or self.batches
+            if self.verbose == 2:
+                if hasattr(self, 'batch_bar'):
+                    self.batch_bar.close()
+                self.batch_bar = self.tqdm_class(
+                    total=total, unit='batch', leave=True)
+                self.on_batch_end = self.bar2callback(
+                    self.batch_bar,
+                    pop=['batch'],
+                    delta=lambda logs: logs.get('size', 1))
+            elif self.verbose == 1:
+                self.batch_bar.reset(total=total)
+            else:
+                raise KeyError('Unknown verbosity')
+
+    def on_train_end(self, *_, **__):
+        if self.verbose:
+            self.batch_bar.close()
+        self.epoch_bar.close()

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -247,6 +247,21 @@ class tqdm_notebook(std_tqdm):
         # void -> avoid extraneous `\n` in IPython output cell
         return
 
+    def reset(self, total=None):
+        """
+        Resets to 0 iterations for repeated use.
+
+        Consider combining with `leave=True`.
+
+        Parameters
+        ----------
+        total  : int or float, optional. Total to use for the new bar.
+        """
+        if total is not None:
+            pbar, _ = self.container.children
+            pbar.max = total
+        return super(tqdm_notebook, self).reset(total=total)
+
 
 def tnrange(*args, **kwargs):
     """

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -10,8 +10,8 @@ Usage:
 from __future__ import absolute_import, division
 # compatibility functions and utilities
 from .utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
-    _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, _text_width, \
-    Comparable, RE_ANSI, _is_ascii, FormatReplace, \
+    _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
+    Comparable, _is_ascii, FormatReplace, disp_len, disp_trim, \
     SimpleTextIOWrapper, CallbackIOWrapper
 from ._monitor import TMonitor
 # native libraries
@@ -479,12 +479,13 @@ class tqdm(Comparable):
             # Formatting progress bar space available for bar's display
             full_bar = Bar(
                 frac,
-                max(1, ncols - _text_width(RE_ANSI.sub('', nobar)))
+                max(1, ncols - disp_len(nobar))
                 if ncols else 10,
                 charset=Bar.ASCII if ascii is True else ascii or Bar.UTF)
             if not _is_ascii(full_bar.charset) and _is_ascii(bar_format):
                 bar_format = _unicode(bar_format)
-            return bar_format.format(bar=full_bar, **format_dict)
+            res = bar_format.format(bar=full_bar, **format_dict)
+            return disp_trim(res, ncols) if ncols else res
 
         elif bar_format:
             # user-specified bar_format but no total
@@ -496,10 +497,11 @@ class tqdm(Comparable):
                 return nobar
             full_bar = Bar(
                 0,
-                max(1, ncols - _text_width(RE_ANSI.sub('', nobar)))
+                max(1, ncols - disp_len(nobar))
                 if ncols else 10,
                 charset=Bar.BLANK)
-            return bar_format.format(bar=full_bar, **format_dict)
+            res = bar_format.format(bar=full_bar, **format_dict)
+            return disp_trim(res, ncols) if ncols else res
         else:
             # no total: no progressbar, ETA, just progress stats
             return ((prefix + ": ") if prefix else '') + \

--- a/tqdm/tests/tests_keras.py
+++ b/tqdm/tests/tests_keras.py
@@ -1,0 +1,92 @@
+from tqdm import tqdm
+from tests_tqdm import with_setup, pretest, posttest, SkipTest, StringIO, \
+    closing
+
+
+@with_setup(pretest, posttest)
+def test_keras():
+    """Test tqdm.keras.TqdmCallback"""
+    try:
+        from tqdm.keras import TqdmCallback
+        import numpy as np
+        import keras as K
+    except ImportError:
+        raise SkipTest
+
+    # 1D autoencoder
+    dtype = np.float32
+    model = K.models.Sequential(
+        [K.layers.InputLayer((1, 1), dtype=dtype), K.layers.Conv1D(1, 1)]
+    )
+    model.compile("adam", "mse")
+    x = np.random.rand(100, 1, 1).astype(dtype)
+    batch_size = 10
+    epochs = 5
+
+    with closing(StringIO()) as our_file:
+
+        class Tqdm(tqdm):
+            """redirected I/O class"""
+
+            def __init__(self, *a, **k):
+                k.setdefault("file", our_file)
+                super(Tqdm, self).__init__(*a, **k)
+
+        # just epoch (no batch) progress
+        model.fit(
+            x,
+            x,
+            epochs=epochs,
+            batch_size=batch_size,
+            verbose=False,
+            callbacks=[
+                TqdmCallback(
+                    epochs,
+                    data_size=len(x),
+                    batch_size=batch_size,
+                    verbose=0,
+                    tqdm_class=Tqdm,
+                )
+            ],
+        )
+        res = our_file.getvalue()
+        assert res.count("100%") == 1
+        assert "{epochs}/{epochs}".format(epochs=epochs) in res
+
+        # full (epoch and batch) progress
+        our_file.seek(0)
+        our_file.truncate()
+        model.fit(
+            x,
+            x,
+            epochs=epochs,
+            batch_size=batch_size,
+            verbose=False,
+            callbacks=[
+                TqdmCallback(
+                    epochs,
+                    data_size=len(x),
+                    batch_size=batch_size,
+                    verbose=2,
+                    tqdm_class=Tqdm,
+                )
+            ],
+        )
+        res = our_file.getvalue()
+        assert res.count("100%") >= epochs + 1
+        assert "{epochs}/{epochs}".format(epochs=epochs) in res
+
+        # auto-detect epochs and batches
+        our_file.seek(0)
+        our_file.truncate()
+        model.fit(
+            x,
+            x,
+            epochs=epochs,
+            batch_size=batch_size,
+            verbose=False,
+            callbacks=[TqdmCallback(verbose=2, tqdm_class=Tqdm)],
+        )
+        res = our_file.getvalue()
+        assert res.count("100%") >= epochs + 1
+        assert "{epochs}/{epochs}".format(epochs=epochs) in res

--- a/tqdm/tests/tests_main.py
+++ b/tqdm/tests/tests_main.py
@@ -4,9 +4,10 @@ from os import path
 from shutil import rmtree
 from tempfile import mkdtemp
 from tqdm.cli import main, TqdmKeyError, TqdmTypeError
+from tqdm.utils import IS_WIN
 
 from tests_tqdm import with_setup, pretest, posttest, _range, closing, \
-    UnicodeIO, StringIO
+    UnicodeIO, StringIO, SkipTest
 
 
 def _sh(*cmd, **kwargs):
@@ -82,6 +83,8 @@ def test_main():
 
 def test_manpath():
     """Test CLI --manpath"""
+    if IS_WIN:
+        raise SkipTest
     tmp = mkdtemp()
     man = path.join(tmp, "tqdm.1")
     assert not path.exists(man)

--- a/tqdm/tests/tests_synchronisation.py
+++ b/tqdm/tests/tests_synchronisation.py
@@ -3,7 +3,9 @@ from tqdm import tqdm, trange, TMonitor
 from tests_tqdm import with_setup, pretest, posttest, SkipTest, \
     StringIO, closing
 from tests_tqdm import DiscreteTimer, cpu_timify
+from tests_perf import retry_on_except
 
+import sys
 from time import sleep
 from threading import Event
 
@@ -188,6 +190,8 @@ def test_imap():
     assert res[-1] == 100
 
 
+# py2: locks won't propagate to incr_bar so may cause `AttributeError`
+@retry_on_except(n=3 if sys.version_info < (3,) else 1)
 @with_setup(pretest, posttest)
 def test_threadpool():
     """Test concurrent.futures.ThreadPoolExecutor"""

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -343,3 +343,27 @@ else:
     def _text_width(s):
         return sum(
             2 if east_asian_width(ch) in 'FW' else 1 for ch in _unicode(s))
+
+
+def disp_len(data):
+    """
+    Returns the real on-screen length of a string which may contain
+    ANSI control codes and wide chars.
+    """
+    return _text_width(RE_ANSI.sub('', data))
+
+
+def disp_trim(data, length):
+    """
+    Trim a string which may contain ANSI control characters.
+    """
+    if len(data) == disp_len(data):
+        return data[:length]
+
+    ansi_present = bool(RE_ANSI.search(data))
+    while disp_len(data) > length:  # carefully delete one char at a time
+        data = data[:-1]
+    if ansi_present and bool(RE_ANSI.search(data)):
+        # assume ANSI reset is required
+        return data if data.endswith("\033[0m") else data + "\033[0m"
+    return data


### PR DESCRIPTION
- trim on `ncols` overflow with ANSI handling (#850, #716 <- #690)
- add `notebook.reset()` (#864)
- add `keras.TqdmCallback` (#867 <- #835)
- documentation updates
  + document newly added features (above)
  + notebook `ncols` percentage/pixels (#276)
- test updates
  + test newly added features (above)
  + add CI for `win` and `osx` (#841)
  + `py2` threading