### PR TITLE
rework `_decr_instances` (nested `close`)

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -553,11 +553,14 @@ class tqdm(Comparable):
             # else:
             if not instance.gui:
                 pos = abs(instance.pos)
+                nrows = int(instance.nrows or 20)
+                clear = pos < nrows
                 instances = filter(lambda i: hasattr(i, "pos"), cls._instances)
                 for inst in sorted(instances, reverse=True, key=lambda i: i.pos):
                     # negative `pos` means fixed
                     if pos < inst.pos:
-                        inst.clear(nolock=True)
+                        if clear:
+                            inst.clear(nolock=True)
                         inst.pos -= 1
                         # TODO: check this doesn't overwrite another fixed bar
             # Kill monitor if no instances are left

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -556,14 +556,15 @@ class tqdm(Comparable):
                 pass  # py2: maybe magically removed already
             # else:
             if not instance.gui:
-                nrows = int(instance.nrows or 20)
-                # find unfixed (`pos >= 0`) overflow (`pos >= nrows`) instances
+                last = (instance.nrows or 20) - 1
+                # find unfixed (`pos >= 0`) overflow (`pos >= nrows - 1`)
                 instances = list(filter(
-                    lambda i: hasattr(i, "pos") and nrows <= i.pos,
+                    lambda i: hasattr(i, "pos") and last <= i.pos,
                     cls._instances))
                 # set first found to current `pos`
                 if instances:
                     inst = min(instances, key=lambda i: i.pos)
+                    inst.clear(nolock=True)
                     inst.pos = abs(instance.pos)
             # Kill monitor if no instances are left
             if not cls._instances and cls.monitor:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1290,10 +1290,9 @@ class tqdm(Comparable):
                 self.avg_time = None
                 self.display(pos=0)
                 fp_write('\n')
-            elif pos < (self.nrows or 20):
+            else:
                 # clear previous display
-                self.display(msg='', pos=pos)
-                if not pos:
+                if self.display(msg='', pos=pos) and not pos:
                     fp_write('\r')
 
     def clear(self, nolock=False):
@@ -1461,7 +1460,7 @@ class tqdm(Comparable):
         nrows = self.nrows or 20
         if pos >= nrows - 1:
             if pos >= nrows:
-                return
+                return False
             if msg or msg is None:  # override at `nrows - 1`
                 msg = " ... (more hidden) ..."
 
@@ -1470,6 +1469,7 @@ class tqdm(Comparable):
         self.sp(self.__repr__() if msg is None else msg)
         if pos:
             self.moveto(-pos)
+        return True
 
     @classmethod
     @contextmanager

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1267,9 +1267,8 @@ class tqdm(Comparable):
         pos = abs(self.pos)
         self._decr_instances(self)
 
-        # GUI mode or overflow
-        if not hasattr(self, "sp") or pos >= (self.nrows or 20):
-            # never printed so nothing to do
+        # GUI mode
+        if not hasattr(self, "sp"):
             return
 
         # annoyingly, _supports_unicode isn't good enough
@@ -1291,7 +1290,8 @@ class tqdm(Comparable):
                 self.avg_time = None
                 self.display(pos=0)
                 fp_write('\n')
-            else:
+            elif pos < (self.nrows or 20):
+                # clear previous display
                 self.display(msg='', pos=pos)
                 if not pos:
                     fp_write('\r')

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -552,9 +552,11 @@ class tqdm(Comparable):
                 pass  # py2: maybe magically removed already
             # else:
             if not instance.gui:
-                for inst in cls._instances:
+                pos = abs(instance.pos)
+                instances = filter(lambda i: hasattr(i, "pos"), cls._instances)
+                for inst in sorted(instances, reverse=True, key=lambda i: i.pos):
                     # negative `pos` means fixed
-                    if hasattr(inst, "pos") and inst.pos > abs(instance.pos):
+                    if pos < inst.pos:
                         inst.clear(nolock=True)
                         inst.pos -= 1
                         # TODO: check this doesn't overwrite another fixed bar

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -556,7 +556,8 @@ class tqdm(Comparable):
                 nrows = int(instance.nrows or 20)
                 clear = pos < nrows
                 instances = filter(lambda i: hasattr(i, "pos"), cls._instances)
-                for inst in sorted(instances, reverse=True, key=lambda i: i.pos):
+                for inst in sorted(
+                        instances, reverse=True, key=lambda i: i.pos):
                     # negative `pos` means fixed
                     if pos < inst.pos:
                         if clear:

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1318,31 +1318,29 @@ def test_position():
     # Test auto repositioning of bars when a bar is prematurely closed
     # tqdm._instances.clear()  # reset number of instances
     with closing(StringIO()) as our_file:
-        t1 = tqdm(total=10, file=our_file, desc='pos0 bar', mininterval=0)
-        t2 = tqdm(total=10, file=our_file, desc='pos1 bar', mininterval=0)
-        t3 = tqdm(total=10, file=our_file, desc='pos2 bar', mininterval=0)
+        t1 = tqdm(total=10, file=our_file, desc='1.pos0 bar', mininterval=0)
+        t2 = tqdm(total=10, file=our_file, desc='2.pos1 bar', mininterval=0)
+        t3 = tqdm(total=10, file=our_file, desc='3.pos2 bar', mininterval=0)
         res = [m[0] for m in RE_pos.findall(our_file.getvalue())]
-        exres = ['\rpos0 bar:   0%',
-                 '\n\rpos1 bar:   0%',
-                 '\n\n\rpos2 bar:   0%']
+        exres = ['\r1.pos0 bar:   0%',
+                 '\n\r2.pos1 bar:   0%',
+                 '\n\n\r3.pos2 bar:   0%']
         pos_line_diff(res, exres)
 
         t2.close()
-        t4 = tqdm(total=10, file=our_file, desc='pos3 bar', mininterval=0)
+        t4 = tqdm(total=10, file=our_file, desc='4.pos2 bar', mininterval=0)
         t1.update(1)
         t3.update(1)
         t4.update(1)
         res = [m[0] for m in RE_pos.findall(our_file.getvalue())]
-        exres = ['\rpos0 bar:   0%',
-                 '\n\rpos1 bar:   0%',
-                 '\n\n\rpos2 bar:   0%',
-                 '\n\n\r      ',
-                 '\r\x1b[A\x1b[A',
-                 '\rpos1 bar:   0%',
-                 '\n\n\n\rpos3 bar:   0%',
-                 '\rpos0 bar:  10%',
-                 '\n\rpos2 bar:  10%',
-                 '\n\n\rpos3 bar:  10%']
+        exres = ['\r1.pos0 bar:   0%',
+                 '\n\r2.pos1 bar:   0%',
+                 '\n\n\r3.pos2 bar:   0%',
+                 '\r2.pos1 bar:   0%',
+                 '\n\n\r4.pos2 bar:   0%',
+                 '\r1.pos0 bar:  10%',
+                 '\n\n\r3.pos2 bar:  10%',
+                 '\n\r4.pos2 bar:  10%']
         pos_line_diff(res, exres)
         t4.close()
         t3.close()

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1902,31 +1902,12 @@ def test_screen_shape():
         res = our_file.getvalue()
         assert all(len(i) == 50 for i in get_bar(res))
 
-    # no second bar, leave=False
+    # no second/third bar, leave=False
     with closing(StringIO()) as our_file:
         kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0,
                       mininterval=0, leave=False)
         with trange(10, desc="one", **kwargs) as t1:
             with trange(10, desc="two", **kwargs) as t2:
-                list(t2)
-            list(t1)
-
-        res = our_file.getvalue()
-        assert "one" in res
-        assert "two" not in res
-        assert "\n\n" not in res
-        assert "more hidden" in res
-        # double-check ncols
-        assert all(len(i) == 50 for i in get_bar(res)
-                   if i.strip() and "more hidden" not in i)
-
-    # no third bar, leave=True
-    with closing(StringIO()) as our_file:
-        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0,
-                      mininterval=0)
-        with trange(10, desc="one", **kwargs) as t1:
-            with trange(10, desc="two", **kwargs) as t2:
-                assert "two" not in our_file.getvalue()
                 with trange(10, desc="three", **kwargs) as t3:
                     list(t3)
                 list(t2)
@@ -1934,8 +1915,31 @@ def test_screen_shape():
 
         res = our_file.getvalue()
         assert "one" in res
-        assert "two" in res
+        assert "two" not in res
         assert "three" not in res
+        assert "\n\n" not in res
+        assert "more hidden" in res
+        # double-check ncols
+        assert all(len(i) == 50 for i in get_bar(res)
+                   if i.strip() and "more hidden" not in i)
+
+    # all bars, leave=True
+    with closing(StringIO()) as our_file:
+        kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0,
+                      mininterval=0)
+        with trange(10, desc="one", **kwargs) as t1:
+            with trange(10, desc="two", **kwargs) as t2:
+                assert "two" not in our_file.getvalue()
+                with trange(10, desc="three", **kwargs) as t3:
+                    assert "three" not in our_file.getvalue()
+                    list(t3)
+                list(t2)
+            list(t1)
+
+        res = our_file.getvalue()
+        assert "one" in res
+        assert "two" in res
+        assert "three" in res
         assert "\n\n" not in res
         assert "more hidden" in res
         # double-check ncols
@@ -1947,16 +1951,15 @@ def test_screen_shape():
         kwargs = dict(file=our_file, ncols=50, nrows=2, miniters=0,
                       mininterval=0, leave=False)
         t1 = tqdm(total=10, desc="one", **kwargs)
-        t2 = tqdm(total=10, desc="two", **kwargs)
-        t1.update()
-        t2.update()
-        t1.close()
-        res = our_file.getvalue()
-        assert "one" in res
-        assert "two" not in res
-        assert "more hidden" in res
-        t2.update()
-        t2.close()
+        with tqdm(total=10, desc="two", **kwargs) as t2:
+            t1.update()
+            t2.update()
+            t1.close()
+            res = our_file.getvalue()
+            assert "one" in res
+            assert "two" not in res
+            assert "more hidden" in res
+            t2.update()
 
         res = our_file.getvalue()
         assert "two" in res


### PR DESCRIPTION
Reduces screen flicker/blank space at the cost of ordering.

- [x] don't move displaying (non-overflow) bars upwards
- [x] move the first unfixed (`pos >= 0`) overflow (`pos >= nrows - 1`) bar to the current `pos`
- [x] test
- continues #924 <- #918, #677