### PR TITLE
Speed up tqdm.auto import when not in an IPython notebook

### DIFF
--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -1,7 +1,8 @@
 import os
+import sys
 
 try:
-    from IPython import get_ipython
+    get_ipython = sys.modules['IPython'].get_ipython
     if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover
         raise ImportError("console")
     if 'VSCODE_PID' in os.environ:  # pragma: no cover

--- a/tqdm/contrib/utils_worker.py
+++ b/tqdm/contrib/utils_worker.py
@@ -29,7 +29,7 @@ class MonoWorker(object):
                 if len(futures):  # clear waiting
                     waiting = futures.pop()
                     waiting.cancel()
-                futures.append(running)  # re-insert running
+                futures.appendleft(running)  # re-insert running
         try:
             waiting = self.pool.submit(func, *args, **kwargs)
         except Exception as e:


### PR DESCRIPTION
In tqdm.auto, look for `IPython` in `sys.modules` rather than explicitly importing it. If we are in an IPython notebook, then IPython will have already been imported. If we are not in an IPython notebook, then importing IPython will take almost half a second.

Here are import times on a 2018 MacBook Pro with an SSD. Before this patch:

    $ time python -c 'from tqdm.auto import tqdm'

    real     0m0.474s
    user     0m0.278s
    sys      0m0.142s

After this patch:

    $ time python -c 'from tqdm.auto import tqdm'

    real    0m0.069s
    user    0m0.041s
    sys     0m0.020s

Fixes #709.