### PR TITLE
next release v4.47.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,5 +5,6 @@ omit =
     tqdm/contrib/bells.py
     tqdm/contrib/discord.py
     tqdm/contrib/telegram.py
+    tqdm/contrib/utils_worker.py
 [report]
 show_missing = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 omit =
     tqdm/tests/*
+    tqdm/contrib/bells.py
     tqdm/contrib/discord.py
     tqdm/contrib/telegram.py
 [report]

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 omit =
     tqdm/tests/*
+    tqdm/contrib/discord.py
     tqdm/contrib/telegram.py
 [report]
 show_missing = True

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -139,9 +139,8 @@ Changelog
 
 The list of all changes is available either on GitHub's Releases:
 |GitHub-Status|, on the
-`wiki <https://github.com/tqdm/tqdm/wiki/Releases>`__, on the
-`website <https://tqdm.github.io/releases/>`__, or on crawlers such as
-`allmychanges.com <https://allmychanges.com/p/python/tqdm/>`_.
+`wiki <https://github.com/tqdm/tqdm/wiki/Releases>`__, or on the
+`website <https://tqdm.github.io/releases/>`__.
 
 
 Usage

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -428,6 +428,10 @@ The ``tqdm.contrib`` package also contains experimental modules:
 
 - ``tqdm.contrib.itertools``: Thin wrappers around ``itertools``
 - ``tqdm.contrib.concurrent``: Thin wrappers around ``concurrent.futures``
+- ``tqdm.contrib.bells``: Automagically enables all optional features
+
+  * ``auto``, ``pandas``, ``discord``, ``telegram``
+
 - ``tqdm.contrib.discord``: Posts to `Discord <https://discord.com/>`__ bots
 - ``tqdm.contrib.telegram``: Posts to `Telegram <https://telegram.org/>`__ bots
 

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -428,6 +428,7 @@ The ``tqdm.contrib`` package also contains experimental modules:
 
 - ``tqdm.contrib.itertools``: Thin wrappers around ``itertools``
 - ``tqdm.contrib.concurrent``: Thin wrappers around ``concurrent.futures``
+- ``tqdm.contrib.discord``: Posts to `Discord <https://discord.com/>`__ bots
 - ``tqdm.contrib.telegram``: Posts to `Telegram <https://telegram.org/>`__ bots
 
 Examples and Advanced Usage

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,14 +48,17 @@ jobs:
   - name: py3.7
     python: 3.7
     env: TOXENV=py37
+  - name: py3.8
+    python: 3.8
+    env: TOXENV=py38
   - name: tf-no-keras
     python: 3.7
     env: TOXENV=tf-no-keras
   - name: pypy2.7
-    python: pypy2.7-5.10.0
+    python: pypy2.7-7.1.1
     env: TOXENV=pypy
   - name: pypy3.5
-    python: pypy3.5-5.10.0
+    python: pypy3.6-7.1.1
     env: TOXENV=pypy3
   - stage: development
     name: py2.7-win

--- a/.travis.yml
+++ b/.travis.yml
@@ -187,18 +187,24 @@ jobs:
      - name: snapcraft
        channel: stable
        confinement: classic
+     - name: review-tools
+       channel: stable
      - name: lxd
        channel: stable
     env:
-    - SNAPCRAFT_IMAGE_INFO: '{"build_url": "$TRAVIS_BUILD_URL"}'
+    - SNAPCRAFT_IMAGE_INFO: |
+        '{"build_url": "$TRAVIS_JOB_WEB_URL"}'
+    - SNAPCRAFT_BUILD_ENVIRONMENT: lxd
+    - SNAPCRAFT_BUILD_INFO: 1  # https://snapcraft.io/blog/introducing-developer-notifications-for-snap-security-updates
     before_install:
+    - sudo usermod --append --groups lxd $USER
     - sudo /snap/bin/lxd.migrate -yes
     - sudo /snap/bin/lxd waitready
     - sudo /snap/bin/lxd init --auto
     install:
     - make snapcraft.yaml
     script:
-    - sudo snapcraft --use-lxd
+    - sg lxd -c snapcraft
     after_failure:
     - sudo journalctl -u snapd
     deploy:

--- a/README.rst
+++ b/README.rst
@@ -139,9 +139,8 @@ Changelog
 
 The list of all changes is available either on GitHub's Releases:
 |GitHub-Status|, on the
-`wiki <https://github.com/tqdm/tqdm/wiki/Releases>`__, on the
-`website <https://tqdm.github.io/releases/>`__, or on crawlers such as
-`allmychanges.com <https://allmychanges.com/p/python/tqdm/>`_.
+`wiki <https://github.com/tqdm/tqdm/wiki/Releases>`__, or on the
+`website <https://tqdm.github.io/releases/>`__.
 
 
 Usage

--- a/README.rst
+++ b/README.rst
@@ -616,6 +616,7 @@ The ``tqdm.contrib`` package also contains experimental modules:
 
 - ``tqdm.contrib.itertools``: Thin wrappers around ``itertools``
 - ``tqdm.contrib.concurrent``: Thin wrappers around ``concurrent.futures``
+- ``tqdm.contrib.discord``: Posts to `Discord <https://discord.com/>`__ bots
 - ``tqdm.contrib.telegram``: Posts to `Telegram <https://telegram.org/>`__ bots
 
 Examples and Advanced Usage

--- a/README.rst
+++ b/README.rst
@@ -616,6 +616,10 @@ The ``tqdm.contrib`` package also contains experimental modules:
 
 - ``tqdm.contrib.itertools``: Thin wrappers around ``itertools``
 - ``tqdm.contrib.concurrent``: Thin wrappers around ``concurrent.futures``
+- ``tqdm.contrib.bells``: Automagically enables all optional features
+
+  * ``auto``, ``pandas``, ``discord``, ``telegram``
+
 - ``tqdm.contrib.discord``: Posts to `Discord <https://discord.com/>`__ bots
 - ``tqdm.contrib.telegram``: Posts to `Telegram <https://telegram.org/>`__ bots
 

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation',
         'Programming Language :: Python :: Implementation :: IronPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # deprecation warning: py{26,32,33,34}
-envlist = py{26,27,33,34,35,36,37,py,py3}, tf-no-keras, perf, flake8, setup.py
+envlist = py{26,27,33,34,35,36,37,38,py,py3}, tf-no-keras, perf, flake8, setup.py
 
 [coverage]
 deps =

--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -1,7 +1,8 @@
 import os
+import sys
 
 try:
-    from IPython import get_ipython
+    get_ipython = sys.modules['IPython'].get_ipython
     if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover
         raise ImportError("console")
     if 'VSCODE_PID' in os.environ:  # pragma: no cover

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -1,3 +1,6 @@
+"""
+Module version for monitoring CLI pipes (`... | python -m tqdm | ...`).
+"""
 from .std import tqdm, TqdmTypeError, TqdmKeyError
 from ._version import __version__  # NOQA
 import sys

--- a/tqdm/contrib/bells.py
+++ b/tqdm/contrib/bells.py
@@ -1,0 +1,25 @@
+"""
+All the bells & whistles:
+
+- tqdm.auto
+- tqdm.tqdm.pandas
+- tqdm.contrib.telegram
+    + uses ${TQDM_TELEGRAM_TOKEN} and ${TQDM_TELEGRAM_CHAT_ID}
+- tqdm.contrib.discord
+    + uses ${TQDM_DISCORD_TOKEN} and ${TQDM_DISCORD_CHANNEL_ID}
+"""
+__all__ = ['tqdm', 'trange']
+from os import getenv
+import warnings
+
+
+if getenv("TQDM_TELEGRAM_TOKEN") and getenv("TQDM_TELEGRAM_CHAT_ID"):
+    from tqdm.contrib.telegram import tqdm, trange
+elif getenv("TQDM_DISCORD_TOKEN") and getenv("TQDM_DISCORD_CHANNEL_ID"):
+    from tqdm.contrib.discord import tqdm, trange
+else:
+    from tqdm.auto import tqdm, trange
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=FutureWarning)
+    tqdm.pandas()

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -53,11 +53,14 @@ class tqdm_discord(tqdm_auto):
     Standard `tqdm.auto.tqdm` but also sends updates to a Discord Bot.
     May take a few seconds to create (`__init__`).
 
+    - create a discord bot (not public, no requirement of OAuth2 code
+      grant, only send message permissions) & invite it to a channel:
+      https://discordpy.readthedocs.io/en/latest/discord.html
+    - copy the bot `{token}` & `{channel_id}` and paste below
+
     >>> from tqdm.contrib.discord import tqdm, trange
-    >>> for i in tqdm(
-    ...     iterable,
-    ...     token='THIS1SSOMETOKEN0BTAINeDfrOmD1SC0rd',
-    ...     channel_id=0246813579):
+    >>> for i in tqdm(iterable, token='{token}', channel_id='{channel_id}'):
+    ...     ...
     """
     def __init__(self, *args, **kwargs):
         """

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -1,0 +1,124 @@
+"""
+Sends updates to a Discord bot.
+"""
+from __future__ import absolute_import
+from copy import deepcopy
+from os import getenv
+
+try:
+    from disco.client import Client, ClientConfig
+except ImportError:
+    raise ImportError("Please `pip install disco-py`")
+
+from tqdm.auto import tqdm as tqdm_auto
+from tqdm.utils import _range
+from .utils_worker import MonoWorker
+__author__ = {"github.com/": ["casperdcl"]}
+__all__ = ['DiscordIO', 'tqdm_discord', 'tdrange', 'tqdm', 'trange']
+
+
+class DiscordIO(MonoWorker):
+    """Non-blocking file-like IO using a Discord Bot."""
+    def __init__(self, token, channel_id):
+        """Creates a new message in the given `channel_id`."""
+        super(DiscordIO, self).__init__()
+        config = ClientConfig()
+        config.token = token
+        client = Client(config)
+        self.text = self.__class__.__name__
+        try:
+            self.message = client.api.channels_messages_create(
+                channel_id, self.text)
+        except Exception as e:
+            tqdm_auto.write(str(e))
+
+    def write(self, s):
+        """Replaces internal `message`'s text with `s`."""
+        if not s:
+            return
+        s = s.replace('\r', '').strip()
+        if s == self.text:
+            return  # skip duplicate message
+        self.text = s
+        try:
+            future = self.submit(self.message.edit, '`' + s + '`')
+        except Exception as e:
+            tqdm_auto.write(str(e))
+        else:
+            return future
+
+
+class tqdm_discord(tqdm_auto):
+    """
+    Standard `tqdm.auto.tqdm` but also sends updates to a Discord Bot.
+    May take a few seconds to create (`__init__`).
+
+    >>> from tqdm.contrib.discord import tqdm, trange
+    >>> for i in tqdm(
+    ...     iterable,
+    ...     token='THIS1SSOMETOKEN0BTAINeDfrOmD1SC0rd',
+    ...     channel_id=0246813579):
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        token  : str, required. Discord token
+            [default: ${TQDM_DISCORD_TOKEN}].
+        channel_id  : int, required. Discord channel ID
+            [default: ${TQDM_DISCORD_CHANNEL_ID}].
+        mininterval  : float, optional.
+          Minimum of [default: 1.5] to avoid rate limit.
+
+        See `tqdm.auto.tqdm.__init__` for other parameters.
+        """
+        kwargs = deepcopy(kwargs)
+        self.dio = DiscordIO(
+            kwargs.pop('token', getenv("TQDM_DISCORD_TOKEN")),
+            kwargs.pop('channel_id', getenv("TQDM_DISCORD_CHANNEL_ID")))
+
+        kwargs['mininterval'] = max(1.5, kwargs.get('mininterval', 1.5))
+        super(tqdm_discord, self).__init__(*args, **kwargs)
+
+    def display(self, **kwargs):
+        super(tqdm_discord, self).display(**kwargs)
+        fmt = self.format_dict
+        if 'bar_format' in fmt and fmt['bar_format']:
+            fmt['bar_format'] = fmt['bar_format'].replace('<bar/>', '{bar}')
+        else:
+            fmt['bar_format'] = '{l_bar}{bar}{r_bar}'
+        fmt['bar_format'] = fmt['bar_format'].replace('{bar}', '{bar:10u}')
+        self.dio.write(self.format_meter(**fmt))
+
+    def __new__(cls, *args, **kwargs):
+        """
+        Workaround for mixed-class same-stream nested progressbars.
+        See [#509](https://github.com/tqdm/tqdm/issues/509)
+        """
+        with cls.get_lock():
+            try:
+                cls._instances = tqdm_auto._instances
+            except AttributeError:
+                pass
+        instance = super(tqdm_discord, cls).__new__(cls, *args, **kwargs)
+        with cls.get_lock():
+            try:
+                # `tqdm_auto` may have been changed so update
+                cls._instances.update(tqdm_auto._instances)
+            except AttributeError:
+                pass
+            tqdm_auto._instances = cls._instances
+        return instance
+
+
+def tdrange(*args, **kwargs):
+    """
+    A shortcut for `tqdm.contrib.discord.tqdm(xrange(*args), **kwargs)`.
+    On Python3+, `range` is used instead of `xrange`.
+    """
+    return tqdm_discord(_range(*args), **kwargs)
+
+
+# Aliases
+tqdm = tqdm_discord
+trange = tdrange

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -61,11 +61,16 @@ class tqdm_telegram(tqdm_auto):
     Standard `tqdm.auto.tqdm` but also sends updates to a Telegram Bot.
     May take a few seconds to create (`__init__`).
 
+    - create a bot https://core.telegram.org/bots#6-botfather
+    - copy its `{token}`
+    - add the bot to a chat and send it a message such as `/start`
+    - go to https://api.telegram.org/bot`{token}`/getUpdates to find out
+      the `{chat_id}`
+    - paste the `{token}` & `{chat_id}` below
+
     >>> from tqdm.contrib.telegram import tqdm, trange
-    >>> for i in tqdm(
-    ...     iterable,
-    ...     token='1234567890:THIS1SSOMETOKEN0BTAINeDfrOmTELEGrAM',
-    ...     chat_id='0246813579'):
+    >>> for i in tqdm(iterable, token='{token}', chat_id='{chat_id}'):
+    ...     ...
     """
     def __init__(self, *args, **kwargs):
         """

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -2,28 +2,29 @@
 Sends updates to a Telegram bot.
 """
 from __future__ import absolute_import
+from copy import deepcopy
+from os import getenv
 
-from concurrent.futures import ThreadPoolExecutor
 from requests import Session
 
 from tqdm.auto import tqdm as tqdm_auto
 from tqdm.utils import _range
+from .utils_worker import MonoWorker
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['TelegramIO', 'tqdm_telegram', 'ttgrange', 'tqdm', 'trange']
 
 
-class TelegramIO():
-    """Non-blocking file-like IO to a Telegram Bot."""
+class TelegramIO(MonoWorker):
+    """Non-blocking file-like IO using a Telegram Bot."""
     API = 'https://api.telegram.org/bot'
 
     def __init__(self, token, chat_id):
         """Creates a new message in the given `chat_id`."""
+        super(TelegramIO, self).__init__()
         self.token = token
         self.chat_id = chat_id
         self.session = session = Session()
         self.text = self.__class__.__name__
-        self.pool = ThreadPoolExecutor()
-        self.futures = []
         try:
             res = session.post(
                 self.API + '%s/sendMessage' % self.token,
@@ -38,12 +39,12 @@ class TelegramIO():
         """Replaces internal `message_id`'s text with `s`."""
         if not s:
             return
-        s = s.strip().replace('\r', '')
+        s = s.replace('\r', '').strip()
         if s == self.text:
             return  # avoid duplicate message Bot error
         self.text = s
         try:
-            f = self.pool.submit(
+            future = self.submit(
                 self.session.post,
                 self.API + '%s/editMessageText' % self.token,
                 data=dict(
@@ -52,27 +53,13 @@ class TelegramIO():
         except Exception as e:
             tqdm_auto.write(str(e))
         else:
-            self.futures.append(f)
-            return f
-
-    def flush(self):
-        """Ensure the last `write` has been processed."""
-        [f.cancel() for f in self.futures[-2::-1]]
-        try:
-            return self.futures[-1].result()
-        except IndexError:
-            pass
-        finally:
-            self.futures = []
-
-    def __del__(self):
-        self.flush()
+            return future
 
 
 class tqdm_telegram(tqdm_auto):
     """
-    Standard `tqdm.auto.tqdm` but also sends updates to a Telegram bot.
-    May take a few seconds to create (`__init__`) and clear (`__del__`).
+    Standard `tqdm.auto.tqdm` but also sends updates to a Telegram Bot.
+    May take a few seconds to create (`__init__`).
 
     >>> from tqdm.contrib.telegram import tqdm, trange
     >>> for i in tqdm(
@@ -84,12 +71,17 @@ class tqdm_telegram(tqdm_auto):
         """
         Parameters
         ----------
-        token  : str, required. Telegram token.
-        chat_id  : str, required. Telegram chat ID.
+        token  : str, required. Telegram token
+            [default: ${TQDM_TELEGRAM_TOKEN}].
+        chat_id  : str, required. Telegram chat ID
+            [default: ${TQDM_TELEGRAM_CHAT_ID}].
 
         See `tqdm.auto.tqdm.__init__` for other parameters.
         """
-        self.tgio = TelegramIO(kwargs.pop('token'), kwargs.pop('chat_id'))
+        kwargs = deepcopy(kwargs)
+        self.tgio = TelegramIO(
+            kwargs.pop('token', getenv('TQDM_TELEGRAM_TOKEN')),
+            kwargs.pop('chat_id', getenv('TQDM_TELEGRAM_CHAT_ID')))
         super(tqdm_telegram, self).__init__(*args, **kwargs)
 
     def display(self, **kwargs):

--- a/tqdm/contrib/utils_worker.py
+++ b/tqdm/contrib/utils_worker.py
@@ -1,0 +1,39 @@
+"""
+IO/concurrency helpers for `tqdm.contrib`.
+"""
+from __future__ import absolute_import
+
+from concurrent.futures import ThreadPoolExecutor
+from collections import deque
+
+from tqdm.auto import tqdm as tqdm_auto
+__author__ = {"github.com/": ["casperdcl"]}
+__all__ = ['MonoWorker']
+
+
+class MonoWorker(object):
+    """
+    Supports one running task and one waiting task.
+    The waiting task is the most recent submitted (others are discarded).
+    """
+    def __init__(self):
+        self.pool = ThreadPoolExecutor(max_workers=1)
+        self.futures = deque([], 2)
+
+    def submit(self, func, *args, **kwargs):
+        """`func(*args, **kwargs)` may replace currently waiting task."""
+        futures = self.futures
+        if len(futures) == futures.maxlen:
+            running = futures.popleft()
+            if not running.done():
+                if len(futures):  # clear waiting
+                    waiting = futures.pop()
+                    waiting.cancel()
+                futures.append(running)  # re-insert running
+        try:
+            waiting = self.pool.submit(func, *args, **kwargs)
+        except Exception as e:
+            tqdm_auto.write(str(e))
+        else:
+            futures.append(waiting)
+            return waiting

--- a/tqdm/contrib/utils_worker.py
+++ b/tqdm/contrib/utils_worker.py
@@ -29,7 +29,7 @@ class MonoWorker(object):
                 if len(futures):  # clear waiting
                     waiting = futures.pop()
                     waiting.cancel()
-                futures.append(running)  # re-insert running
+                futures.appendleft(running)  # re-insert running
         try:
             waiting = self.pool.submit(func, *args, **kwargs)
         except Exception as e:

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -53,7 +53,7 @@ class tqdm_gui(std_tqdm):  # pragma: no cover
         self.mininterval = max(self.mininterval, 0.5)
         self.fig, ax = plt.subplots(figsize=(9, 2.2))
         # self.fig.subplots_adjust(bottom=0.2)
-        total = len(self)
+        total = self.__len__()  # avoids TypeError on None #971
         if total is not None:
             self.xdata = []
             self.ydata = []

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -56,6 +56,7 @@ if True:  # pragma: no cover
             IPY = 2
         except ImportError:
             IPY = 0
+            IProgress = None
 
     try:
         from IPython.display import display  # , clear_output
@@ -91,19 +92,17 @@ class tqdm_notebook(std_tqdm):
         # fp = file
 
         # Prepare IPython progress bar
-        try:
-            if total:
-                pbar = IProgress(min=0, max=total)
-            else:  # No total? Show info style bar with no progress tqdm status
-                pbar = IProgress(min=0, max=1)
-                pbar.value = 1
-                pbar.bar_style = 'info'
-        except NameError:
-            # #187 #451 #558
+        if IProgress is None:  # #187 #451 #558 #872
             raise ImportError(
-                "FloatProgress not found. Please update jupyter and ipywidgets."
+                "IProgress not found. Please update jupyter and ipywidgets."
                 " See https://ipywidgets.readthedocs.io/en/stable"
                 "/user_install.html")
+        if total:
+            pbar = IProgress(min=0, max=total)
+        else:  # No total? Show info style bar with no progress tqdm status
+            pbar = IProgress(min=0, max=1)
+            pbar.value = 1
+            pbar.bar_style = 'info'
 
         if desc:
             pbar.description = desc

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -1,3 +1,6 @@
+"""
+General helpers required for `tqdm.std`.
+"""
 from functools import wraps
 import os
 from platform import system as _curos


### PR DESCRIPTION
- add `contrib.discord` (similar to `contrib.telegram`) (#976)
- add `contrib.bells` to auto-enable all extras
- add `contrib.utils_worker` for common slow tasks (e.g. web I/O)
  + fix lazy large memory usage & discard unsent messages (unprocessed tasks)
- fix slow notebook imports (#955 <- #709)
- fix `gui` `TypeError` on unknown `len()` (#971)
- misc documentation/error message updates
  + more succinct ImportError on missing `ipywidgets` (#872)
  + fix broken/deprecated link (#981)
  + add inline usage for `contrib.discord` and `contrib.telegram`
- misc framework updates
  + add official `py3.8` support (#986)
  + fix `snap` builds

---

- fixes #981
- closes #986
- closes #976
- closes #955
- fixes #709
- fixes #872
- fixes #971

---

- [ ] maybe add docs/images

![image](https://user-images.githubusercontent.com/10780059/82755091-62374c80-9dc9-11ea-88bb-fd8cafe854ff.png)

![](https://github.com/ermakovpetr/tg_tqdm/blob/master/tg_tqdm_how_it_work.gif?raw=true)