### PR TITLE
Allow negative position arguments to fix parallel output issue

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -533,7 +533,7 @@ class tqdm(Comparable):
     @classmethod
     def _get_free_pos(cls, instance=None):
         """Skips specified instance."""
-        positions = set(abs(inst.pos) for inst in cls._instances
+        positions = set(inst.pos for inst in cls._instances
                         if inst is not instance and hasattr(inst, "pos"))
         return min(set(range(len(positions) + 1)).difference(positions))
 
@@ -565,7 +565,7 @@ class tqdm(Comparable):
                 if instances:
                     inst = min(instances, key=lambda i: i.pos)
                     inst.clear(nolock=True)
-                    inst.pos = abs(instance.pos)
+                    inst.pos = instance.pos
             # Kill monitor if no instances are left
             if not cls._instances and cls.monitor:
                 try:
@@ -1042,7 +1042,7 @@ class tqdm(Comparable):
             if position is None:
                 self.pos = self._get_free_pos(self)
             else:  # mark fixed positions as negative
-                self.pos = -position
+                self.pos = position
 
         if not gui:
             # Initialize the screen printer
@@ -1266,7 +1266,7 @@ class tqdm(Comparable):
         self.disable = True
 
         # decrement instance pos and remove from internal set
-        pos = abs(self.pos)
+        pos = self.pos
         self._decr_instances(self)
 
         # GUI mode
@@ -1290,8 +1290,9 @@ class tqdm(Comparable):
             if leave:
                 # stats for overall rate (no weighted average)
                 self.avg_time = None
-                self.display(pos=0)
-                fp_write('\n')
+                self.display(pos=pos)
+                if pos >= 0:
+                    fp_write('\n')
             else:
                 # clear previous display
                 if self.display(msg='', pos=pos) and not pos:
@@ -1304,12 +1305,12 @@ class tqdm(Comparable):
 
         if not nolock:
             self._lock.acquire()
-        pos = abs(self.pos)
-        if pos < (self.nrows or 20):
-            self.moveto(pos)
+        pos = self.pos
+        if abs(pos) < (self.nrows or 20):
+            self.moveto(-pos)
             self.sp('')
             self.fp.write('\r')  # place cursor back at the beginning of line
-            self.moveto(-pos)
+            self.moveto(pos)
         if not nolock:
             self._lock.release()
 
@@ -1454,14 +1455,15 @@ class tqdm(Comparable):
         ----------
         msg  : str, optional. What to display (default: `repr(self)`).
         pos  : int, optional. Position to `moveto`
-          (default: `abs(self.pos)`).
+          (default: `self.pos`).
         """
         if pos is None:
-            pos = abs(self.pos)
+            pos = self.pos
+        apos = abs(pos)
 
         nrows = self.nrows or 20
-        if pos >= nrows - 1:
-            if pos >= nrows:
+        if apos >= nrows - 1:
+            if apos >= nrows:
                 return False
             if msg or msg is None:  # override at `nrows - 1`
                 msg = " ... (more hidden) ..."


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [x] visual output fix
    + [ ] documentation modification
    + [x] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)

  4.47.0 3.6.9 (default, Apr 18 2020, 01:56:04) 
  [GCC 8.4.0] linux
  ```

This commit allows the position argument in `tqdm` to be negative.  The reason is to fix the overlapping bars issues #285, #1000, #889 and https://github.com/tqdm/tqdm/pull/329#issuecomment-269557028

For example, with these changes the following example (using position `with_negative_pos = True`):
```python
#!/usr/bin/env python3
from time import sleep
from tqdm import trange, tqdm
from multiprocessing import Pool, freeze_support, Lock

L = list(range(9))

with_negative_pos = True

def progresser(n):
    interval = 0.001 / (n + 2)
    total = 1000
    text = "#{}, est. {:<04.2}s".format(n, interval * total)
    pos = n
    if with_negative_pos:
        pos += -len(L)
    for _ in trange(total, desc=text, position=pos):
        sleep(interval)

if __name__ == '__main__':
    block = "\n"*len(L)*int(with_negative_pos)

    print("----------- Parallel Example: ")
    print(block, end='')
    p = Pool(initializer=tqdm.set_lock, initargs=(Lock(),))
    p.map(progresser, L)


    print("----------- Sequential Example: ")
    print(block, end='')
    list(map(progresser, L))

    input(">")
```
has the following output

![new-negative](https://user-images.githubusercontent.com/17233936/87081800-e03c9f00-c221-11ea-9d3b-aa0e8e5870ad.gif)

The idea is to ask the use to reserve the needed space (in lines) and then `tqmd` simply outputs the progress bar in one of the reserved lines.

Note that the output of the previous example (setting `with_negative_pos = False`) and without the changes proposed in this commit has the output:

![old-positive](https://user-images.githubusercontent.com/17233936/87082082-580ac980-c222-11ea-9585-e75c7b55a6fb.gif)
