### PR TITLE
tqdm.contrib.concurrent.process_map: Add 'chunksize' argument

### DIFF
--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -12,6 +12,14 @@ except ImportError:
     except ImportError:
         def cpu_count():
             return 4
+try:
+    from operator import length_hint
+except ImportError:
+    def length_hint(it, default=0):
+        try:
+            return len(it)
+        except TypeError:
+            return default
 import sys
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['thread_map', 'process_map']
@@ -20,23 +28,20 @@ __all__ = ['thread_map', 'process_map']
 def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
     """
     Implementation of `thread_map` and `process_map`.
-
-    Parameters
-    ----------
-    tqdm_class  : [default: tqdm.auto.tqdm].
     """
     kwargs = deepcopy(tqdm_kwargs)
     if "total" not in kwargs:
         kwargs["total"] = len(iterables[0])
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
     max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))
+    chunksize = kwargs.pop("chunksize", 1)
     pool_kwargs = dict(max_workers=max_workers)
     if sys.version_info[:2] >= (3, 7):
         # share lock in case workers are already using `tqdm`
         pool_kwargs.update(
             initializer=tqdm_class.set_lock, initargs=(tqdm_class.get_lock(),))
     with PoolExecutor(**pool_kwargs) as ex:
-        return list(tqdm_class(ex.map(fn, *iterables), **kwargs))
+        return list(tqdm_class(ex.map(fn, *iterables, chunksize=chunksize), **kwargs))
 
 
 def thread_map(fn, *iterables, **tqdm_kwargs):
@@ -46,7 +51,12 @@ def thread_map(fn, *iterables, **tqdm_kwargs):
 
     Parameters
     ----------
-    tqdm_class  : [default: tqdm.auto.tqdm].
+    tqdm_class : optional
+        `tqdm` class to use for bars [default: `tqdm.auto.tqdm`].
+    max_workers : int, optional
+        Maximum number of workers to spawn; passed to
+        `concurrent.futures.ThreadPoolExecutor.__init__`.
+        [default: max(32, cpu_count() + 4)].
     """
     from concurrent.futures import ThreadPoolExecutor
     return _executor_map(ThreadPoolExecutor, fn, *iterables, **tqdm_kwargs)
@@ -59,7 +69,27 @@ def process_map(fn, *iterables, **tqdm_kwargs):
 
     Parameters
     ----------
-    tqdm_class  : [default: tqdm.auto.tqdm].
+    tqdm_class  : optional
+        `tqdm` class to use for bars [default: `tqdm.auto.tqdm`].
+    max_workers : int, optional
+        Maximum number of workers to spawn; passed to
+        `concurrent.futures.ProcessPoolExecutor.__init__`.
+        [default: max(32, cpu_count() + 4)].
+    chunksize : int, optional
+        Size of chunks sent to worker processes; passed to
+        `concurrent.futures.ProcessPoolExecutor.map`.  [default: 1].
     """
     from concurrent.futures import ProcessPoolExecutor
+    if iterables and "chunksize" not in tqdm_kwargs:
+        # For large iterables, default chunksize has very bad performance
+        # because most time is spent sending items to workers.
+        longest_iterable_len = max(map(length_hint, iterables))
+        if longest_iterable_len >= 1000:
+            from warnings import warn
+            warn(
+                "Received iterable of length {} but 'chunksize' parameter is "
+                "not set. This may seriously degrade multiprocess performance. "
+                "To silence this warning, set 'chunksize' to a value >= 1.".format(longest_iterable_len),
+                RuntimeWarning, stacklevel=2,
+            )
     return _executor_map(ProcessPoolExecutor, fn, *iterables, **tqdm_kwargs)

--- a/tqdm/tests/tests_concurrent.py
+++ b/tqdm/tests/tests_concurrent.py
@@ -1,6 +1,7 @@
 """
 Tests for `tqdm.contrib.concurrent`.
 """
+import sys
 from tqdm.contrib.concurrent import thread_map, process_map
 from tests_tqdm import with_setup, pretest, posttest, SkipTest, StringIO, \
     closing
@@ -34,3 +35,24 @@ def test_process_map():
             assert process_map(incr, a, file=our_file) == b
         except ImportError:
             raise SkipTest
+
+
+def test_chunksize_warning():
+    if sys.version_info < (3, 3):
+        raise SkipTest("Need unittest.mock")
+
+    from unittest.mock import patch
+    from warnings import catch_warnings
+
+    for iterables, should_warn in [
+        ([], False),
+        (['x'], False),
+        ([()], False),
+        (['x', ()], False),
+        (['x' * 1000], True),
+        (['x' * 100, ('x',) * 1000], True),
+    ]:
+        with patch('tqdm.contrib.concurrent._executor_map'):
+            with catch_warnings(record=True) as w:
+                process_map(incr, *iterables)
+                assert should_warn == bool(w)

--- a/tqdm/tests/tests_concurrent.py
+++ b/tqdm/tests/tests_concurrent.py
@@ -1,7 +1,7 @@
 """
 Tests for `tqdm.contrib.concurrent`.
 """
-import sys
+from warnings import catch_warnings
 from tqdm.contrib.concurrent import thread_map, process_map
 from tests_tqdm import with_setup, pretest, posttest, SkipTest, StringIO, \
     closing
@@ -38,19 +38,18 @@ def test_process_map():
 
 
 def test_chunksize_warning():
-    if sys.version_info < (3, 3):
-        raise SkipTest("Need unittest.mock")
-
-    from unittest.mock import patch
-    from warnings import catch_warnings
+    try:
+        from unittest.mock import patch
+    except ImportError:
+        raise SkipTest
 
     for iterables, should_warn in [
         ([], False),
         (['x'], False),
         ([()], False),
         (['x', ()], False),
-        (['x' * 1000], True),
-        (['x' * 100, ('x',) * 1000], True),
+        (['x' * 1001], True),
+        (['x' * 100, ('x',) * 1001], True),
     ]:
         with patch('tqdm.contrib.concurrent._executor_map'):
             with catch_warnings(record=True) as w:


### PR DESCRIPTION
Allow to set ProcessPoolExecutor.map 'chunksize' argument and provide
sane default value if unset.

- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [x] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
