### PR TITLE
add contrib.discord: first Discord Bot!

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 omit =
     tqdm/tests/*
+    tqdm/contrib/discord.py
     tqdm/contrib/telegram.py
 [report]
 show_missing = True

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -428,6 +428,7 @@ The ``tqdm.contrib`` package also contains experimental modules:
 
 - ``tqdm.contrib.itertools``: Thin wrappers around ``itertools``
 - ``tqdm.contrib.concurrent``: Thin wrappers around ``concurrent.futures``
+- ``tqdm.contrib.discord``: Posts to `Discord <https://discord.com/>`__ bots
 - ``tqdm.contrib.telegram``: Posts to `Telegram <https://telegram.org/>`__ bots
 
 Examples and Advanced Usage

--- a/README.rst
+++ b/README.rst
@@ -616,6 +616,7 @@ The ``tqdm.contrib`` package also contains experimental modules:
 
 - ``tqdm.contrib.itertools``: Thin wrappers around ``itertools``
 - ``tqdm.contrib.concurrent``: Thin wrappers around ``concurrent.futures``
+- ``tqdm.contrib.discord``: Posts to `Discord <https://discord.com/>`__ bots
 - ``tqdm.contrib.telegram``: Posts to `Telegram <https://telegram.org/>`__ bots
 
 Examples and Advanced Usage

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -1,3 +1,6 @@
+"""
+Module version for monitoring CLI pipes (`... | python -m tqdm | ...`).
+"""
 from .std import tqdm, TqdmTypeError, TqdmKeyError
 from ._version import __version__  # NOQA
 import sys

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -2,6 +2,8 @@
 Sends updates to a Discord bot.
 """
 from __future__ import absolute_import
+from copy import deepcopy
+from os import getenv
 
 try:
     from disco.client import Client, ClientConfig
@@ -34,7 +36,7 @@ class DiscordIO(MonoWorker):
         """Replaces internal `message`'s text with `s`."""
         if not s:
             return
-        s = s.strip().replace('\r', '')
+        s = s.replace('\r', '').strip()
         if s == self.text:
             return  # skip duplicate message
         self.text = s
@@ -62,13 +64,19 @@ class tqdm_discord(tqdm_auto):
         Parameters
         ----------
         token  : str, required. Discord token
+            [default: ${TQDM_DISCORD_TOKEN}].
         channel_id  : int, required. Discord channel ID
+            [default: ${TQDM_DISCORD_CHANNEL_ID}].
         mininterval  : float, optional.
           Minimum of [default: 1.5] to avoid rate limit.
 
         See `tqdm.auto.tqdm.__init__` for other parameters.
         """
-        self.dio = DiscordIO(kwargs.pop('token'), kwargs.pop('channel_id'))
+        kwargs = deepcopy(kwargs)
+        self.dio = DiscordIO(
+            kwargs.pop('token', getenv("TQDM_DISCORD_TOKEN")),
+            kwargs.pop('channel_id', getenv("TQDM_DISCORD_CHANNEL_ID")))
+
         kwargs['mininterval'] = max(1.5, kwargs.get('mininterval', 1.5))
         super(tqdm_discord, self).__init__(*args, **kwargs)
 

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -16,7 +16,7 @@ __all__ = ['DiscordIO', 'tqdm_discord', 'tdrange', 'tqdm', 'trange']
 
 
 class DiscordIO(MonoWorker):
-    """Non-blocking file-like IO to using a Discord Bot."""
+    """Non-blocking file-like IO using a Discord Bot."""
     def __init__(self, token, channel_id):
         """Creates a new message in the given `channel_id`."""
         super(DiscordIO, self).__init__()
@@ -25,30 +25,30 @@ class DiscordIO(MonoWorker):
         client = Client(config)
         self.text = self.__class__.__name__
         try:
-            self.msg = client.api.channels_messages_create(
+            self.message = client.api.channels_messages_create(
                 channel_id, self.text)
         except Exception as e:
             tqdm_auto.write(str(e))
 
     def write(self, s):
-        """Replaces internal `message_id`'s text with `s`."""
+        """Replaces internal `message`'s text with `s`."""
         if not s:
             return
         s = s.strip().replace('\r', '')
         if s == self.text:
-            return  # avoid duplicate message Bot error
+            return  # skip duplicate message
         self.text = s
         try:
-            f = self.submit(self.msg.edit, '`' + s + '`')
+            future = self.submit(self.message.edit, '`' + s + '`')
         except Exception as e:
             tqdm_auto.write(str(e))
         else:
-            return f
+            return future
 
 
 class tqdm_discord(tqdm_auto):
     """
-    Standard `tqdm.auto.tqdm` but also sends updates to a Discord bot.
+    Standard `tqdm.auto.tqdm` but also sends updates to a Discord Bot.
     May take a few seconds to create (`__init__`).
 
     >>> from tqdm.contrib.discord import tqdm, trange
@@ -61,8 +61,8 @@ class tqdm_discord(tqdm_auto):
         """
         Parameters
         ----------
-        token  : str, required. Telegram token.
-        chat_id  : str, required. Telegram chat ID.
+        token  : str, required. Discord token
+        channel_id  : int, required. Discord channel ID
         mininterval  : float, optional.
           Minimum of [default: 1.5] to avoid rate limit.
 

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -49,7 +49,7 @@ class DiscordIO(MonoWorker):
 class tqdm_discord(tqdm_auto):
     """
     Standard `tqdm.auto.tqdm` but also sends updates to a Discord bot.
-    May take a few seconds to create (`__init__`) and clear (`__del__`).
+    May take a few seconds to create (`__init__`).
 
     >>> from tqdm.contrib.discord import tqdm, trange
     >>> for i in tqdm(

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -1,0 +1,131 @@
+"""
+Sends updates to a Discord bot.
+"""
+from __future__ import absolute_import
+
+from concurrent.futures import ThreadPoolExecutor
+try:
+    from disco.client import Client, ClientConfig
+except ImportError:
+    raise ImportError("Please `pip install disco-py`")
+
+from tqdm.auto import tqdm as tqdm_auto
+from tqdm.utils import _range
+__author__ = {"github.com/": ["casperdcl"]}
+__all__ = ['DiscordIO', 'tqdm_discord', 'tdrange', 'tqdm', 'trange']
+
+
+class DiscordIO():
+    """Non-blocking file-like IO to using a Discord Bot."""
+    def __init__(self, token, channel_id):
+        """Creates a new message in the given `channel_id`."""
+        config = ClientConfig()
+        config.token = token
+        client = Client(config)
+        self.text = self.__class__.__name__
+        self.pool = ThreadPoolExecutor()
+        self.futures = []
+        try:
+            self.msg = client.api.channels_messages_create(
+                channel_id, self.text)
+        except Exception as e:
+            tqdm_auto.write(str(e))
+
+    def write(self, s):
+        """Replaces internal `message_id`'s text with `s`."""
+        if not s:
+            return
+        s = s.strip().replace('\r', '')
+        if s == self.text:
+            return  # avoid duplicate message Bot error
+        self.text = s
+        try:
+            f = self.pool.submit(self.msg.edit, '`' + s + '`')
+        except Exception as e:
+            tqdm_auto.write(str(e))
+        else:
+            self.futures.append(f)
+            return f
+
+    def flush(self):
+        """Ensure the last `write` has been processed."""
+        [f.cancel() for f in self.futures[-2::-1]]
+        try:
+            return self.futures[-1].result()
+        except IndexError:
+            pass
+        finally:
+            self.futures = []
+
+    def __del__(self):
+        self.flush()
+
+
+class tqdm_discord(tqdm_auto):
+    """
+    Standard `tqdm.auto.tqdm` but also sends updates to a Discord bot.
+    May take a few seconds to create (`__init__`) and clear (`__del__`).
+
+    >>> from tqdm.contrib.discord import tqdm, trange
+    >>> for i in tqdm(
+    ...     iterable,
+    ...     token='THIS1SSOMETOKEN0BTAINeDfrOmD1SC0rd',
+    ...     channel_id=0246813579):
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        token  : str, required. Telegram token.
+        chat_id  : str, required. Telegram chat ID.
+        mininterval  : float, optional.
+          Minimum of [default: 1.5] to avoid rate limit.
+
+        See `tqdm.auto.tqdm.__init__` for other parameters.
+        """
+        self.dio = DiscordIO(kwargs.pop('token'), kwargs.pop('channel_id'))
+        kwargs['mininterval'] = max(1.5, kwargs.get('mininterval', 1.5))
+        super(tqdm_discord, self).__init__(*args, **kwargs)
+
+    def display(self, **kwargs):
+        super(tqdm_discord, self).display(**kwargs)
+        fmt = self.format_dict
+        if 'bar_format' in fmt and fmt['bar_format']:
+            fmt['bar_format'] = fmt['bar_format'].replace('<bar/>', '{bar}')
+        else:
+            fmt['bar_format'] = '{l_bar}{bar}{r_bar}'
+        fmt['bar_format'] = fmt['bar_format'].replace('{bar}', '{bar:10u}')
+        self.dio.write(self.format_meter(**fmt))
+
+    def __new__(cls, *args, **kwargs):
+        """
+        Workaround for mixed-class same-stream nested progressbars.
+        See [#509](https://github.com/tqdm/tqdm/issues/509)
+        """
+        with cls.get_lock():
+            try:
+                cls._instances = tqdm_auto._instances
+            except AttributeError:
+                pass
+        instance = super(tqdm_discord, cls).__new__(cls, *args, **kwargs)
+        with cls.get_lock():
+            try:
+                # `tqdm_auto` may have been changed so update
+                cls._instances.update(tqdm_auto._instances)
+            except AttributeError:
+                pass
+            tqdm_auto._instances = cls._instances
+        return instance
+
+
+def tdrange(*args, **kwargs):
+    """
+    A shortcut for `tqdm.contrib.discord.tqdm(xrange(*args), **kwargs)`.
+    On Python3+, `range` is used instead of `xrange`.
+    """
+    return tqdm_discord(_range(*args), **kwargs)
+
+
+# Aliases
+tqdm = tqdm_discord
+trange = tdrange

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -13,7 +13,7 @@ __all__ = ['TelegramIO', 'tqdm_telegram', 'ttgrange', 'tqdm', 'trange']
 
 
 class TelegramIO(MonoWorker):
-    """Non-blocking file-like IO to a Telegram Bot."""
+    """Non-blocking file-like IO using a Telegram Bot."""
     API = 'https://api.telegram.org/bot'
 
     def __init__(self, token, chat_id):
@@ -42,7 +42,7 @@ class TelegramIO(MonoWorker):
             return  # avoid duplicate message Bot error
         self.text = s
         try:
-            f = self.submit(
+            future = self.submit(
                 self.session.post,
                 self.API + '%s/editMessageText' % self.token,
                 data=dict(
@@ -51,12 +51,12 @@ class TelegramIO(MonoWorker):
         except Exception as e:
             tqdm_auto.write(str(e))
         else:
-            return f
+            return future
 
 
 class tqdm_telegram(tqdm_auto):
     """
-    Standard `tqdm.auto.tqdm` but also sends updates to a Telegram bot.
+    Standard `tqdm.auto.tqdm` but also sends updates to a Telegram Bot.
     May take a few seconds to create (`__init__`).
 
     >>> from tqdm.contrib.telegram import tqdm, trange

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -57,7 +57,7 @@ class TelegramIO(MonoWorker):
 class tqdm_telegram(tqdm_auto):
     """
     Standard `tqdm.auto.tqdm` but also sends updates to a Telegram bot.
-    May take a few seconds to create (`__init__`) and clear (`__del__`).
+    May take a few seconds to create (`__init__`).
 
     >>> from tqdm.contrib.telegram import tqdm, trange
     >>> for i in tqdm(

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -2,6 +2,8 @@
 Sends updates to a Telegram bot.
 """
 from __future__ import absolute_import
+from copy import deepcopy
+from os import getenv
 
 from requests import Session
 
@@ -37,7 +39,7 @@ class TelegramIO(MonoWorker):
         """Replaces internal `message_id`'s text with `s`."""
         if not s:
             return
-        s = s.strip().replace('\r', '')
+        s = s.replace('\r', '').strip()
         if s == self.text:
             return  # avoid duplicate message Bot error
         self.text = s
@@ -69,12 +71,17 @@ class tqdm_telegram(tqdm_auto):
         """
         Parameters
         ----------
-        token  : str, required. Telegram token.
-        chat_id  : str, required. Telegram chat ID.
+        token  : str, required. Telegram token
+            [default: ${TQDM_TELEGRAM_TOKEN}].
+        chat_id  : str, required. Telegram chat ID
+            [default: ${TQDM_TELEGRAM_CHAT_ID}].
 
         See `tqdm.auto.tqdm.__init__` for other parameters.
         """
-        self.tgio = TelegramIO(kwargs.pop('token'), kwargs.pop('chat_id'))
+        kwargs = deepcopy(kwargs)
+        self.tgio = TelegramIO(
+            kwargs.pop('token', getenv('TQDM_TELEGRAM_TOKEN')),
+            kwargs.pop('chat_id', getenv('TQDM_TELEGRAM_CHAT_ID')))
         super(tqdm_telegram, self).__init__(*args, **kwargs)
 
     def display(self, **kwargs):

--- a/tqdm/contrib/utils_worker.py
+++ b/tqdm/contrib/utils_worker.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+from concurrent.futures import ThreadPoolExecutor
+from collections import deque
+
+from tqdm.auto import tqdm as tqdm_auto
+__author__ = {"github.com/": ["casperdcl"]}
+__all__ = ['MonoWorker']
+
+
+class MonoWorker(object):
+    """
+    Supports one running task and one waiting task.
+    The waiting task is the most recent submitted (others are discarded).
+    """
+    def __init__(self):
+        self.pool = ThreadPoolExecutor(max_workers=1)
+        self.futures = deque([], 2)
+
+    def submit(self, func, *args, **kwargs):
+        futures = self.futures
+        if len(futures) == futures.maxlen:
+            running = futures.popleft()
+            if not running.done():
+                if len(futures):  # clear waiting
+                    waiting = futures.pop()
+                    waiting.cancel()
+                futures.append(running)  # re-insert running
+        try:
+            waiting = self.pool.submit(func, *args, **kwargs)
+        except Exception as e:
+            tqdm_auto.write(str(e))
+        else:
+            futures.append(waiting)
+            return waiting

--- a/tqdm/contrib/utils_worker.py
+++ b/tqdm/contrib/utils_worker.py
@@ -1,3 +1,6 @@
+"""
+IO/concurrency helpers for `tqdm.contrib`.
+"""
 from __future__ import absolute_import
 
 from concurrent.futures import ThreadPoolExecutor
@@ -18,6 +21,7 @@ class MonoWorker(object):
         self.futures = deque([], 2)
 
     def submit(self, func, *args, **kwargs):
+        """`func(*args, **kwargs)` may replace currently waiting task."""
         futures = self.futures
         if len(futures) == futures.maxlen:
             running = futures.popleft()

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -1,3 +1,6 @@
+"""
+General helpers required for `tqdm.std`.
+"""
 from functools import wraps
 import os
 from platform import system as _curos


### PR DESCRIPTION
- [x] add `contrib.discord` (similar to `contrib.telegram`)
- [x] document
- [x] abstract common features with `contrib.telegram`
  + [x] fix lazy large memory usage and discard unsent messages

Steps to test:

- `pip install -U 'git+https://github.com/tqdm/tqdm@discord#egg=tqdm'`
- [create a discord bot (not public, no requirement of OAuth2 code grant, only send message permissions) & invite it to a channel](https://discordpy.readthedocs.io/en/latest/discord.html)
- copy the bot token & channel ID and paste below:

```python
from tqdm.contrib.discord import tqdm, trange
for _ in trange(
	int(1e8),
	token='THIS1SSOMETOKEN0BTAINeDfrOmD1SC0rd',
    channel_id=0246813579,
):
    # worst-case empty for-loop
    # still does ~6M it/s, i.e. overhead ~170 ns/it
	pass
```

Result:

![image](https://user-images.githubusercontent.com/10780059/82755091-62374c80-9dc9-11ea-88bb-fd8cafe854ff.png)