### PR TITLE
Fix test_min_iters() more clearly

### DIFF
--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -676,15 +676,24 @@ def test_max_interval():
 def test_min_iters():
     """Test miniters"""
     with closing(StringIO()) as our_file:
-        for _ in tqdm(_range(3), file=our_file, leave=True, mininterval=0, miniters=4):
-            our_file.write('blank\n')
-        assert '\nblank\nblank\n' in our_file.getvalue()
+        for _ in tqdm(_range(3), file=our_file, leave=True, mininterval=0, miniters=2):
+            pass
+
+        out = our_file.getvalue()
+        assert '| 0/3 ' in out
+        assert '| 1/3 ' not in out
+        assert '| 2/3 ' in out
+        assert '| 3/3 ' in out
 
     with closing(StringIO()) as our_file:
         for _ in tqdm(_range(3), file=our_file, leave=True, mininterval=0, miniters=1):
-            our_file.write('blank\n')
-        # assume automatic mininterval = 0 means intermediate output
-        assert '| 3/3 ' in our_file.getvalue()
+            pass
+
+        out = our_file.getvalue()
+        assert '| 0/3 ' in out
+        assert '| 1/3 ' in out
+        assert '| 2/3 ' in out
+        assert '| 3/3 ' in out
 
 
 @with_setup(pretest, posttest)

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -676,12 +676,12 @@ def test_max_interval():
 def test_min_iters():
     """Test miniters"""
     with closing(StringIO()) as our_file:
-        for _ in tqdm(_range(3), file=our_file, leave=True, miniters=4):
+        for _ in tqdm(_range(3), file=our_file, leave=True, mininterval=0, miniters=4):
             our_file.write('blank\n')
         assert '\nblank\nblank\n' in our_file.getvalue()
 
     with closing(StringIO()) as our_file:
-        for _ in tqdm(_range(3), file=our_file, leave=True, miniters=1):
+        for _ in tqdm(_range(3), file=our_file, leave=True, mininterval=0, miniters=1):
             our_file.write('blank\n')
         # assume automatic mininterval = 0 means intermediate output
         assert '| 3/3 ' in our_file.getvalue()


### PR DESCRIPTION
I fixed test_min_iters().

Previously, the wrong behavior could also pass.
I fixed the code so that I can test the function clearly.

--------

- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] visual output fix
    + [x] documentation modification
    + [ ] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
  > 4.47.0 3.7.6 | packaged by conda-forge | (default, Jun  1 2020, 18:57:50) 
  > [GCC 7.5.0] linux

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
