### PR TITLE
Notebook tqdm should treat `None` analogously to console tqdm

### DIFF
--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -195,7 +195,7 @@ class tqdm_notebook(std_tqdm):
         display = kwargs.get('display')
         kwargs['display'] = display if display is not None else False
         super(tqdm_notebook, self).__init__(*args, **kwargs)
-        if not self.disable or not kwargs['gui']:
+        if self.disable or not kwargs['gui']:
             return
 
         # Get bar width
@@ -209,7 +209,7 @@ class tqdm_notebook(std_tqdm):
         self.sp = self.display
 
         # Print initial bar state
-        if self.disable:
+        if not self.disable:
             self.display()
 
     def __iter__(self, *args, **kwargs):

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -193,7 +193,7 @@ class tqdm_notebook(std_tqdm):
         kwargs.setdefault('bar_format', '{l_bar}{bar}{r_bar}')
         kwargs['bar_format'] = kwargs['bar_format'].replace('{bar}', '<bar/>')
         super(tqdm_notebook, self).__init__(*args, **kwargs)
-        if self.disable or not kwargs['gui']:
+        if self.disable is not False or not kwargs['gui']:
             return
 
         # Get bar width
@@ -207,7 +207,7 @@ class tqdm_notebook(std_tqdm):
         self.sp = self.display
 
         # Print initial bar state
-        if not self.disable:
+        if self.disable is not False:
             self.display()
 
     def __iter__(self, *args, **kwargs):

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -192,8 +192,8 @@ class tqdm_notebook(std_tqdm):
         kwargs['gui'] = True
         kwargs.setdefault('bar_format', '{l_bar}{bar}{r_bar}')
         kwargs['bar_format'] = kwargs['bar_format'].replace('{bar}', '<bar/>')
-        display = kwargs.get('display')
-        kwargs['display'] = display if display is not None else False
+        disable = kwargs.get('disable')
+        kwargs['disable'] = disable if disable is not None else False
         super(tqdm_notebook, self).__init__(*args, **kwargs)
         if self.disable or not kwargs['gui']:
             return

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -195,7 +195,7 @@ class tqdm_notebook(std_tqdm):
         display = kwargs.get('display')
         kwargs['display'] = display if display is not None else False
         super(tqdm_notebook, self).__init__(*args, **kwargs)
-        if self.disable or not kwargs['gui']:
+        if not self.disable or not kwargs['gui']:
             return
 
         # Get bar width

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -192,8 +192,10 @@ class tqdm_notebook(std_tqdm):
         kwargs['gui'] = True
         kwargs.setdefault('bar_format', '{l_bar}{bar}{r_bar}')
         kwargs['bar_format'] = kwargs['bar_format'].replace('{bar}', '<bar/>')
+        display = kwargs.get('display')
+        kwargs['display'] = display if display is not None else False
         super(tqdm_notebook, self).__init__(*args, **kwargs)
-        if self.disable is not False or not kwargs['gui']:
+        if self.disable or not kwargs['gui']:
             return
 
         # Get bar width
@@ -207,7 +209,7 @@ class tqdm_notebook(std_tqdm):
         self.sp = self.display
 
         # Print initial bar state
-        if self.disable is not False:
+        if self.disable:
             self.display()
 
     def __iter__(self, *args, **kwargs):


### PR DESCRIPTION
- [ ] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [x] visual output fix
    + [ ] documentation modification
    + [ ] new feature

The [parameters docs](https://github.com/tqdm/tqdm#parameters) indicate that disable can be use to "do the right thing" if there's no TTY:
> disable : bool, optional
> Whether to disable the entire progressbar wrapper [default: False]. If set to None, disable on non-TTY.

It's less surprising for Jupyter tqdm to display itself when `disable=None` rather than to hide itself. I'd say being in a Notebook is more like being connected to a TTY than not.