### PR TITLE
cli: add --update and --update_to

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -272,6 +272,16 @@ Or done on a file level using 7-zip:
       | grep -v Compressing
     100%|██████████████████████████▉| 15327/15327 [01:00<00:00, 712.96files/s]
 
+Pre-existing CLI programs already outputting basic progress information will
+benefit from ``tqdm``'s ``--update`` and ``--update_to`` flags:
+
+.. code:: sh
+
+    seq 3 0.1 5 | tqdm --total 5 --update_to --null
+    100%|████████████████████████████████████| 5.0/5 [00:00<00:00, 9673.21it/s]
+    seq 10 | tqdm --update --null  # 1 + 2 + ... + 10 = 55 iterations
+    55it [00:00, 90006.52it/s]
+
 FAQ and Known Issues
 --------------------
 

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ tqdm/tqdm.1: .meta/.tqdm.1.md tqdm/cli.py tqdm/std.py
 	python -m tqdm --help | tail -n+5 |\
     sed -r -e 's/\\/\\\\/g' \
       -e 's/^  (--.*)=<(.*)>  : (.*)$$/\n\\\1=*\2*\n: \3./' \
+      -e 's/^  (--.*)  : (.*)$$/\n\\\1\n: \2./' \
       -e 's/  (-.*, )(--.*)  /\n\1\\\2\n: /' |\
     cat "$<" - |\
     pandoc -o "$@" -s -t man

--- a/README.rst
+++ b/README.rst
@@ -272,6 +272,16 @@ Or done on a file level using 7-zip:
       | grep -v Compressing
     100%|██████████████████████████▉| 15327/15327 [01:00<00:00, 712.96files/s]
 
+Pre-existing CLI programs already outputting basic progress information will
+benefit from ``tqdm``'s ``--update`` and ``--update_to`` flags:
+
+.. code:: sh
+
+    seq 3 0.1 5 | tqdm --total 5 --update_to --null
+    100%|████████████████████████████████████| 5.0/5 [00:00<00:00, 9673.21it/s]
+    seq 10 | tqdm --update --null  # 1 + 2 + ... + 10 = 55 iterations
+    55it [00:00, 90006.52it/s]
+
 FAQ and Known Issues
 --------------------
 

--- a/README.rst
+++ b/README.rst
@@ -471,6 +471,8 @@ Extra CLI Options
 * update_to  : bool, optional  
     If true, will treat input as total elapsed iterations,
     i.e. numbers to assign to ``self.n``.
+* null  : bool, optional  
+    If true, will discard input (no stdout).
 * manpath  : str, optional  
     Directory in which to install tqdm man pages.
 * comppath  : str, optional  

--- a/README.rst
+++ b/README.rst
@@ -465,6 +465,12 @@ Extra CLI Options
     ``unit_scale`` to True, ``unit_divisor`` to 1024, and ``unit`` to 'B'.
 * tee  : bool, optional  
     If true, passes ``stdin`` to both ``stderr`` and ``stdout``.
+* update  : bool, optional  
+    If true, will treat input as newly elapsed iterations,
+    i.e. numbers to pass to ``update()``.
+* update_to  : bool, optional  
+    If true, will treat input as total elapsed iterations,
+    i.e. numbers to assign to ``self.n``.
 * manpath  : str, optional  
     Directory in which to install tqdm man pages.
 * comppath  : str, optional  

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -3,9 +3,9 @@ Module version for monitoring CLI pipes (`... | python -m tqdm | ...`).
 """
 from .std import tqdm, TqdmTypeError, TqdmKeyError
 from ._version import __version__  # NOQA
-import sys
-import re
 import logging
+import re
+import sys
 __all__ = ["main"]
 log = logging.getLogger(__name__)
 
@@ -148,6 +148,8 @@ CLI_EXTRA_DOC = r"""
         update_to  : bool, optional
             If true, will treat input as total elapsed iterations,
             i.e. numbers to assign to `self.n`.
+        null  : bool, optional
+            If true, will discard input (no stdout).
         manpath  : str, optional
             Directory in which to install tqdm man pages.
         comppath  : str, optional
@@ -248,8 +250,15 @@ Options:
         tee = tqdm_args.pop('tee', False)
         manpath = tqdm_args.pop('manpath', None)
         comppath = tqdm_args.pop('comppath', None)
+        if tqdm_args.pop('null', False):
+            class stdout(object):
+                @staticmethod
+                def write(_):
+                    pass
+        else:
+            stdout = sys.stdout
+            stdout = getattr(stdout, 'buffer', stdout)
         stdin = getattr(sys.stdin, 'buffer', sys.stdin)
-        stdout = getattr(sys.stdout, 'buffer', sys.stdout)
         if manpath or comppath:
             from os import path
             from shutil import copyfile

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -198,8 +198,9 @@ def main(fp=sys.stderr, argv=None):
     # d = RE_OPTS.sub(r'  --\1=<\1>  : \2', d)
     split = RE_OPTS.split(d)
     opt_types_desc = zip(split[1::3], split[2::3], split[3::3])
-    d = ''.join('\n  --{0}=<{1}>  : {2}{3}'.format(
-                otd[0].replace('_', '-'), otd[0], *otd[1:])
+    d = ''.join(('\n  --{0}  : {2}{3}' if otd[1] == 'bool' else
+                 '\n  --{0}=<{1}>  : {2}{3}').format(
+                     otd[0].replace('_', '-'), otd[0], *otd[1:])
                 for otd in opt_types_desc if otd[0] not in UNSUPPORTED_OPTS)
 
     d = """Usage:

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -198,7 +198,8 @@ def main(fp=sys.stderr, argv=None):
     # d = RE_OPTS.sub(r'  --\1=<\1>  : \2', d)
     split = RE_OPTS.split(d)
     opt_types_desc = zip(split[1::3], split[2::3], split[3::3])
-    d = ''.join('\n  --{0}=<{0}>  : {1}{2}'.format(*otd)
+    d = ''.join('\n  --{0}=<{1}>  : {2}{3}'.format(
+                otd[0].replace('_', '-'), otd[0], *otd[1:])
                 for otd in opt_types_desc if otd[0] not in UNSUPPORTED_OPTS)
 
     d = """Usage:
@@ -226,6 +227,7 @@ Options:
     tqdm_args = {'file': fp}
     try:
         for (o, v) in opts.items():
+            o = o.replace('-', '_')
             try:
                 tqdm_args[o] = cast(v, opt_types[o])
             except KeyError as e:

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -205,9 +205,8 @@ def main(fp=sys.stderr, argv=None):
   tqdm [--help | options]
 
 Options:
-  -h, --help     Print this help and exit
-  -v, --version  Print version and exit
-
+  -h, --help     Print this help and exit.
+  -v, --version  Print version and exit.
 """ + d.strip('\n') + '\n'
 
     # opts = docopt(d, version=__version__)

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -32,12 +32,12 @@ def cast(val, typ):
         return eval(typ + '("' + val + '")')
     except:
         if typ == 'chr':
-            return chr(ord(eval('"' + val + '"')))
+            return chr(ord(eval('"' + val + '"'))).encode()
         else:
             raise TqdmTypeError(val + ' : ' + typ)
 
 
-def posix_pipe(fin, fout, delim='\n', buf_size=256,
+def posix_pipe(fin, fout, delim=b'\\n', buf_size=256,
                callback=lambda int: None  # pragma: no cover
                ):
     """
@@ -49,7 +49,7 @@ def posix_pipe(fin, fout, delim='\n', buf_size=256,
     """
     fp_write = fout.write
 
-    # tmp = ''
+    # tmp = b''
     if not delim:
         while True:
             tmp = fin.read(buf_size)
@@ -63,7 +63,7 @@ def posix_pipe(fin, fout, delim='\n', buf_size=256,
             callback(len(tmp))
         # return
 
-    buf = ''
+    buf = b''
     # n = 0
     while True:
         tmp = fin.read(buf_size)
@@ -85,7 +85,7 @@ def posix_pipe(fin, fout, delim='\n', buf_size=256,
             else:
                 fp_write(buf + tmp[:i + len(delim)])
                 callback(1)  # n += 1
-                buf = ''
+                buf = b''
                 tmp = tmp[i + len(delim):]
 
 
@@ -204,7 +204,7 @@ Options:
         raise
     else:
         buf_size = tqdm_args.pop('buf_size', 256)
-        delim = tqdm_args.pop('delim', '\n')
+        delim = tqdm_args.pop('delim', b'\\n')
         delim_per_char = tqdm_args.pop('bytes', False)
         tee = tqdm_args.pop('tee', False)
         manpath = tqdm_args.pop('manpath', None)
@@ -245,7 +245,7 @@ Options:
             log.debug(tqdm_args)
             with tqdm(**tqdm_args) as t:
                 posix_pipe(stdin, stdout, '', buf_size, t.update)
-        elif delim == '\n':
+        elif delim == b'\\n':
             log.debug(tqdm_args)
             for i in tqdm(stdin, **tqdm_args):
                 stdout.write(i)

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -3,6 +3,7 @@ Module version for monitoring CLI pipes (`... | python -m tqdm | ...`).
 """
 from .std import tqdm, TqdmTypeError, TqdmKeyError
 from ._version import __version__  # NOQA
+from ast import literal_eval as numeric
 import logging
 import re
 import sys
@@ -301,10 +302,10 @@ Options:
                 with tqdm(**tqdm_args) as t:
                     if update:
                         def callback(i):
-                            t.update(float(i))
+                            t.update(numeric(i))
                     else:  # update_to
                         def callback(i):
-                            t.update(float(i) - t.n)
+                            t.update(numeric(i) - t.n)
                     for i in stdin:
                         stdout.write(i)
                         callback(i)
@@ -317,10 +318,10 @@ Options:
                 callback_len = False
                 if update:
                     def callback(i):
-                        t.update(float(i))
+                        t.update(numeric(i))
                 elif update_to:
                     def callback(i):
-                        t.update(float(i) - t.n)
+                        t.update(numeric(i) - t.n)
                 else:
                     callback = t.update
                     callback_len = True

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -7,10 +7,10 @@ import sys
 import re
 import logging
 __all__ = ["main"]
+log = logging.getLogger(__name__)
 
 
 def cast(val, typ):
-    log = logging.getLogger(__name__)
     log.debug((val, typ))
     if " or " in typ:
         for t in typ.split(" or "):
@@ -167,7 +167,7 @@ def main(fp=sys.stderr, argv=None):
     if argv is None:
         argv = sys.argv[1:]
     try:
-        log = argv.index('--log')
+        log_idx = argv.index('--log')
     except ValueError:
         for i in argv:
             if i.startswith('--log='):
@@ -176,13 +176,12 @@ def main(fp=sys.stderr, argv=None):
         else:
             logLevel = 'INFO'
     else:
-        # argv.pop(log)
-        # logLevel = argv.pop(log)
-        logLevel = argv[log + 1]
+        # argv.pop(log_idx)
+        # logLevel = argv.pop(log_idx)
+        logLevel = argv[log_idx + 1]
     logging.basicConfig(
         level=getattr(logging, logLevel),
         format="%(levelname)s:%(module)s:%(lineno)d:%(message)s")
-    log = logging.getLogger(__name__)
 
     d = tqdm.__init__.__doc__ + CLI_EXTRA_DOC
 

--- a/tqdm/completion.sh
+++ b/tqdm/completion.sh
@@ -12,7 +12,7 @@ _tqdm(){
     COMPREPLY=($(compgen -W       'CRITICAL FATAL ERROR WARN WARNING INFO DEBUG NOTSET' -- ${cur}))
     ;;
   *)
-    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_scale --version --write_bytes -h -v' -- ${cur}))
+    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_scale --update --update_to --version --write_bytes -h -v' -- ${cur}))
     ;;
   esac
 }

--- a/tqdm/completion.sh
+++ b/tqdm/completion.sh
@@ -12,7 +12,7 @@ _tqdm(){
     COMPREPLY=($(compgen -W       'CRITICAL FATAL ERROR WARN WARNING INFO DEBUG NOTSET' -- ${cur}))
     ;;
   *)
-    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_scale --update --update_to --version --write_bytes -h -v' -- ${cur}))
+    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --null --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_scale --update --update_to --version --write_bytes -h -v' -- ${cur}))
     ;;
   esac
 }

--- a/tqdm/tests/tests_main.py
+++ b/tqdm/tests/tests_main.py
@@ -47,16 +47,17 @@ def test_pipes():
 def test_main():
     """Test misc CLI options"""
     _SYS = sys.stdin, sys.argv
+    N = 123
 
     # test direct import
-    sys.stdin = map(str, _range(int(123)))
+    sys.stdin = map(str, _range(N))
     sys.argv = ['', '--desc', 'Test CLI import',
                 '--ascii', 'True', '--unit_scale', 'True']
     import tqdm.__main__  # NOQA
     sys.stderr.write("Test misc CLI options ... ")
 
     # test --delim
-    IN_DATA = '\0'.join(map(str, _range(int(123))))
+    IN_DATA = '\0'.join(map(str, _range(N)))
     with closing(StringIO()) as sys.stdin:
         sys.argv = ['', '--desc', 'Test CLI delim',
                     '--ascii', 'True', '--delim', r'\0', '--buf_size', '64']
@@ -78,7 +79,7 @@ def test_main():
             assert str(len(IN_DATA)) in fp.getvalue()
 
     # test --log
-    sys.stdin = map(str, _range(int(123)))
+    sys.stdin = map(str, _range(N))
     # with closing(UnicodeIO()) as fp:
     main(argv=['--log', 'DEBUG'], fp=NULL)
     # assert "DEBUG:" in sys.stdout.getvalue()
@@ -98,6 +99,39 @@ def test_main():
             main(argv=['--tee', '--mininterval', '0', '--miniters', '1'], fp=fp)
             # spaces to clear intermediate lines could increase length
             assert len(fp.getvalue()) >= res + len(IN_DATA)
+
+    # test integer --update
+    with closing(StringIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA)
+
+        sys.stdin.seek(0)
+        with closing(UnicodeIO()) as fp:
+            main(argv=['--update'], fp=fp)
+            res = fp.getvalue()
+            assert str(N // 2 * N) + 'it' in res  # arithmetic sum formula
+
+    # test integer --update_to
+    with closing(StringIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA)
+
+        sys.stdin.seek(0)
+        with closing(UnicodeIO()) as fp:
+            main(argv=['--update-to'], fp=fp)
+            res = fp.getvalue()
+            assert str(N - 1) + 'it' in res
+            assert str(N) + 'it' not in res
+
+    # test float --update_to
+    IN_DATA = '\n'.join((str(i / 2.0) for i in _range(N)))
+    with closing(StringIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA)
+
+        sys.stdin.seek(0)
+        with closing(UnicodeIO()) as fp:
+            main(argv=['--update-to'], fp=fp)
+            res = fp.getvalue()
+            assert str((N - 1) / 2.0) + 'it' in res
+            assert str(N / 2.0) + 'it' not in res
 
     # clean up
     sys.stdin, sys.argv = _SYS
@@ -150,7 +184,7 @@ def test_comppath():
 def test_exceptions():
     """Test CLI Exceptions"""
     _SYS = sys.stdin, sys.argv
-    sys.stdin = map(str, _range(int(123)))
+    sys.stdin = map(str, _range(123))
 
     sys.argv = ['', '-ascii', '-unit_scale', '--bad_arg_u_ment', 'foo']
     try:

--- a/tqdm/tests/tests_main.py
+++ b/tqdm/tests/tests_main.py
@@ -100,6 +100,31 @@ def test_main():
             # spaces to clear intermediate lines could increase length
             assert len(fp.getvalue()) >= res + len(IN_DATA)
 
+    # test --null
+    _STDOUT = sys.stdout
+    try:
+        with closing(StringIO()) as sys.stdout:
+            with closing(StringIO()) as sys.stdin:
+                sys.stdin.write(IN_DATA)
+
+                sys.stdin.seek(0)
+                with closing(UnicodeIO()) as fp:
+                    main(argv=['--null'], fp=fp)
+                    assert not sys.stdout.getvalue()
+
+            with closing(StringIO()) as sys.stdin:
+                sys.stdin.write(IN_DATA)
+
+                sys.stdin.seek(0)
+                with closing(UnicodeIO()) as fp:
+                    main(argv=[], fp=fp)
+                    assert sys.stdout.getvalue()
+    except:
+        sys.stdout = _STDOUT
+        raise
+    else:
+        sys.stdout = _STDOUT
+
     # test integer --update
     with closing(StringIO()) as sys.stdin:
         sys.stdin.write(IN_DATA)

--- a/tqdm/tests/tests_main.py
+++ b/tqdm/tests/tests_main.py
@@ -66,7 +66,7 @@ def test_main():
         sys.stdin.seek(0)
         with closing(UnicodeIO()) as fp:
             main(fp=fp)
-            assert "123it" in fp.getvalue()
+            assert str(N) + "it" in fp.getvalue()
 
     # test --bytes
     IN_DATA = IN_DATA.replace('\0', '\n')
@@ -108,7 +108,17 @@ def test_main():
         with closing(UnicodeIO()) as fp:
             main(argv=['--update'], fp=fp)
             res = fp.getvalue()
-            assert str(N // 2 * N) + 'it' in res  # arithmetic sum formula
+            assert str(N // 2 * N) + "it" in res  # arithmetic sum formula
+
+    # test integer --update --delim
+    with closing(StringIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA.replace('\n', 'D'))
+
+        sys.stdin.seek(0)
+        with closing(UnicodeIO()) as fp:
+            main(argv=['--update', '--delim', 'D'], fp=fp)
+            res = fp.getvalue()
+            assert str(N // 2 * N) + "it" in res  # arithmetic sum formula
 
     # test integer --update_to
     with closing(StringIO()) as sys.stdin:
@@ -118,8 +128,19 @@ def test_main():
         with closing(UnicodeIO()) as fp:
             main(argv=['--update-to'], fp=fp)
             res = fp.getvalue()
-            assert str(N - 1) + 'it' in res
-            assert str(N) + 'it' not in res
+            assert str(N - 1) + "it" in res
+            assert str(N) + "it" not in res
+
+    # test integer --update_to --delim
+    with closing(StringIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA.replace('\n', 'D'))
+
+        sys.stdin.seek(0)
+        with closing(UnicodeIO()) as fp:
+            main(argv=['--update-to', '--delim', 'D'], fp=fp)
+            res = fp.getvalue()
+            assert str(N - 1) + "it" in res
+            assert str(N) + "it" not in res
 
     # test float --update_to
     IN_DATA = '\n'.join((str(i / 2.0) for i in _range(N)))
@@ -130,8 +151,8 @@ def test_main():
         with closing(UnicodeIO()) as fp:
             main(argv=['--update-to'], fp=fp)
             res = fp.getvalue()
-            assert str((N - 1) / 2.0) + 'it' in res
-            assert str(N / 2.0) + 'it' not in res
+            assert str((N - 1) / 2.0) + "it" in res
+            assert str(N / 2.0) + "it" not in res
 
     # clean up
     sys.stdin, sys.argv = _SYS
@@ -212,6 +233,15 @@ def test_exceptions():
             raise
     else:
         raise TqdmTypeError('invalid_int_value')
+
+    sys.argv = ['', '--update', '--update_to']
+    try:
+        main(fp=NULL)
+    except TqdmKeyError as e:
+        if 'Can only have one of --' not in str(e):
+            raise
+    else:
+        raise TqdmKeyError('Cannot have both --update --update_to')
 
     # test SystemExits
     for i in ('-h', '--help', '-v', '--version'):

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -63,7 +63,7 @@ specify an initial arbitrary large positive number, e.g.
 .RS
 .RE
 .TP
-.B \-\-leave=\f[I]leave\f[]
+.B \-\-leave
 bool, optional.
 If [default: True], keeps all traces of the progressbar upon termination
 of iteration.
@@ -117,7 +117,7 @@ The fallback is to use ASCII characters " 123456789#".
 .RS
 .RE
 .TP
-.B \-\-disable=\f[I]disable\f[]
+.B \-\-disable
 bool, optional.
 Whether to disable the entire progressbar wrapper [default: False].
 If set to None, disable on non\-TTY.
@@ -140,7 +140,7 @@ If any other non\-zero number, will scale \f[C]total\f[] and \f[C]n\f[].
 .RS
 .RE
 .TP
-.B \-\-dynamic\-ncols=\f[I]dynamic_ncols\f[]
+.B \-\-dynamic\-ncols
 bool, optional.
 If set, constantly alters \f[C]ncols\f[] and \f[C]nrows\f[] to the
 environment (allowing for window resizes) [default: False].
@@ -202,7 +202,7 @@ float, optional.
 .RS
 .RE
 .TP
-.B \-\-write\-bytes=\f[I]write_bytes\f[]
+.B \-\-write\-bytes
 bool, optional.
 If (default: None) and \f[C]file\f[] is unspecified, bytes will be
 written in Python 2.
@@ -243,7 +243,7 @@ specified.
 .RS
 .RE
 .TP
-.B \-\-bytes=\f[I]bytes\f[]
+.B \-\-bytes
 bool, optional.
 If true, will count bytes, ignore \f[C]delim\f[], and default
 \f[C]unit_scale\f[] to True, \f[C]unit_divisor\f[] to 1024, and
@@ -258,21 +258,21 @@ If true, passes \f[C]stdin\f[] to both \f[C]stderr\f[] and
 .RS
 .RE
 .TP
-.B \-\-update=\f[I]update\f[]
+.B \-\-update
 bool, optional.
 If true, will treat input as newly elapsed iterations, i.e.
 numbers to pass to \f[C]update()\f[].
 .RS
 .RE
 .TP
-.B \-\-update\-to=\f[I]update_to\f[]
+.B \-\-update\-to
 bool, optional.
 If true, will treat input as total elapsed iterations, i.e.
 numbers to assign to \f[C]self.n\f[].
 .RS
 .RE
 .TP
-.B \-\-null=\f[I]null\f[]
+.B \-\-null
 bool, optional.
 If true, will discard input (no stdout).
 .RS

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -251,7 +251,7 @@ If true, will count bytes, ignore \f[C]delim\f[], and default
 .RS
 .RE
 .TP
-.B \-\-tee=\f[I]tee\f[]
+.B \-\-tee
 bool, optional.
 If true, passes \f[C]stdin\f[] to both \f[C]stderr\f[] and
 \f[C]stdout\f[].

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -131,7 +131,7 @@ it].
 .RS
 .RE
 .TP
-.B \-\-unit_scale=\f[I]unit_scale\f[]
+.B \-\-unit\-scale=\f[I]unit_scale\f[]
 bool or int or float, optional.
 If 1 or True, the number of iterations will be reduced/scaled
 automatically and a metric prefix following the International System of
@@ -140,7 +140,7 @@ If any other non\-zero number, will scale \f[C]total\f[] and \f[C]n\f[].
 .RS
 .RE
 .TP
-.B \-\-dynamic_ncols=\f[I]dynamic_ncols\f[]
+.B \-\-dynamic\-ncols=\f[I]dynamic_ncols\f[]
 bool, optional.
 If set, constantly alters \f[C]ncols\f[] and \f[C]nrows\f[] to the
 environment (allowing for window resizes) [default: False].
@@ -156,7 +156,7 @@ Ranges from 0 (average speed) to 1 (current/instantaneous speed)
 .RS
 .RE
 .TP
-.B \-\-bar_format=\f[I]bar_format\f[]
+.B \-\-bar\-format=\f[I]bar_format\f[]
 str, optional.
 Specify a custom bar string formatting.
 May impact performance.
@@ -196,13 +196,13 @@ Calls \f[C]set_postfix(**postfix)\f[] if possible (dict).
 .RS
 .RE
 .TP
-.B \-\-unit_divisor=\f[I]unit_divisor\f[]
+.B \-\-unit\-divisor=\f[I]unit_divisor\f[]
 float, optional.
 [default: 1000], ignored unless \f[C]unit_scale\f[] is True.
 .RS
 .RE
 .TP
-.B \-\-write_bytes=\f[I]write_bytes\f[]
+.B \-\-write\-bytes=\f[I]write_bytes\f[]
 bool, optional.
 If (default: None) and \f[C]file\f[] is unspecified, bytes will be
 written in Python 2.
@@ -211,7 +211,7 @@ In all other cases will default to unicode.
 .RS
 .RE
 .TP
-.B \-\-lock_args=\f[I]lock_args\f[]
+.B \-\-lock\-args=\f[I]lock_args\f[]
 tuple, optional.
 Passed to \f[C]refresh\f[] for intermediate output (initialisation,
 iterating, and updating).
@@ -236,7 +236,7 @@ N.B.: on Windows systems, Python converts \[aq]\\n\[aq] to
 .RS
 .RE
 .TP
-.B \-\-buf_size=\f[I]buf_size\f[]
+.B \-\-buf\-size=\f[I]buf_size\f[]
 int, optional.
 String buffer size in bytes [default: 256] used when \f[C]delim\f[] is
 specified.
@@ -265,7 +265,7 @@ numbers to pass to \f[C]update()\f[].
 .RS
 .RE
 .TP
-.B \-\-update_to=\f[I]update_to\f[]
+.B \-\-update\-to=\f[I]update_to\f[]
 bool, optional.
 If true, will treat input as total elapsed iterations, i.e.
 numbers to assign to \f[C]self.n\f[].

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -258,6 +258,20 @@ If true, passes \f[C]stdin\f[] to both \f[C]stderr\f[] and
 .RS
 .RE
 .TP
+.B \-\-update=\f[I]update\f[]
+bool, optional.
+If true, will treat input as newly elapsed iterations, i.e.
+numbers to pass to \f[C]update()\f[].
+.RS
+.RE
+.TP
+.B \-\-update_to=\f[I]update_to\f[]
+bool, optional.
+If true, will treat input as total elapsed iterations, i.e.
+numbers to assign to \f[C]self.n\f[].
+.RS
+.RE
+.TP
 .B \-\-manpath=\f[I]manpath\f[]
 str, optional.
 Directory in which to install tqdm man pages.

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -272,6 +272,12 @@ numbers to assign to \f[C]self.n\f[].
 .RS
 .RE
 .TP
+.B \-\-null=\f[I]null\f[]
+bool, optional.
+If true, will discard input (no stdout).
+.RS
+.RE
+.TP
 .B \-\-manpath=\f[I]manpath\f[]
 str, optional.
 Directory in which to install tqdm man pages.

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -36,12 +36,12 @@ counting:\ 100%|█████████|\ 432/432\ [00:00<00:00,\ 794361.83f
 .SH OPTIONS
 .TP
 .B \-h, \-\-help
-Print this help and exit
+Print this help and exit.
 .RS
 .RE
 .TP
 .B \-v, \-\-version
-Print version and exit
+Print version and exit.
 .RS
 .RE
 .TP


### PR DESCRIPTION
- [x] add `--update`
  + input passed to `update()`; treated as `float` if needed
- [x] add `--update_to` (fixes #975)
  + input passed to `self.n`; treated as `float` if needed
- [x] add `--null` (discards `stdin`; no `stdout`)
- [x] improved help formatting of boolean options
- [x] add tests
- [ ] update documentation/examples?


```bash
$ seq 2 2 8642086 | python -m tqdm --total 4321043 | wc -l  # old way
100%|██████████| 4321043/4321043 [00:02<00:00, 2136389.54it/s]
4321043

$ seq 2 2 8642086 | python -m tqdm --total 8642086 --update_to | wc -l  # new way
100%|██████████| 8642086.0/8642086 [00:03<00:00, 2642268.18it/s]
4321043
```

More advanced example (add efficient progress to any other program, even if it's written badly to spam the console with >3 million updates per second):

```bash
$ cat a.c && gcc a.c -o a.out
```
```cpp
#include "stdio.h"
#define TOTAL 1<<23  // prints 0 to 100 with TOTAL increments
int main(){
  for(unsigned i=1; i<=TOTAL; i+=2) printf("%.0f\n", i/(double)(TOTAL)*100); }
```
```bash
$ ./a.out | python -m tqdm | wc -l  # old way
4194304it [00:02, 3425772.13it/s]
4194304
$ ./a.out | python -m tqdm --total 100 --update_to --unit '%' | wc -l  # new way
100%|██████████| 100.0/100 [00:02<00:00, 35.38%/s]
4194304
```