### PR TITLE
Fix error due to missing sys.setcheckinterval in py3.9

### DIFF
--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -123,7 +123,10 @@ def cpu_timify(t, timer=None):
 
 def pretest():
     # setcheckinterval is deprecated
-    getattr(sys, 'setswitchinterval', getattr(sys, 'setcheckinterval'))(100)
+    try:
+        sys.setswitchinterval(1)
+    except AttributeError:
+        sys.setcheckinterval(100)
 
     if getattr(tqdm, "_instances", False):
         n = len(tqdm._instances)


### PR DESCRIPTION
Python 3.9 finally removed sys.setcheckinterval().  While the package
apparently tried to account for that, the logic is flawed and the second
getattr() raises an AttributeError even if its result is never used.
This caused tests to fail:

      File "/tmp/tqdm/tqdm/tests/tests_tqdm.py", line 126, in pretest
        getattr(sys, 'setswitchinterval', getattr(sys, 'setcheckinterval'))(100)
    AttributeError: module 'sys' has no attribute 'setcheckinterval'

Refactor the code into a try/except construct that does not execute
the setcheckinterval() branch unless setswitchinterval() is actually
missing.  While at it, scale the arguments a bit -- the current version
used either 100 instructions or 100 seconds that were rather of very
different magnitudes.

python version:
```
3.9.0b1 (default, May 19 2020, 09:27:48) 
[GCC 9.2.0] linux
```

- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
