### PR TITLE
contrib.telegram

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,5 +2,6 @@
 branch = True
 omit =
     tqdm/tests/*
+    tqdm/contrib/telegram.py
 [report]
 show_missing = True

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -419,10 +419,14 @@ Returns
     def tqdm.contrib.tmap(function, *sequences, **tqdm_kwargs):
         """Equivalent of builtin `map`."""
 
+``contrib``
+-----------
+
 The ``tqdm.contrib`` package also contains experimental modules:
 
 - ``tqdm.contrib.itertools``: Thin wrappers around ``itertools``
 - ``tqdm.contrib.concurrent``: Thin wrappers around ``concurrent.futures``
+- ``tqdm.contrib.telegram``: Posts to `Telegram <https://telegram.org/>`__ bots
 
 Examples and Advanced Usage
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -605,10 +605,14 @@ Returns
     def tqdm.contrib.tmap(function, *sequences, **tqdm_kwargs):
         """Equivalent of builtin `map`."""
 
+``contrib``
+-----------
+
 The ``tqdm.contrib`` package also contains experimental modules:
 
 - ``tqdm.contrib.itertools``: Thin wrappers around ``itertools``
 - ``tqdm.contrib.concurrent``: Thin wrappers around ``concurrent.futures``
+- ``tqdm.contrib.telegram``: Posts to `Telegram <https://telegram.org/>`__ bots
 
 Examples and Advanced Usage
 ---------------------------

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -72,6 +72,7 @@ class TelegramIO():
 class tqdm_telegram(tqdm_auto):
     """
     Standard `tqdm.auto.tqdm` but also sends updates to a Telegram bot.
+    May take a few seconds to create (`__init__`) and clear (`__del__`).
 
     >>> from tqdm.contrib.telegram import tqdm, trange
     >>> for i in tqdm(
@@ -113,6 +114,11 @@ class tqdm_telegram(tqdm_auto):
                 pass
         instance = super(tqdm_telegram, cls).__new__(cls, *args, **kwargs)
         with cls.get_lock():
+            try:
+                # `tqdm_auto` may have been changed so update
+                cls._instances.update(tqdm_auto._instances)
+            except AttributeError:
+                pass
             tqdm_auto._instances = cls._instances
         return instance
 

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -78,6 +78,19 @@ class tqdm_telegram(tqdm_auto):
         fmt['bar_format'] = fmt['bar_format'].replace('{bar}', '{bar:10u}')
         self.tgio.write(self.format_meter(**fmt))
 
+    def __new__(cls, *args, **kwargs):
+        """
+        Workaround for mixed-class same-stream nested progressbars.
+        See [#509](https://github.com/tqdm/tqdm/issues/509)
+        """
+        try:
+            cls._instances = tqdm_auto._instances
+        except AttributeError:
+            pass
+        instance = super(tqdm_telegram, cls).__new__(cls, *args, **kwargs)
+        tqdm_auto._instances = cls._instances
+        return instance
+
 
 def ttgrange(*args, **kwargs):
     """

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -8,7 +8,6 @@ Usage:
         ...
 """
 from __future__ import absolute_import
-from html import escape
 
 from requests import Session
 
@@ -29,8 +28,8 @@ class TelegramIO():
         try:
             res = session.post(
                 self.API + '%s/sendMessage' % self.token,
-                data=dict(text=escape(self.text), chat_id=self.chat_id,
-                          parse_mode='HTML'))
+                data=dict(text='`' + self.text + '`', chat_id=self.chat_id,
+                          parse_mode='MarkdownV2'))
         except Exception as e:
             print(e)
         else:
@@ -46,8 +45,8 @@ class TelegramIO():
         try:
             return self.session.post(
                 self.API + '%s/editMessageText' % self.token,
-                data=dict(text=escape(s), chat_id=self.chat_id,
-                          message_id=self.message_id, parse_mode='HTML'))
+                data=dict(text='`' + s + '`', chat_id=self.chat_id,
+                          message_id=self.message_id, parse_mode='MarkdownV2'))
         except Exception as e:
             print(e)
 
@@ -60,7 +59,6 @@ class tqdm_telegram(tqdm_auto):
         token  : str, required. Telegram token.
         chat_id  : str, required. Telegram chat ID.
 
-
         See `tqdm.auto.tqdm.__init__` for other parameters.
         """
         self.tgio = TelegramIO(kwargs.pop('token'), kwargs.pop('chat_id'))
@@ -71,6 +69,9 @@ class tqdm_telegram(tqdm_auto):
         fmt = self.format_dict
         if 'bar_format' in fmt and fmt['bar_format']:
             fmt['bar_format'] = fmt['bar_format'].replace('<bar/>', '{bar}')
+        else:
+            fmt['bar_format'] = '{l_bar}{bar}{r_bar}'
+        fmt['bar_format'] = fmt['bar_format'].replace('{bar}', '{bar:10u}')
         self.tgio.write(self.format_meter(**fmt))
 
 

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -106,12 +106,14 @@ class tqdm_telegram(tqdm_auto):
         Workaround for mixed-class same-stream nested progressbars.
         See [#509](https://github.com/tqdm/tqdm/issues/509)
         """
-        try:
-            cls._instances = tqdm_auto._instances
-        except AttributeError:
-            pass
+        with cls.get_lock():
+            try:
+                cls._instances = tqdm_auto._instances
+            except AttributeError:
+                pass
         instance = super(tqdm_telegram, cls).__new__(cls, *args, **kwargs)
-        tqdm_auto._instances = cls._instances
+        with cls.get_lock():
+            tqdm_auto._instances = cls._instances
         return instance
 
 

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -14,20 +14,22 @@ from telepot import Bot
 from tqdm.auto import tqdm as tqdm_auto
 from tqdm.utils import _range
 __author__ = {"github.com/": ["casperdcl"]}
-__all__ = ['TelegramIO', 'tqdm_telegram', 'tqdm']
+__all__ = ['TelegramIO', 'tqdm_telegram', 'ttgrange', 'tqdm', 'trange']
 
 
 class TelegramIO():
     def __init__(self, token, chat_id):
         self.bot = Bot(token)
         self.chat_id = chat_id
-        self.message_id = self.bot.sendMessage(
-            chat_id, self.__class__.__name__)['message_id']
+        self.text = self.__class__.__name__
+        self.message_id = self.bot.sendMessage(chat_id, self.text)['message_id']
 
     def write(self, s):
         if s:
-            self.bot.editMessageText(
-                (self.chat_id, self.message_id), s.strip().replace('\r', ''))
+            s = s.strip().replace('\r', '')
+            if s != self.text:  # avoid duplicate message Bot error
+                self.text = s
+                self.bot.editMessageText((self.chat_id, self.message_id), s)
 
 
 class tqdm_telegram(tqdm_auto):
@@ -49,7 +51,6 @@ class tqdm_telegram(tqdm_auto):
         fmt = self.format_dict
         if 'bar_format' in fmt and fmt['bar_format']:
             fmt['bar_format'] = fmt['bar_format'].replace('<bar/>', '{bar}')
-        fmt['ncols'] = 50
         self.tgio.write(self.format_meter(**fmt))
 
 

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -66,10 +66,10 @@ class tqdm_telegram(tqdm_auto):
         See `tqdm.auto.tqdm.__init__` for other parameters.
         """
         self.tgio = TelegramIO(kwargs.pop('token'), kwargs.pop('chat_id'))
-        super().__init__(*args, **kwargs)
+        super(tqdm_telegram, self).__init__(*args, **kwargs)
 
     def display(self, msg=None, **kwargs):
-        super().display(msg=msg, **kwargs)
+        super(tqdm_telegram, self).display(msg=msg, **kwargs)
         fmt = self.format_dict
         if 'bar_format' in fmt and fmt['bar_format']:
             fmt['bar_format'] = fmt['bar_format'].replace('<bar/>', '{bar}')

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -1,0 +1,66 @@
+"""
+Send updates to a Telegram bot.
+
+Usage:
+    from tqdm.contrib.telegram import tqdm, trange
+    for i in trange(10, token='1234567890:THIS1SSOMETOKEN0BTAINeDfrOmTELEGrAM',
+                    chat_id='0246813579'):
+        ...
+"""
+from __future__ import absolute_import
+
+from telepot import Bot
+
+from tqdm.auto import tqdm as tqdm_auto
+from tqdm.utils import _range
+__author__ = {"github.com/": ["casperdcl"]}
+__all__ = ['TelegramIO', 'tqdm_telegram', 'tqdm']
+
+
+class TelegramIO():
+    def __init__(self, token, chat_id):
+        self.bot = Bot(token)
+        self.chat_id = chat_id
+        self.message_id = self.bot.sendMessage(
+            chat_id, self.__class__.__name__)['message_id']
+
+    def write(self, s):
+        if s:
+            self.bot.editMessageText(
+                (self.chat_id, self.message_id), s.strip().replace('\r', ''))
+
+
+class tqdm_telegram(tqdm_auto):
+    def __init__(self, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        token  : str, required. Telegram token.
+        chat_id  : str, required. Telegram chat ID.
+
+
+        See `tqdm.auto.tqdm.__init__` for other parameters.
+        """
+        self.tgio = TelegramIO(kwargs.pop('token'), kwargs.pop('chat_id'))
+        super().__init__(*args, **kwargs)
+
+    def display(self, msg=None, **kwargs):
+        super().display(msg=msg, **kwargs)
+        fmt = self.format_dict
+        if 'bar_format' in fmt and fmt['bar_format']:
+            fmt['bar_format'] = fmt['bar_format'].replace('<bar/>', '{bar}')
+        fmt['ncols'] = 50
+        self.tgio.write(self.format_meter(**fmt))
+
+
+def ttgrange(*args, **kwargs):
+    """
+    A shortcut for `tqdm.contrib.telegram.tqdm(xrange(*args), **kwargs)`.
+    On Python3+, `range` is used instead of `xrange`.
+    """
+    return tqdm_telegram(_range(*args), **kwargs)
+
+
+# Aliases
+tqdm = tqdm_telegram
+trange = ttgrange

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -34,7 +34,7 @@ class TelegramIO():
                 data=dict(text='`' + self.text + '`', chat_id=self.chat_id,
                           parse_mode='MarkdownV2'))
         except Exception as e:
-            print(e)
+            tqdm_auto.write(str(e))
         else:
             self.message_id = res.json()['result']['message_id']
 
@@ -52,7 +52,7 @@ class TelegramIO():
                 data=dict(text='`' + s + '`', chat_id=self.chat_id,
                           message_id=self.message_id, parse_mode='MarkdownV2'))
         except Exception as e:
-            print(e)
+            tqdm_auto.write(str(e))
 
 
 class tqdm_telegram(tqdm_auto):

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -9,6 +9,7 @@ Usage:
 """
 from __future__ import absolute_import
 
+from concurrent.futures import ThreadPoolExecutor
 from requests import Session
 
 from tqdm.auto import tqdm as tqdm_auto
@@ -25,6 +26,8 @@ class TelegramIO():
         self.chat_id = chat_id
         self.session = session = Session()
         self.text = self.__class__.__name__
+        self.pool = pool = ThreadPoolExecutor()
+        self.submit = pool.__enter__().submit
         try:
             res = session.post(
                 self.API + '%s/sendMessage' % self.token,
@@ -43,7 +46,8 @@ class TelegramIO():
             return  # avoid duplicate message Bot error
         self.text = s
         try:
-            return self.session.post(
+            return self.submit(
+                self.session.post,
                 self.API + '%s/editMessageText' % self.token,
                 data=dict(text='`' + s + '`', chat_id=self.chat_id,
                           message_id=self.message_id, parse_mode='MarkdownV2'))


### PR DESCRIPTION
Example use pushing to Telegram.

- [x] document
- [x] subclass work-around #509
- [x] use `requests`
  + [x] make non-blocking
- fixes #948

To test:

```bash
$ pip install 'git+https://github.com/tqdm/tqdm.git@telegram#egg=tqdm'
```
```python
from time import sleep
from tqdm.contrib.telegram import tqdm, trange
for i in trange(10, token='1234567890:THIS1SSOMETOKEN0BTAINeDfrOmTELEGrAM',
                chat_id='0246813579'):
    sleep(1)
```

Idea from [tg_tqdm](https://github.com/datagym-ru/tg_tqdm):

![](https://github.com/ermakovpetr/tg_tqdm/blob/master/tg_tqdm_how_it_work.gif?raw=true)