### PR TITLE
next release v4.44.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -380,8 +380,8 @@ Parameters
     (kilo, mega, etc.) [default: False]. If any other non-zero
     number, will scale ``total`` and ``n``.
 * dynamic_ncols  : bool, optional  
-    If set, constantly alters ``ncols`` to the environment (allowing
-    for window resizes) [default: False].
+    If set, constantly alters ``ncols`` and ``nrows`` to the
+    environment (allowing for window resizes) [default: False].
 * smoothing  : float, optional  
     Exponential moving average smoothing factor for speed estimates
     (ignored in GUI mode). Ranges from 0 (average speed) to 1
@@ -393,7 +393,7 @@ Parameters
     r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, '
     '{rate_fmt}{postfix}]'
     Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt,
-    percentage, elapsed, elapsed_s, ncols, desc, unit,
+    percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
     rate, rate_fmt, rate_noinv, rate_noinv_fmt,
     rate_inv, rate_inv_fmt, postfix, unit_divisor,
     remaining, remaining_s.
@@ -419,6 +419,10 @@ Parameters
 * lock_args  : tuple, optional  
     Passed to ``refresh`` for intermediate output
     (initialisation, iterating, and updating).
+* nrows  : int, optional  
+    The screen height. If specified, hides nested bars outside this
+    bound. If unspecified, attempts to use environment height.
+    The fallback is 20.
 
 Extra CLI Options
 ~~~~~~~~~~~~~~~~~

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -2,8 +2,17 @@
 Thin wrappers around `concurrent.futures`.
 """
 from __future__ import absolute_import
+from tqdm import TqdmWarning
 from tqdm.auto import tqdm as tqdm_auto
 from copy import deepcopy
+try:
+    from operator import length_hint
+except ImportError:
+    def length_hint(it, default=0):
+        try:
+            return len(it)
+        except TypeError:
+            return default
 try:
     from os import cpu_count
 except ImportError:
@@ -24,19 +33,23 @@ def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
     Parameters
     ----------
     tqdm_class  : [default: tqdm.auto.tqdm].
+    max_workers  : [default: max(32, cpu_count() + 4)].
+    chunksize  : [default: 1].
     """
     kwargs = deepcopy(tqdm_kwargs)
     if "total" not in kwargs:
         kwargs["total"] = len(iterables[0])
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
     max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))
+    chunksize = kwargs.pop("chunksize", 1)
     pool_kwargs = dict(max_workers=max_workers)
     if sys.version_info[:2] >= (3, 7):
         # share lock in case workers are already using `tqdm`
         pool_kwargs.update(
             initializer=tqdm_class.set_lock, initargs=(tqdm_class.get_lock(),))
     with PoolExecutor(**pool_kwargs) as ex:
-        return list(tqdm_class(ex.map(fn, *iterables), **kwargs))
+        return list(tqdm_class(
+            ex.map(fn, *iterables, chunksize=chunksize), **kwargs))
 
 
 def thread_map(fn, *iterables, **tqdm_kwargs):
@@ -46,7 +59,12 @@ def thread_map(fn, *iterables, **tqdm_kwargs):
 
     Parameters
     ----------
-    tqdm_class  : [default: tqdm.auto.tqdm].
+    tqdm_class : optional
+        `tqdm` class to use for bars [default: tqdm.auto.tqdm].
+    max_workers : int, optional
+        Maximum number of workers to spawn; passed to
+        `concurrent.futures.ThreadPoolExecutor.__init__`.
+        [default: max(32, cpu_count() + 4)].
     """
     from concurrent.futures import ThreadPoolExecutor
     return _executor_map(ThreadPoolExecutor, fn, *iterables, **tqdm_kwargs)
@@ -59,7 +77,25 @@ def process_map(fn, *iterables, **tqdm_kwargs):
 
     Parameters
     ----------
-    tqdm_class  : [default: tqdm.auto.tqdm].
+    tqdm_class  : optional
+        `tqdm` class to use for bars [default: tqdm.auto.tqdm].
+    max_workers : int, optional
+        Maximum number of workers to spawn; passed to
+        `concurrent.futures.ProcessPoolExecutor.__init__`.
+        [default: max(32, cpu_count() + 4)].
+    chunksize : int, optional
+        Size of chunks sent to worker processes; passed to
+        `concurrent.futures.ProcessPoolExecutor.map`. [default: 1].
     """
     from concurrent.futures import ProcessPoolExecutor
+    if iterables and "chunksize" not in tqdm_kwargs:
+        # default `chunksize=1` has poor performance for large iterables
+        # (most time spent dispatching items to workers).
+        longest_iterable_len = max(map(length_hint, iterables))
+        if longest_iterable_len > 1000:
+            from warnings import warn
+            warn("Iterable length %d > 1000 but `chunksize` is not set."
+                 " This may seriously degrade multiprocess performance."
+                 " Set `chunksize=1` or more." % longest_iterable_len,
+                 TqdmWarning, stacklevel=2)
     return _executor_map(ProcessPoolExecutor, fn, *iterables, **tqdm_kwargs)

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -9,6 +9,7 @@ try:
     from operator import length_hint
 except ImportError:
     def length_hint(it, default=0):
+        """Returns `len(it)`, falling back to `default`"""
         try:
             return len(it)
         except TypeError:

--- a/tqdm/tests/tests_concurrent.py
+++ b/tqdm/tests/tests_concurrent.py
@@ -38,6 +38,7 @@ def test_process_map():
 
 
 def test_chunksize_warning():
+    """Test contrib.concurrent.process_map chunksize warnings"""
     try:
         from unittest.mock import patch
     except ImportError:

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1904,7 +1904,8 @@ def test_screen_shape():
 
     # no second bar, leave=False
     with closing(StringIO()) as our_file:
-        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0, mininterval=0, leave=False)
+        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0,
+                      mininterval=0, leave=False)
         with trange(10, desc="one", **kwargs) as t1:
             with trange(10, desc="two", **kwargs) as t2:
                 list(t2)
@@ -1921,7 +1922,8 @@ def test_screen_shape():
 
     # no third bar, leave=True
     with closing(StringIO()) as our_file:
-        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0, mininterval=0)
+        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0,
+                      mininterval=0)
         with trange(10, desc="one", **kwargs) as t1:
             with trange(10, desc="two", **kwargs) as t2:
                 assert "two" not in our_file.getvalue()
@@ -1942,7 +1944,8 @@ def test_screen_shape():
 
     # second bar becomes first, leave=False
     with closing(StringIO()) as our_file:
-        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0, mininterval=0, leave=False)
+        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0,
+                      mininterval=0, leave=False)
         t1 = tqdm(total=10, desc="one", **kwargs)
         t2 = tqdm(total=10, desc="two", **kwargs)
         t1.update()

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -194,8 +194,7 @@ def squash_ctrlchars(s):
     lines = ['']  # state of our fake terminal
 
     # Split input string by control codes
-    RE_ctrl = re.compile("(%s)" % ("|".join(CTRLCHR)), flags=re.DOTALL)
-    s_split = RE_ctrl.split(s)
+    s_split = RE_ctrlchr.split(s)
     s_split = filter(None, s_split)  # filter out empty splits
 
     # For each control character or message
@@ -1890,3 +1889,71 @@ def test_float_progress():
                         assert not w
                 assert w
                 assert "clamping frac" in str(w[-1].message)
+
+
+@with_setup(pretest, posttest)
+def test_screen_shape():
+    """Test screen shape"""
+    # ncols
+    with closing(StringIO()) as our_file:
+        with trange(10, file=our_file, ncols=50) as t:
+            list(t)
+
+        res = our_file.getvalue()
+        assert all(len(i.strip('\n')) in (0, 50) for i in res.split('\r'))
+
+    # no second bar, leave=False
+    with closing(StringIO()) as our_file:
+        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0, mininterval=0, leave=False)
+        with trange(10, desc="one", **kwargs) as t1:
+            with trange(10, desc="two", **kwargs) as t2:
+                list(t2)
+            list(t1)
+
+        res = our_file.getvalue()
+        assert "one" in res
+        assert "two" not in res
+        assert "\n\n" not in res
+        assert "more hidden" in res
+        # double-check ncols
+        assert all(len(i) in (0, 50) for i in squash_ctrlchars(res)
+                   if "more hidden" not in i)
+
+    # no third bar, leave=True
+    with closing(StringIO()) as our_file:
+        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0, mininterval=0)
+        with trange(10, desc="one", **kwargs) as t1:
+            with trange(10, desc="two", **kwargs) as t2:
+                assert "two" not in our_file.getvalue()
+                with trange(10, desc="three", **kwargs) as t3:
+                    list(t3)
+                list(t2)
+            list(t1)
+
+        res = our_file.getvalue()
+        assert "one" in res
+        assert "two" in res
+        assert "three" not in res
+        assert "\n\n" not in res
+        assert "more hidden" in res
+        # double-check ncols
+        assert all(len(i) in (0, 50) for i in squash_ctrlchars(res)
+                   if "more hidden" not in i)
+
+    # second bar becomes first, leave=False
+    with closing(StringIO()) as our_file:
+        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0, mininterval=0, leave=False)
+        t1 = tqdm(total=10, desc="one", **kwargs)
+        t2 = tqdm(total=10, desc="two", **kwargs)
+        t1.update()
+        t2.update()
+        t1.close()
+        res = our_file.getvalue()
+        assert "one" in res
+        assert "two" not in res
+        assert "more hidden" in res
+        t2.update()
+        t2.close()
+
+        res = our_file.getvalue()
+        assert "two" in res

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -142,8 +142,8 @@ If any other non\-zero number, will scale \f[C]total\f[] and \f[C]n\f[].
 .TP
 .B \-\-dynamic_ncols=\f[I]dynamic_ncols\f[]
 bool, optional.
-If set, constantly alters \f[C]ncols\f[] to the environment (allowing
-for window resizes) [default: False].
+If set, constantly alters \f[C]ncols\f[] and \f[C]nrows\f[] to the
+environment (allowing for window resizes) [default: False].
 .RS
 .RE
 .TP
@@ -164,9 +164,9 @@ May impact performance.
 {percentage:3.0f}%|\[aq] and r_bar=\[aq]| {n_fmt}/{total_fmt}
 [{elapsed}<{remaining}, \[aq] \[aq]{rate_fmt}{postfix}]\[aq] Possible
 vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt, percentage,
-elapsed, elapsed_s, ncols, desc, unit, rate, rate_fmt, rate_noinv,
-rate_noinv_fmt, rate_inv, rate_inv_fmt, postfix, unit_divisor,
-remaining, remaining_s.
+elapsed, elapsed_s, ncols, nrows, desc, unit, rate, rate_fmt,
+rate_noinv, rate_noinv_fmt, rate_inv, rate_inv_fmt, postfix,
+unit_divisor, remaining, remaining_s.
 Note that a trailing ": " is automatically removed after {desc} if the
 latter is empty.
 .RS
@@ -215,6 +215,15 @@ In all other cases will default to unicode.
 tuple, optional.
 Passed to \f[C]refresh\f[] for intermediate output (initialisation,
 iterating, and updating).
+.RS
+.RE
+.TP
+.B \-\-nrows=\f[I]nrows\f[]
+int, optional.
+The screen height.
+If specified, hides nested bars outside this bound.
+If unspecified, attempts to use environment height.
+The fallback is 20.
 .RS
 .RE
 .TP

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -203,6 +203,9 @@ class SimpleTextIOWrapper(ObjectWrapper):
         """
         return self._wrapped.write(s.encode(self.wrapper_getattr('encoding')))
 
+    def __eq__(self, other):
+        return self._wrapped == getattr(other, '_wrapped', other)
+
 
 class CallbackIOWrapper(ObjectWrapper):
     def __init__(self, callback, stream, method="read"):

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -3,6 +3,8 @@ import os
 from platform import system as _curos
 import re
 import subprocess
+from warnings import warn
+
 CUR_OS = _curos()
 IS_WIN = CUR_OS in ['Windows', 'cli']
 IS_NIX = (not IS_WIN) and any(
@@ -263,22 +265,22 @@ def _is_ascii(s):
     return _supports_unicode(s)
 
 
-def _environ_cols_wrapper():  # pragma: no cover
+def _screen_shape_wrapper():  # pragma: no cover
     """
-    Return a function which gets width and height of console
-    (linux,osx,windows,cygwin).
+    Return a function which returns console dimensions (width, height).
+    Supported: linux, osx, windows, cygwin.
     """
-    _environ_cols = None
+    _screen_shape = None
     if IS_WIN:
-        _environ_cols = _environ_cols_windows
-        if _environ_cols is None:
-            _environ_cols = _environ_cols_tput
+        _screen_shape = _screen_shape_windows
+        if _screen_shape is None:
+            _screen_shape = _screen_shape_tput
     if IS_NIX:
-        _environ_cols = _environ_cols_linux
-    return _environ_cols
+        _screen_shape = _screen_shape_linux
+    return _screen_shape
 
 
-def _environ_cols_windows(fp):  # pragma: no cover
+def _screen_shape_windows(fp):  # pragma: no cover
     try:
         from ctypes import windll, create_string_buffer
         import struct
@@ -294,28 +296,26 @@ def _environ_cols_windows(fp):  # pragma: no cover
         csbi = create_string_buffer(22)
         res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
         if res:
-            (_bufx, _bufy, _curx, _cury, _wattr, left, _top, right, _bottom,
+            (_bufx, _bufy, _curx, _cury, _wattr, left, top, right, bottom,
              _maxx, _maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
-            # nlines = bottom - top + 1
-            return right - left  # +1
+            return right - left, bottom - top  # +1
     except:
         pass
-    return None
+    return None, None
 
 
-def _environ_cols_tput(*_):  # pragma: no cover
+def _screen_shape_tput(*_):  # pragma: no cover
     """cygwin xterm (windows)"""
     try:
         import shlex
-        cols = int(subprocess.check_call(shlex.split('tput cols')))
-        # rows = int(subprocess.check_call(shlex.split('tput lines')))
-        return cols
+        return [int(subprocess.check_call(shlex.split('tput ' + i))) - 1
+                for i in ('cols', 'lines')]
     except:
         pass
-    return None
+    return None, None
 
 
-def _environ_cols_linux(fp):  # pragma: no cover
+def _screen_shape_linux(fp):  # pragma: no cover
 
     try:
         from termios import TIOCGWINSZ
@@ -325,12 +325,31 @@ def _environ_cols_linux(fp):  # pragma: no cover
         return None
     else:
         try:
-            return array('h', ioctl(fp, TIOCGWINSZ, '\0' * 8))[1]
+            rows, cols = array('h', ioctl(fp, TIOCGWINSZ, '\0' * 8))[:2]
+            return cols, rows
         except:
             try:
-                return int(os.environ["COLUMNS"]) - 1
+                return [int(os.environ[i]) - 1 for i in ("COLUMNS", "LINES")]
             except KeyError:
-                return None
+                return None, None
+
+
+def _environ_cols_wrapper():  # pragma: no cover
+    """
+    Return a function which returns console width.
+    Supported: linux, osx, windows, cygwin.
+    """
+    warn("Use `_screen_shape_wrapper()(file)[0]` instead of"
+         " `_environ_cols_wrapper()(file)`", DeprecationWarning, stacklevel=2)
+    shape = _screen_shape_wrapper()
+    if not shape:
+        return None
+
+    @wraps(shape)
+    def inner(fp):
+        return shape(fp)[0]
+
+    return inner
 
 
 def _term_move_up():  # pragma: no cover


### PR DESCRIPTION
- add `nrows` (#918 -> #924)
- expose and warn about small `chunksize` in `tqdm.contrib.concurrent.process_map` (#912)
- fix py2 file stream comparison (#727 -> #730)

---

- fixes #727 -> closes #730
- fixes #918 -> closes #924
- closes #912