### PR TITLE
`DummyTqdmFile` line buffering

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Advice: use repr(our_file.read()) to print the full output of tqdm
 # (else '\r' will replace the previous lines and you'll see only the latest.
+from __future__ import print_function
 
 import csv
 import os
@@ -1722,8 +1723,14 @@ def test_file_redirection():
     with closing(StringIO()) as our_file:
         # Redirect stdout to tqdm.write()
         with std_out_err_redirect_tqdm(tqdm_file=our_file):
-            for _ in trange(3):
+            with tqdm(total=3) as pbar:
                 print("Such fun")
+                pbar.update(1)
+                print("Such", "fun")
+                pbar.update(1)
+                print("Such ", end="")
+                print("fun")
+                pbar.update(1)
         res = our_file.getvalue()
         assert res.count("Such fun\n") == 3
         assert "0/3" in res

--- a/tqdm/contrib/__init__.py
+++ b/tqdm/contrib/__init__.py
@@ -16,10 +16,19 @@ __all__ = ['tenumerate', 'tzip', 'tmap']
 
 class DummyTqdmFile(ObjectWrapper):
     """Dummy file-like that will write to tqdm"""
+    def __init__(self, wrapped):
+        super(DummyTqdmFile, self).__init__(wrapped)
+        self._buf = []
+
     def write(self, x, nolock=False):
-        # Avoid print() second call (useless \n)
-        if len(x.rstrip()) > 0:
-            tqdm.write(x, file=self._wrapped, nolock=nolock)
+        nl = "\n" if isinstance(x, str) else b"\n"
+        pre, sep, post = x.rpartition(nl)
+        if sep:
+            tqdm.write(type(nl)().join(self._buf) + pre,
+                       file=self._wrapped, nolock=nolock)
+            self._buf = [post]
+        else:
+            self._buf.append(x)
 
 
 def builtin_iterable(func):


### PR DESCRIPTION
Only call `tqdm.write` (which inserts a newline) if
`DummyTqdmFile.write` is itself called with a string containing a
newline; otherwise buffer the rest of the string.

See changes in test_tqdm.py for the patterns this allows.

- [X] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [X] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [X] I have visited the [source website], and in particular
  read the [known issues]
- [X] I have searched through the [issue tracker] for duplicates
- [ ] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
