### PR TITLE
add `nrows`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -380,8 +380,8 @@ Parameters
     (kilo, mega, etc.) [default: False]. If any other non-zero
     number, will scale ``total`` and ``n``.
 * dynamic_ncols  : bool, optional  
-    If set, constantly alters ``ncols`` to the environment (allowing
-    for window resizes) [default: False].
+    If set, constantly alters ``ncols`` and ``nrows`` to the
+    environment (allowing for window resizes) [default: False].
 * smoothing  : float, optional  
     Exponential moving average smoothing factor for speed estimates
     (ignored in GUI mode). Ranges from 0 (average speed) to 1
@@ -393,7 +393,7 @@ Parameters
     r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, '
     '{rate_fmt}{postfix}]'
     Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt,
-    percentage, elapsed, elapsed_s, ncols, desc, unit,
+    percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
     rate, rate_fmt, rate_noinv, rate_noinv_fmt,
     rate_inv, rate_inv_fmt, postfix, unit_divisor,
     remaining, remaining_s.
@@ -419,6 +419,10 @@ Parameters
 * lock_args  : tuple, optional  
     Passed to ``refresh`` for intermediate output
     (initialisation, iterating, and updating).
+* nrows  : int, optional  
+    The screen height. If specified, hides nested bars outside this
+    bound. If unspecified, attempts to use environment height.
+    The fallback is 20.
 
 Extra CLI Options
 ~~~~~~~~~~~~~~~~~

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1260,7 +1260,7 @@ class tqdm(Comparable):
         self._decr_instances(self)
 
         # GUI mode or overflow
-        if not hasattr(self, "sp") or pos > (self.nrows or 20):
+        if not hasattr(self, "sp") or pos >= (self.nrows or 20):
             # never printed so nothing to do
             return
 
@@ -1295,10 +1295,12 @@ class tqdm(Comparable):
 
         if not nolock:
             self._lock.acquire()
-        self.moveto(abs(self.pos))
-        self.sp('')
-        self.fp.write('\r')  # place cursor back at the beginning of line
-        self.moveto(-abs(self.pos))
+        pos = abs(self.pos)
+        if pos < (self.nrows or 20):
+            self.moveto(pos)
+            self.sp('')
+            self.fp.write('\r')  # place cursor back at the beginning of line
+            self.moveto(-pos)
         if not nolock:
             self._lock.release()
 
@@ -1449,13 +1451,14 @@ class tqdm(Comparable):
             pos = abs(self.pos)
 
         nrows = self.nrows or 20
-        if pos > nrows:
-            return
+        if pos >= nrows - 1:
+            if pos >= nrows:
+                return
+            msg = " ... (more hidden) ..."
 
         if pos:
             self.moveto(pos)
-        self.sp(" ... (more hidden) ..." if pos == nrows else
-                self.__repr__() if msg is None else msg)
+        self.sp(self.__repr__() if msg is None else msg)
         if pos:
             self.moveto(-pos)
 

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1419,9 +1419,8 @@ class tqdm(Comparable):
     def format_dict(self):
         """Public API for read-only member access."""
         if self.dynamic_ncols:
-            ncols, nrows = self.dynamic_ncols(self.fp)
-        else:
-            ncols, nrows = self.ncols, self.nrows
+            self.ncols, self.nrows = self.dynamic_ncols(self.fp)
+        ncols, nrows = self.ncols, self.nrows
         return dict(
             n=self.n, total=self.total,
             elapsed=self._time() - self.start_t

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1259,8 +1259,9 @@ class tqdm(Comparable):
         pos = abs(self.pos)
         self._decr_instances(self)
 
-        # GUI mode
-        if not hasattr(self, "sp"):
+        # GUI mode or overflow
+        if not hasattr(self, "sp") or pos > self.nrows:
+            # never printed so nothing to do
             return
 
         # annoyingly, _supports_unicode isn't good enough
@@ -1447,10 +1448,13 @@ class tqdm(Comparable):
         """
         if pos is None:
             pos = abs(self.pos)
+        if pos > self.nrows:
+            return
 
         if pos:
             self.moveto(pos)
-        self.sp(self.__repr__() if msg is None else msg)
+        self.sp(self.__repr__() if msg is None else
+                " ... (more hidden) ..." if pos == self.nrows else msg)
         if pos:
             self.moveto(-pos)
 

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1260,7 +1260,7 @@ class tqdm(Comparable):
         self._decr_instances(self)
 
         # GUI mode or overflow
-        if not hasattr(self, "sp") or pos > self.nrows:
+        if not hasattr(self, "sp") or pos > (self.nrows or 20):
             # never printed so nothing to do
             return
 
@@ -1447,13 +1447,15 @@ class tqdm(Comparable):
         """
         if pos is None:
             pos = abs(self.pos)
-        if pos > self.nrows:
+
+        nrows = self.nrows or 20
+        if pos > nrows:
             return
 
         if pos:
             self.moveto(pos)
         self.sp(self.__repr__() if msg is None else
-                " ... (more hidden) ..." if pos == self.nrows else msg)
+                " ... (more hidden) ..." if pos == nrows else msg)
         if pos:
             self.moveto(-pos)
 

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1454,8 +1454,8 @@ class tqdm(Comparable):
 
         if pos:
             self.moveto(pos)
-        self.sp(self.__repr__() if msg is None else
-                " ... (more hidden) ..." if pos == nrows else msg)
+        self.sp(" ... (more hidden) ..." if pos == nrows else
+                self.__repr__() if msg is None else msg)
         if pos:
             self.moveto(-pos)
 

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -9,7 +9,7 @@ Usage:
 """
 from __future__ import absolute_import, division
 # compatibility functions and utilities
-from .utils import _supports_unicode, _environ_cols_wrapper, _range, _unich, \
+from .utils import _supports_unicode, _screen_shape_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
     Comparable, _is_ascii, FormatReplace, disp_len, disp_trim, \
     SimpleTextIOWrapper, CallbackIOWrapper
@@ -352,7 +352,7 @@ class tqdm(Comparable):
             r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, '
               '{rate_fmt}{postfix}]'
             Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt,
-              percentage, elapsed, elapsed_s, ncols, desc, unit,
+              percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
               rate, rate_fmt, rate_noinv, rate_noinv_fmt,
               rate_inv, rate_inv_fmt, postfix, unit_divisor,
               remaining, remaining_s.
@@ -790,6 +790,7 @@ class tqdm(Comparable):
                  unit_scale=False, dynamic_ncols=False, smoothing=0.3,
                  bar_format=None, initial=0, position=None, postfix=None,
                  unit_divisor=1000, write_bytes=None, lock_args=None,
+                 nrows=None,
                  gui=False, **kwargs):
         """
         Parameters
@@ -852,8 +853,8 @@ class tqdm(Comparable):
             (kilo, mega, etc.) [default: False]. If any other non-zero
             number, will scale `total` and `n`.
         dynamic_ncols  : bool, optional
-            If set, constantly alters `ncols` to the environment (allowing
-            for window resizes) [default: False].
+            If set, constantly alters `ncols` and `nrows` to the
+            environment (allowing for window resizes) [default: False].
         smoothing  : float, optional
             Exponential moving average smoothing factor for speed estimates
             (ignored in GUI mode). Ranges from 0 (average speed) to 1
@@ -865,7 +866,7 @@ class tqdm(Comparable):
             r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, '
               '{rate_fmt}{postfix}]'
             Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt,
-              percentage, elapsed, elapsed_s, ncols, desc, unit,
+              percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
               rate, rate_fmt, rate_noinv, rate_noinv_fmt,
               rate_inv, rate_inv_fmt, postfix, unit_divisor,
               remaining, remaining_s.
@@ -891,6 +892,10 @@ class tqdm(Comparable):
         lock_args  : tuple, optional
             Passed to `refresh` for intermediate output
             (initialisation, iterating, and updating).
+        nrows  : int, optional
+            The screen height. If specified, hides nested bars outside this
+            bound. If unspecified, attempts to use environment height.
+            The fallback is 20.
         gui  : bool, optional
             WARNING: internal parameter - do not use.
             Use tqdm.gui.tqdm(...) instead. If set, will attempt to use
@@ -949,16 +954,21 @@ class tqdm(Comparable):
                 TqdmKeyError("Unknown argument(s): " + str(kwargs)))
 
         # Preprocess the arguments
-        if ((ncols is None) and (file in (sys.stderr, sys.stdout))) or \
+        if ((ncols is None or nrows is None) and
+            (file in (sys.stderr, sys.stdout))) or \
                 dynamic_ncols:  # pragma: no cover
             if dynamic_ncols:
-                dynamic_ncols = _environ_cols_wrapper()
+                dynamic_ncols = _screen_shape_wrapper()
                 if dynamic_ncols:
-                    ncols = dynamic_ncols(file)
+                    ncols, nrows = dynamic_ncols(file)
             else:
-                _dynamic_ncols = _environ_cols_wrapper()
+                _dynamic_ncols = _screen_shape_wrapper()
                 if _dynamic_ncols:
-                    ncols = _dynamic_ncols(file)
+                    _ncols, _nrows = _dynamic_ncols(file)
+                    if ncols is None:
+                        ncols = _ncols
+                    if nrows is None:
+                        nrows = _nrows
 
         if miniters is None:
             miniters = 0
@@ -989,6 +999,7 @@ class tqdm(Comparable):
         self.leave = leave
         self.fp = file
         self.ncols = ncols
+        self.nrows = nrows
         self.mininterval = mininterval
         self.maxinterval = maxinterval
         self.miniters = miniters
@@ -1406,12 +1417,15 @@ class tqdm(Comparable):
     @property
     def format_dict(self):
         """Public API for read-only member access."""
+        if self.dynamic_ncols:
+            ncols, nrows = self.dynamic_ncols(self.fp)
+        else:
+            ncols, nrows = self.ncols, self.nrows
         return dict(
             n=self.n, total=self.total,
             elapsed=self._time() - self.start_t
             if hasattr(self, 'start_t') else 0,
-            ncols=self.dynamic_ncols(self.fp)
-            if self.dynamic_ncols else self.ncols,
+            ncols=ncols, nrows=nrows,
             prefix=self.desc, ascii=self.ascii, unit=self.unit,
             unit_scale=self.unit_scale,
             rate=1 / self.avg_time if self.avg_time else None,

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1890,3 +1890,30 @@ def test_float_progress():
                         assert not w
                 assert w
                 assert "clamping frac" in str(w[-1].message)
+
+
+@with_setup(pretest, posttest)
+def test_screen_shape():
+    """Test screen shape"""
+    with closing(StringIO()) as our_file:
+        with trange(10, file=our_file, ncols=50) as t:
+            list(t)
+
+        res = our_file.getvalue()
+        assert all(len(i.strip('\n')) in (0, 50) for i in res.split('\r'))
+
+    with closing(StringIO()) as our_file:
+        with trange(10, file=our_file, ncols=50, nrows=1, desc="one") as t1:
+            with trange(10, file=our_file, ncols=50, nrows=1, desc="two") as t2:
+                with trange(10, file=our_file, ncols=50, nrows=1, desc="three") as t3:
+                    list(t3)
+                list(t2)
+            list(t1)
+
+        res = our_file.getvalue()
+        assert "one" in res
+        assert "two" in res
+        assert "three" not in res
+        assert "more hidden" in res
+        assert all(len(i.strip('\n')) in (0, 50) for i in res.split('\r')
+                   if "more hidden" not in i)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1903,9 +1903,9 @@ def test_screen_shape():
 
     # no third bar
     with closing(StringIO()) as our_file:
-        with trange(10, file=our_file, ncols=50, nrows=1, desc="one") as t1:
-            with trange(10, file=our_file, ncols=50, nrows=1, desc="two") as t2:
-                with trange(10, file=our_file, ncols=50, nrows=1, desc="three") as t3:
+        with trange(10, file=our_file, ncols=50, nrows=2, desc="one") as t1:
+            with trange(10, file=our_file, ncols=50, nrows=2, desc="two") as t2:
+                with trange(10, file=our_file, ncols=50, nrows=2, desc="three") as t3:
                     list(t3)
                 list(t2)
             list(t1)
@@ -1922,9 +1922,9 @@ def test_screen_shape():
 
     # third bar becomes second
     with closing(StringIO()) as our_file:
-        t1 = trange(10, file=our_file, ncols=50, nrows=1, desc="one")
-        t2 = trange(10, file=our_file, ncols=50, nrows=1, desc="two")
-        t3 = trange(10, file=our_file, ncols=50, nrows=1, desc="three")
+        t1 = trange(10, file=our_file, ncols=50, nrows=2, desc="one")
+        t2 = trange(10, file=our_file, ncols=50, nrows=2, desc="two")
+        t3 = trange(10, file=our_file, ncols=50, nrows=2, desc="three")
         list(t2)
         t2.close()
         list(t3)

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -142,8 +142,8 @@ If any other non\-zero number, will scale \f[C]total\f[] and \f[C]n\f[].
 .TP
 .B \-\-dynamic_ncols=\f[I]dynamic_ncols\f[]
 bool, optional.
-If set, constantly alters \f[C]ncols\f[] to the environment (allowing
-for window resizes) [default: False].
+If set, constantly alters \f[C]ncols\f[] and \f[C]nrows\f[] to the
+environment (allowing for window resizes) [default: False].
 .RS
 .RE
 .TP
@@ -164,9 +164,9 @@ May impact performance.
 {percentage:3.0f}%|\[aq] and r_bar=\[aq]| {n_fmt}/{total_fmt}
 [{elapsed}<{remaining}, \[aq] \[aq]{rate_fmt}{postfix}]\[aq] Possible
 vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt, percentage,
-elapsed, elapsed_s, ncols, desc, unit, rate, rate_fmt, rate_noinv,
-rate_noinv_fmt, rate_inv, rate_inv_fmt, postfix, unit_divisor,
-remaining, remaining_s.
+elapsed, elapsed_s, ncols, nrows, desc, unit, rate, rate_fmt,
+rate_noinv, rate_noinv_fmt, rate_inv, rate_inv_fmt, postfix,
+unit_divisor, remaining, remaining_s.
 Note that a trailing ": " is automatically removed after {desc} if the
 latter is empty.
 .RS
@@ -215,6 +215,15 @@ In all other cases will default to unicode.
 tuple, optional.
 Passed to \f[C]refresh\f[] for intermediate output (initialisation,
 iterating, and updating).
+.RS
+.RE
+.TP
+.B \-\-nrows=\f[I]nrows\f[]
+int, optional.
+The screen height.
+If specified, hides nested bars outside this bound.
+If unspecified, attempts to use environment height.
+The fallback is 20.
 .RS
 .RE
 .TP

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -3,6 +3,8 @@ import os
 from platform import system as _curos
 import re
 import subprocess
+from warnings import warn
+
 CUR_OS = _curos()
 IS_WIN = CUR_OS in ['Windows', 'cli']
 IS_NIX = (not IS_WIN) and any(
@@ -330,6 +332,23 @@ def _screen_shape_linux(fp):  # pragma: no cover
                 return [int(os.environ[i]) - 1 for i in ("COLUMNS", "LINES")]
             except KeyError:
                 return None, None
+
+
+def _environ_cols_wrapper():  # pragma: no cover
+    """
+    Return a function which returns console width.
+    Supported: linux, osx, windows, cygwin.
+    """
+    warn("Use `_screen_shape_wrapper()(file)[0]` instead of"
+         " `_environ_cols_wrapper()(file)`", DeprecationWarning, stacklevel=2)
+    shape = _screen_shape_wrapper()
+    if not shape:
+        return None
+
+    def inner(fp):
+        return shape(fp)[0]
+
+    return inner
 
 
 def _term_move_up():  # pragma: no cover

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -345,6 +345,7 @@ def _environ_cols_wrapper():  # pragma: no cover
     if not shape:
         return None
 
+    @wraps(shape)
     def inner(fp):
         return shape(fp)[0]
 

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -263,22 +263,22 @@ def _is_ascii(s):
     return _supports_unicode(s)
 
 
-def _environ_cols_wrapper():  # pragma: no cover
+def _screen_shape_wrapper():  # pragma: no cover
     """
-    Return a function which gets width and height of console
-    (linux,osx,windows,cygwin).
+    Return a function which returns console dimensions (width, height).
+    Supported: linux, osx, windows, cygwin.
     """
-    _environ_cols = None
+    _screen_shape = None
     if IS_WIN:
-        _environ_cols = _environ_cols_windows
-        if _environ_cols is None:
-            _environ_cols = _environ_cols_tput
+        _screen_shape = _screen_shape_windows
+        if _screen_shape is None:
+            _screen_shape = _screen_shape_tput
     if IS_NIX:
-        _environ_cols = _environ_cols_linux
-    return _environ_cols
+        _screen_shape = _screen_shape_linux
+    return _screen_shape
 
 
-def _environ_cols_windows(fp):  # pragma: no cover
+def _screen_shape_windows(fp):  # pragma: no cover
     try:
         from ctypes import windll, create_string_buffer
         import struct
@@ -294,28 +294,26 @@ def _environ_cols_windows(fp):  # pragma: no cover
         csbi = create_string_buffer(22)
         res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
         if res:
-            (_bufx, _bufy, _curx, _cury, _wattr, left, _top, right, _bottom,
+            (_bufx, _bufy, _curx, _cury, _wattr, left, top, right, bottom,
              _maxx, _maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
-            # nlines = bottom - top + 1
-            return right - left  # +1
+            return right - left, bottom - top  # +1
     except:
         pass
-    return None
+    return None, None
 
 
-def _environ_cols_tput(*_):  # pragma: no cover
+def _screen_shape_tput(*_):  # pragma: no cover
     """cygwin xterm (windows)"""
     try:
         import shlex
-        cols = int(subprocess.check_call(shlex.split('tput cols')))
-        # rows = int(subprocess.check_call(shlex.split('tput lines')))
-        return cols
+        return [int(subprocess.check_call(shlex.split('tput ' + i))) - 1
+                for i in ('cols', 'lines')]
     except:
         pass
-    return None
+    return None, None
 
 
-def _environ_cols_linux(fp):  # pragma: no cover
+def _screen_shape_linux(fp):  # pragma: no cover
 
     try:
         from termios import TIOCGWINSZ
@@ -325,12 +323,13 @@ def _environ_cols_linux(fp):  # pragma: no cover
         return None
     else:
         try:
-            return array('h', ioctl(fp, TIOCGWINSZ, '\0' * 8))[1]
+            rows, cols = array('h', ioctl(fp, TIOCGWINSZ, '\0' * 8))[:2]
+            return cols, rows
         except:
             try:
-                return int(os.environ["COLUMNS"]) - 1
+                return [int(os.environ[i]) - 1 for i in ("COLUMNS", "LINES")]
             except KeyError:
-                return None
+                return None, None
 
 
 def _term_move_up():  # pragma: no cover


### PR DESCRIPTION
- [x] expose `nrows` argument
- [x] automatically detect based on window heights
  + [x] add `_screen_shape_wrapper` helper
  + [x] deprecate  `_environ_cols_wrapper`
- [x] actually use `nrows` to hide overflowing nested progress bars
- [x] test
- [x] document
- fixes #918

Notes:

- uses `dynamic_ncols` in the same way as `ncols` does. This is preferable to creating a new `dynamic_nrows` argument because:
  + feature: it's unlikely that users would want only one to be dynamic
  + performance: if one needs to be dynamic, then it's usually relatively easy to calculate the other too
  + API: it's best to rename `dynamic_ncols` => `dynamic_size` later in v5