### PR TITLE
Smoothing time

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -13,6 +13,7 @@ import sys
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from math import exp
 from numbers import Number
 from time import time
 from warnings import warn
@@ -1263,9 +1264,7 @@ class tqdm(Comparable):
                     # EMA (not just overall average)
                     avg_it_time = self._ema_dt(dt) / self._ema_dn(dn)
                     if self.smoothing_time:
-                        new_alpha = avg_it_time / self.smoothing_time
-                        if new_alpha > 1.0:
-                            new_alpha = 1.0
+                        new_alpha = 1 - exp(-avg_it_time / self.smoothing_time)
                         self._ema_dn.alpha = self._ema_dt.alpha = new_alpha
                 self.refresh(lock_args=self.lock_args)
                 if self.dynamic_miniters:


### PR DESCRIPTION
This PR provides a new setting, `smoothing_time` applicable for any use of tqdm. This new way to define smoothing is more general/universal; if you know how often you might glance at the progress bar, you know how many seconds to use for `smoothing_time`.

I always found the smoothing parameter hard to use and eventually settled on a recipe where I would set `smoothing = 1/(tqdm rate last time i did it)/seconds`, based on a little dimensional analysis and comparing EWMA formulas for discrete and time-based cases (e.g. Linux system load averages). This always seemed like a shame to do because obviously the numbers needed must be inside tqdm already. Lo and behold I finally go digging and the implementation is very elegant.

- Minimal performance penalty to old code (extra `elif self.smoothing_time:` statements)
- One extra division and one extra name assignment compared to `smoothing`
- Minimal new lines of code

When documenting the setting, I noticed a statement that smoothing is ignored in GUI mode. This doesn't seem to be the case for `tqdm.gui.tqdm` so I took the liberty of removing it.

I do apologize, but I couldn't get the test suite working on my local machine so I'll be relying on CI.


- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [x] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [ ] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
