### PR TITLE
Tqdm tk

### DIFF
--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -274,8 +274,20 @@ class tqdm_tk(std_tqdm):
         pbar_frame.pack()
         self.tk_desc_frame = ttk.Frame(pbar_frame)
         self.tk_desc_frame.pack()
-        self.tk_desc_label = None
+        self.tk_desc_var.set(self.desc)
+        # avoid importing ttk in display method
         self.ttk_label = ttk.Label
+        if self.desc:
+            self.tk_desc_label = self.ttk_label(
+                self.tk_desc_frame,
+                textvariable=self.tk_desc_var,
+                wraplength=600,
+                anchor="center",
+                justify="center",
+            )
+            self.tk_desc_label.pack()
+        else:
+            self.tk_desc_label = None
         self.tk_label = self.ttk_label(
             pbar_frame,
             textvariable=self.tk_text_var,

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -188,7 +188,7 @@ def tgrange(*args, **kwargs):
     return tqdm_gui(_range(*args), **kwargs)
 
 
-class tqdm_tk(tqdm_gui):
+class tqdm_tk(std_tqdm):
     """
     Experimental Tkinter GUI version of tqdm!
     """
@@ -230,9 +230,11 @@ class tqdm_tk(tqdm_gui):
                 "{percentage:3.0f}%"
             )
 
-        # don't want to share __init__ with tqdm_gui
-        # preferably we would have a gui base class
-        std_tqdm.__init__(self, *args, **kwargs)
+        # This signals std_tqdm that it's a GUI but no need to crash
+        # Maybe there is a better way?
+        self.sp = object()
+
+        super(tqdm_tk, self).__init__(*args, **kwargs)
 
         # Discover parent widget
         if tk_parent is None:
@@ -299,6 +301,20 @@ class tqdm_tk(tqdm_gui):
             self.tk_button.pack()
         if grab:
             self.tk_window.grab_set()
+
+    def refresh(self, nolock=True, lock_args=None):
+        """
+        Force refresh the display of this bar.
+
+        Parameters
+        ----------
+        nolock  : bool, optional
+            Ignored, behaves as if always set true
+        lock_args  : tuple, optional
+            Ignored
+        """
+        nolock = True  # necessary to force true or is default true enough?
+        return super(tqdm_tk, self).refresh(nolock, lock_args)
 
     def display(self):
         self.tk_n_var.set(self.n)

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -191,6 +191,10 @@ def tgrange(*args, **kwargs):
 class tqdm_tk(std_tqdm):
     """
     Experimental Tkinter GUI version of tqdm!
+
+    Note: Window interactivity suffers if `tqdm_tk` is not running within
+    a Tkinter mainloop and values are generated infrequently. In this case,
+    consider calling `tqdm_tk.update(0)` frequently in the Tk thread.
     """
 
     def __init__(self, *args, **kwargs):
@@ -350,7 +354,9 @@ class tqdm_tk(std_tqdm):
             self._tk_window.update()
 
     def cancel(self):
-        """Call cancel_callback and close the progress bar"""
+        """Call cancel_callback and then close the progress bar
+
+        Called when the window close or cancel buttons are clicked."""
         if self._cancel_callback is not None:
             self._cancel_callback()
         self.close()

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -20,12 +20,13 @@ from .std import tqdm as std_tqdm
 from .utils import _range
 
 __author__ = {"github.com/": ["casperdcl", "lrq3000", "richardsheridan"]}
-__all__ = ['tqdm_gui', 'tgrange', 'tqdm_tk', 'ttkrange', 'tqdm', 'trange']
+__all__ = ['tqdm', 'trange', 'tqdm_gui', 'tgrange', 'tqdm_mpl', 'tmplrange',
+           'tqdm_tk', 'ttkrange']
 
 
-class tqdm_gui(std_tqdm):  # pragma: no cover
+class tqdm_mpl(std_tqdm):  # pragma: no cover
     """
-    Experimental GUI version of tqdm!
+    Experimental Matplotlib GUI version of tqdm!
     """
 
     # TODO: @classmethod: write() on GUI?
@@ -38,7 +39,7 @@ class tqdm_gui(std_tqdm):  # pragma: no cover
         kwargs = kwargs.copy()
         kwargs['gui'] = True
         colour = kwargs.pop('colour', 'g')
-        super(tqdm_gui, self).__init__(*args, **kwargs)
+        super(tqdm_mpl, self).__init__(*args, **kwargs)
 
         # Initialize the GUI display
         if self.disable or not kwargs['gui']:
@@ -180,15 +181,15 @@ class tqdm_gui(std_tqdm):  # pragma: no cover
         self.plt.pause(1e-9)
 
 
-def tgrange(*args, **kwargs):
+def tmplrange(*args, **kwargs):
     """
-    A shortcut for `tqdm.gui.tqdm(xrange(*args), **kwargs)`.
+    A shortcut for `tqdm.gui.tqdm_mpl(xrange(*args), **kwargs)`.
     On Python3+, `range` is used instead of `xrange`.
     """
-    return tqdm_gui(_range(*args), **kwargs)
+    return tqdm_mpl(_range(*args), **kwargs)
 
 
-class tqdm_tk(std_tqdm):
+class tqdm_tk(std_tqdm):  # pragma: no cover
     """
     Experimental Tkinter GUI version of tqdm!
 
@@ -417,5 +418,5 @@ def ttkrange(*args, **kwargs):
 
 
 # Aliases
-tqdm = tqdm_gui
-trange = tgrange
+tqdm = tqdm_gui = tqdm_tk
+trange = tgrange = ttkrange

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -261,7 +261,7 @@ class tqdm_tk(std_tqdm):
             self.leave = False
 
         self._tk_window.protocol("WM_DELETE_WINDOW", self.cancel)
-        self._tk_window.wm_title("tqdm_tk")
+        self._tk_window.wm_title(self.desc)
         self._tk_window.wm_attributes("-topmost", 1)
         self._tk_window.after(
             0,
@@ -276,20 +276,7 @@ class tqdm_tk(std_tqdm):
         self._tk_desc_frame = ttk.Frame(pbar_frame)
         self._tk_desc_frame.pack()
         self._tk_desc_var.set(self.desc)
-        # avoid importing ttk in display method
-        self._ttk_label = ttk.Label
-        if self.desc:
-            self._tk_desc_label = self._ttk_label(
-                self._tk_desc_frame,
-                textvariable=self._tk_desc_var,
-                wraplength=600,
-                anchor="center",
-                justify="center",
-            )
-            self._tk_desc_label.pack()
-        else:
-            self._tk_desc_label = None
-        self._tk_label = self._ttk_label(
+        self._tk_label = ttk.Label(
             pbar_frame,
             textvariable=self._tk_text_var,
             wraplength=600,
@@ -317,6 +304,16 @@ class tqdm_tk(std_tqdm):
         if grab:
             self._tk_window.grab_set()
 
+    def set_description(self, desc=None, refresh=True):
+        self.set_description_str(desc, refresh)
+
+    def set_description_str(self, desc=None, refresh=True):
+        self.desc = desc
+        if not self.disable:
+            self._tk_window.wm_title(desc)
+            if refresh and not self._tk_dispatching:
+                self._tk_window.update()
+
     def refresh(self, nolock=True, lock_args=None):
         """
         Force refresh the display of this bar.
@@ -333,21 +330,6 @@ class tqdm_tk(std_tqdm):
 
     def display(self):
         self._tk_n_var.set(self.n)
-        if self.desc:
-            if self._tk_desc_label is None:
-                self._tk_desc_label = self._ttk_label(
-                    self._tk_desc_frame,
-                    textvariable=self._tk_desc_var,
-                    wraplength=600,
-                    anchor="center",
-                    justify="center",
-                )
-                self._tk_desc_label.pack()
-            self._tk_desc_var.set(self.desc)
-        else:
-            if self._tk_desc_label is not None:
-                self._tk_desc_label.destroy()
-                self._tk_desc_label = None
         self._tk_text_var.set(
             self.format_meter(
                 n=self.n,

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -193,9 +193,6 @@ class tqdm_tk(std_tqdm):
     Experimental Tkinter GUI version of tqdm!
     """
 
-    # Monitor thread does not behave nicely with tkinter
-    monitor_interval = 0
-
     def __init__(self, *args, **kwargs):
         try:
             import tkinter

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -199,6 +199,20 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
     """
 
     def __init__(self, *args, **kwargs):
+        """
+        This class accepts the following parameters *in addition* to
+        the parameters accepted by tqdm.
+
+        Parameters
+        ----------
+        grab  : bool, optional
+            Grab the input across all windows of the process.
+        tk_parent  : tkinter.Wm, optional
+            Parent Tk window.
+        cancel_callback  : Callable, optional
+            Create a cancel button and set cancel_callback to be called
+            when the cancel or window close button is clicked.
+        """
         try:
             grab = kwargs.pop("grab")
         except KeyError:

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -195,12 +195,6 @@ class tqdm_tk(std_tqdm):
 
     def __init__(self, *args, **kwargs):
         try:
-            import tkinter
-            import tkinter.ttk as ttk
-        except ImportError:
-            import Tkinter as tkinter
-            import ttk as ttk
-        try:
             grab = kwargs.pop("grab")
         except KeyError:
             grab = False
@@ -233,6 +227,16 @@ class tqdm_tk(std_tqdm):
 
         super(tqdm_tk, self).__init__(*args, **kwargs)
 
+        if self.disable:
+            return
+
+        try:
+            import tkinter
+            import tkinter.ttk as ttk
+        except ImportError:
+            import Tkinter as tkinter
+            import ttk as ttk
+
         # Discover parent widget
         if tk_parent is None:
             # this will error if tkinter.NoDefaultRoot() called
@@ -248,9 +252,6 @@ class tqdm_tk(std_tqdm):
                 self.tk_window = tkinter.Toplevel()
         else:
             self.tk_window = tkinter.Toplevel(tk_parent)
-
-        if self.disable:
-            return
 
         warn('GUI is experimental/alpha', TqdmExperimentalWarning, stacklevel=2
              )
@@ -373,7 +374,7 @@ class tqdm_tk(std_tqdm):
         self.close()
 
     def reset(self, total=None):
-        if total is not None:
+        if total is not None and not self.disable:
             self.tk_pbar.configure(maximum=total)
         super(tqdm_tk, self).reset(total)
 

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -14,17 +14,16 @@ from __future__ import absolute_import, division
 from warnings import warn
 
 # to inherit from the tqdm class
-from .std import TqdmExperimentalWarning, TqdmWarning
+from .std import TqdmExperimentalWarning
 from .std import tqdm as std_tqdm
 # import compatibility functions and utilities
 from .utils import _range
 
-__author__ = {"github.com/": ["casperdcl", "lrq3000", "richardsheridan"]}
-__all__ = ['tqdm', 'trange', 'tqdm_gui', 'tgrange', 'tqdm_mpl', 'tmplrange',
-           'tqdm_tk', 'ttkrange']
+__author__ = {"github.com/": ["casperdcl", "lrq3000"]}
+__all__ = ['tqdm_gui', 'tgrange', 'tqdm', 'trange']
 
 
-class tqdm_mpl(std_tqdm):  # pragma: no cover
+class tqdm_gui(std_tqdm):  # pragma: no cover
     """
     Experimental Matplotlib GUI version of tqdm!
     """
@@ -39,7 +38,7 @@ class tqdm_mpl(std_tqdm):  # pragma: no cover
         kwargs = kwargs.copy()
         kwargs['gui'] = True
         colour = kwargs.pop('colour', 'g')
-        super(tqdm_mpl, self).__init__(*args, **kwargs)
+        super(tqdm_gui, self).__init__(*args, **kwargs)
 
         # Initialize the GUI display
         if self.disable or not kwargs['gui']:
@@ -181,263 +180,14 @@ class tqdm_mpl(std_tqdm):  # pragma: no cover
         self.plt.pause(1e-9)
 
 
-def tmplrange(*args, **kwargs):
+def tgrange(*args, **kwargs):
     """
-    A shortcut for `tqdm.gui.tqdm_mpl(xrange(*args), **kwargs)`.
+    A shortcut for `tqdm.gui.tqdm(xrange(*args), **kwargs)`.
     On Python3+, `range` is used instead of `xrange`.
     """
-    return tqdm_mpl(_range(*args), **kwargs)
-
-
-class tqdm_tk(std_tqdm):  # pragma: no cover
-    """
-    Experimental Tkinter GUI version of tqdm!
-
-    Note: Window interactivity suffers if `tqdm_tk` is not running within
-    a Tkinter mainloop and values are generated infrequently. In this case,
-    consider calling `tqdm_tk.refresh()` frequently in the Tk thread.
-    """
-
-    def __init__(self, *args, **kwargs):
-        """
-        This class accepts the following parameters *in addition* to
-        the parameters accepted by tqdm.
-
-        Parameters
-        ----------
-        grab  : bool, optional
-            Grab the input across all windows of the process.
-        tk_parent  : tkinter.Wm, optional
-            Parent Tk window.
-        cancel_callback  : Callable, optional
-            Create a cancel button and set cancel_callback to be called
-            when the cancel or window close button is clicked.
-        """
-        # only meaningful to set this warning if someone sets the flag
-        self._warn_leave = "leave" in kwargs
-        try:
-            grab = kwargs.pop("grab")
-        except KeyError:
-            grab = False
-        try:
-            tk_parent = kwargs.pop("tk_parent")
-        except KeyError:
-            tk_parent = None
-        try:
-            self._cancel_callback = kwargs.pop("cancel_callback")
-        except KeyError:
-            self._cancel_callback = None
-        try:
-            bar_format = kwargs.pop("bar_format")
-        except KeyError:
-            bar_format = None
-
-        # Tkinter specific default bar format
-        if bar_format is None:
-            kwargs["bar_format"] = (
-                "{n_fmt}/{total_fmt}, {rate_noinv_fmt}\n"
-                "{elapsed} elapsed, {remaining} ETA\n\n"
-                "{percentage:3.0f}%"
-            )
-
-        # This signals std_tqdm that it's a GUI but no need to crash
-        # Maybe there is a better way?
-        self.sp = object()
-        kwargs["gui"] = True
-
-        super(tqdm_tk, self).__init__(*args, **kwargs)
-
-        if self.disable:
-            return
-
-        try:
-            import tkinter
-            import tkinter.ttk as ttk
-        except ImportError:
-            import Tkinter as tkinter
-            import ttk as ttk
-
-        # Discover parent widget
-        if tk_parent is None:
-            # this will error if tkinter.NoDefaultRoot() called
-            try:
-                tk_parent = tkinter._default_root
-            except AttributeError:
-                raise ValueError("tk_parent required when using NoDefaultRoot")
-            if tk_parent is None:
-                # use new default root window as display
-                self._tk_window = tkinter.Tk()
-            else:
-                # some other windows already exist
-                self._tk_window = tkinter.Toplevel()
-        else:
-            self._tk_window = tkinter.Toplevel(tk_parent)
-
-        warn('GUI is experimental/alpha', TqdmExperimentalWarning, stacklevel=2
-             )
-        self._tk_dispatching = self._tk_dispatching_helper()
-
-        self._tk_window.protocol("WM_DELETE_WINDOW", self.cancel)
-        self._tk_window.wm_title(self.desc)
-        self._tk_window.wm_attributes("-topmost", 1)
-        self._tk_window.after(
-            0,
-            lambda: self._tk_window.wm_attributes("-topmost", 0),
-        )
-        self._tk_n_var = tkinter.DoubleVar(self._tk_window, value=0)
-        self._tk_text_var = tkinter.StringVar(self._tk_window)
-        pbar_frame = ttk.Frame(self._tk_window, padding=5)
-        pbar_frame.pack()
-        _tk_label = ttk.Label(
-            pbar_frame,
-            textvariable=self._tk_text_var,
-            wraplength=600,
-            anchor="center",
-            justify="center",
-        )
-        _tk_label.pack()
-        self._tk_pbar = ttk.Progressbar(
-            pbar_frame,
-            variable=self._tk_n_var,
-            length=450,
-        )
-        if self.total is not None:
-            self._tk_pbar.configure(maximum=self.total)
-        else:
-            self._tk_pbar.configure(mode="indeterminate")
-        self._tk_pbar.pack()
-        if self._cancel_callback is not None:
-            _tk_button = ttk.Button(
-                pbar_frame,
-                text="Cancel",
-                command=self.cancel,
-            )
-            _tk_button.pack()
-        if grab:
-            self._tk_window.grab_set()
-
-    def set_description(self, desc=None, refresh=True):
-        self.set_description_str(desc, refresh)
-
-    def set_description_str(self, desc=None, refresh=True):
-        self.desc = desc
-        if not self.disable:
-            self._tk_window.wm_title(desc)
-            if refresh and not self._tk_dispatching:
-                self._tk_window.update()
-
-    def refresh(self, nolock=True, lock_args=None):
-        """
-        Force refresh the display of this bar.
-
-        Parameters
-        ----------
-        nolock  : bool, optional
-            Ignored, behaves as if always set True
-        lock_args  : tuple, optional
-            Ignored
-        """
-        nolock = True  # necessary to force true or is default true enough?
-        return super(tqdm_tk, self).refresh(nolock, lock_args)
-
-    def display(self):
-        self._tk_n_var.set(self.n)
-        self._tk_text_var.set(
-            self.format_meter(
-                n=self.n,
-                total=self.total,
-                elapsed=self._time() - self.start_t,
-                ncols=None,
-                prefix=self.desc,
-                ascii=self.ascii,
-                unit=self.unit,
-                unit_scale=self.unit_scale,
-                rate=1 / self.avg_time if self.avg_time else None,
-                bar_format=self.bar_format,
-                postfix=self.postfix,
-                unit_divisor=self.unit_divisor,
-            )
-        )
-        if not self._tk_dispatching:
-            self._tk_window.update()
-
-    def cancel(self):
-        """Call cancel_callback and then close the progress bar
-
-        Called when the window close or cancel buttons are clicked."""
-        if self._cancel_callback is not None:
-            self._cancel_callback()
-        self.close()
-
-    def reset(self, total=None):
-        """
-        Resets to 0 iterations for repeated use.
-
-        Parameters
-        ----------
-        total  : int or float, optional. Total to use for the new bar.
-                 If not set, transform progress bar to indeterminate mode.
-        """
-        if not self.disable:
-            if total is None:
-                self._tk_pbar.configure(maximum=100, mode="indeterminate")
-            else:
-                self._tk_pbar.configure(maximum=total, mode="determinate")
-        super(tqdm_tk, self).reset(total)
-
-    def close(self):
-        if self.disable:
-            return
-
-        self.disable = True
-
-        with self.get_lock():
-            self._instances.remove(self)
-
-        def _close():
-            self._tk_window.after('idle', self._tk_window.destroy)
-            if not self._tk_dispatching:
-                self._tk_window.update()
-
-        self._tk_window.protocol("WM_DELETE_WINDOW", _close)
-
-        # if leave is set but we are self-dispatching, the left window is
-        # totally unresponsive unless the user manually dispatches
-        if not self.leave:
-            _close()
-        elif not self._tk_dispatching:
-            if self._warn_leave:
-                warn('leave flag ignored if not in tkinter mainloop',
-                     TqdmWarning, stacklevel=2)
-            _close()
-
-    @staticmethod
-    def _tk_dispatching_helper():
-        """determine if Tkinter mainloop is dispatching events"""
-        try:
-            import tkinter
-        except ImportError:
-            import Tkinter as tkinter
-        import sys
-
-        codes = set((tkinter.mainloop.__code__,
-                     tkinter.Misc.mainloop.__code__))
-        for frame in sys._current_frames().values():
-            while frame:
-                if frame.f_code in codes:
-                    return True
-                frame = frame.f_back
-        return False
-
-
-def ttkrange(*args, **kwargs):
-    """
-    A shortcut for `tqdm.gui.tqdm_tk(xrange(*args), **kwargs)`.
-    On Python3+, `range` is used instead of `xrange`.
-    """
-    return tqdm_tk(_range(*args), **kwargs)
+    return tqdm_gui(_range(*args), **kwargs)
 
 
 # Aliases
-tqdm = tqdm_gui = tqdm_tk
-trange = tgrange = ttkrange
+tqdm = tqdm_gui
+trange = tgrange

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -40,11 +40,10 @@ class tqdm_gui(std_tqdm):  # pragma: no cover
         colour = kwargs.pop('colour', 'g')
         super(tqdm_gui, self).__init__(*args, **kwargs)
 
-        # Initialize the GUI display
-        if self.disable or not kwargs['gui']:
+        if self.disable:
             return
 
-        warn('GUI is experimental/alpha', TqdmExperimentalWarning, stacklevel=2)
+        warn("GUI is experimental/alpha", TqdmExperimentalWarning, stacklevel=2)
         self.mpl = mpl
         self.plt = plt
 
@@ -69,8 +68,8 @@ class tqdm_gui(std_tqdm):  # pragma: no cover
         ax.set_ylim(0, 0.001)
         if total is not None:
             ax.set_xlim(0, 100)
-            ax.set_xlabel('percent')
-            self.fig.legend((self.line1, self.line2), ('cur', 'est'),
+            ax.set_xlabel("percent")
+            self.fig.legend((self.line1, self.line2), ("cur", "est"),
                             loc='center right')
             # progressbar
             self.hspan = plt.axhspan(0, 0.001, xmin=0, xmax=0, color=colour)
@@ -78,11 +77,11 @@ class tqdm_gui(std_tqdm):  # pragma: no cover
             # ax.set_xlim(-60, 0)
             ax.set_xlim(0, 60)
             ax.invert_xaxis()
-            ax.set_xlabel('seconds')
-            ax.legend(('cur', 'est'), loc='lower left')
+            ax.set_xlabel("seconds")
+            ax.legend(("cur", "est"), loc='lower left')
         ax.grid()
         # ax.set_xlabel('seconds')
-        ax.set_ylabel((self.unit if self.unit else 'it') + '/s')
+        ax.set_ylabel((self.unit if self.unit else "it") + "/s")
         if self.unit_scale:
             plt.ticklabel_format(style='sci', axis='y', scilimits=(0, 0))
             ax.yaxis.get_offset_text().set_x(-0.15)
@@ -93,8 +92,6 @@ class tqdm_gui(std_tqdm):  # pragma: no cover
         self.ax = ax
 
     def close(self):
-        # if not self.gui:
-        #   return super(tqdm_gui, self).close()
         if self.disable:
             return
 
@@ -175,7 +172,7 @@ class tqdm_gui(std_tqdm):  # pragma: no cover
             line2.set_data(t_ago, zdata)
 
         d = self.format_dict
-        d["ncols"] = 0
+        d['ncols'] = 0
         ax.set_title(self.format_meter(**d), fontname="DejaVu Sans Mono", fontsize=11)
         self.plt.pause(1e-9)
 

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -261,6 +261,11 @@ class tqdm_tk(std_tqdm):
 
         self.tk_window.protocol("WM_DELETE_WINDOW", self.cancel)
         self.tk_window.wm_title("tqdm_tk")
+        self.tk_window.wm_attributes("-topmost", 1)
+        self.tk_window.after(
+            0,
+            lambda: self.tk_window.wm_attributes("-topmost", 0),
+        )
         self.tk_n_var = tkinter.DoubleVar(self.tk_window, value=0)
         self.tk_desc_var = tkinter.StringVar(self.tk_window)
         self.tk_desc_var.set(self.desc)

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -358,8 +358,19 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
         self.close()
 
     def reset(self, total=None):
-        if total is not None and not self.disable:
-            self._tk_pbar.configure(maximum=total)
+        """
+        Resets to 0 iterations for repeated use.
+
+        Parameters
+        ----------
+        total  : int or float, optional. Total to use for the new bar.
+                 If not set, transform progress bar to indeterminate mode.
+        """
+        if not self.disable:
+            if total is None:
+                self._tk_pbar.configure(maximum=100, mode="indeterminate")
+            else:
+                self._tk_pbar.configure(maximum=total, mode="determinate")
         super(tqdm_tk, self).reset(total)
 
     def close(self):

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -246,10 +246,10 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
         if tk_parent is None:
             # this will error if tkinter.NoDefaultRoot() called
             try:
-                tkparent = tkinter._default_root
+                tk_parent = tkinter._default_root
             except AttributeError:
                 raise ValueError("tk_parent required when using NoDefaultRoot")
-            if tkparent is None:
+            if tk_parent is None:
                 # use new default root window as display
                 self._tk_window = tkinter.Tk()
             else:
@@ -273,22 +273,17 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
             lambda: self._tk_window.wm_attributes("-topmost", 0),
         )
         self._tk_n_var = tkinter.DoubleVar(self._tk_window, value=0)
-        self._tk_desc_var = tkinter.StringVar(self._tk_window)
-        self._tk_desc_var.set(self.desc)
         self._tk_text_var = tkinter.StringVar(self._tk_window)
         pbar_frame = ttk.Frame(self._tk_window, padding=5)
         pbar_frame.pack()
-        self._tk_desc_frame = ttk.Frame(pbar_frame)
-        self._tk_desc_frame.pack()
-        self._tk_desc_var.set(self.desc)
-        self._tk_label = ttk.Label(
+        _tk_label = ttk.Label(
             pbar_frame,
             textvariable=self._tk_text_var,
             wraplength=600,
             anchor="center",
             justify="center",
         )
-        self._tk_label.pack()
+        _tk_label.pack()
         self._tk_pbar = ttk.Progressbar(
             pbar_frame,
             variable=self._tk_n_var,
@@ -300,12 +295,12 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
             self._tk_pbar.configure(mode="indeterminate")
         self._tk_pbar.pack()
         if self._cancel_callback is not None:
-            self._tk_button = ttk.Button(
+            _tk_button = ttk.Button(
                 pbar_frame,
                 text="Cancel",
                 command=self.cancel,
             )
-            self._tk_button.pack()
+            _tk_button.pack()
         if grab:
             self._tk_window.grab_set()
 

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -276,8 +276,6 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
         warn('GUI is experimental/alpha', TqdmExperimentalWarning, stacklevel=2
              )
         self._tk_dispatching = self._tk_dispatching_helper()
-        if not self._tk_dispatching:
-            self.leave = False
 
         self._tk_window.protocol("WM_DELETE_WINDOW", self.cancel)
         self._tk_window.wm_title(self.desc)

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -413,7 +413,8 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
                      TqdmWarning, stacklevel=2)
             _close()
 
-    def _tk_dispatching_helper(self):
+    @staticmethod
+    def _tk_dispatching_helper():
         """determine if Tkinter mainloop is dispatching events"""
         try:
             import tkinter

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -246,76 +246,76 @@ class tqdm_tk(std_tqdm):
                 raise ValueError("tk_parent required when using NoDefaultRoot")
             if tkparent is None:
                 # use new default root window as display
-                self.tk_window = tkinter.Tk()
+                self._tk_window = tkinter.Tk()
             else:
                 # some other windows already exist
-                self.tk_window = tkinter.Toplevel()
+                self._tk_window = tkinter.Toplevel()
         else:
-            self.tk_window = tkinter.Toplevel(tk_parent)
+            self._tk_window = tkinter.Toplevel(tk_parent)
 
         warn('GUI is experimental/alpha', TqdmExperimentalWarning, stacklevel=2
              )
-        self.tk_dispatching = self.tk_dispatching_helper()
-        if not self.tk_dispatching:
+        self._tk_dispatching = self._tk_dispatching_helper()
+        if not self._tk_dispatching:
             # leave is problematic if the mainloop is not running
             self.leave = False
 
-        self.tk_window.protocol("WM_DELETE_WINDOW", self.cancel)
-        self.tk_window.wm_title("tqdm_tk")
-        self.tk_window.wm_attributes("-topmost", 1)
-        self.tk_window.after(
+        self._tk_window.protocol("WM_DELETE_WINDOW", self.cancel)
+        self._tk_window.wm_title("tqdm_tk")
+        self._tk_window.wm_attributes("-topmost", 1)
+        self._tk_window.after(
             0,
-            lambda: self.tk_window.wm_attributes("-topmost", 0),
+            lambda: self._tk_window.wm_attributes("-topmost", 0),
         )
-        self.tk_n_var = tkinter.DoubleVar(self.tk_window, value=0)
-        self.tk_desc_var = tkinter.StringVar(self.tk_window)
-        self.tk_desc_var.set(self.desc)
-        self.tk_text_var = tkinter.StringVar(self.tk_window)
-        pbar_frame = ttk.Frame(self.tk_window, padding=5)
+        self._tk_n_var = tkinter.DoubleVar(self._tk_window, value=0)
+        self._tk_desc_var = tkinter.StringVar(self._tk_window)
+        self._tk_desc_var.set(self.desc)
+        self._tk_text_var = tkinter.StringVar(self._tk_window)
+        pbar_frame = ttk.Frame(self._tk_window, padding=5)
         pbar_frame.pack()
-        self.tk_desc_frame = ttk.Frame(pbar_frame)
-        self.tk_desc_frame.pack()
-        self.tk_desc_var.set(self.desc)
+        self._tk_desc_frame = ttk.Frame(pbar_frame)
+        self._tk_desc_frame.pack()
+        self._tk_desc_var.set(self.desc)
         # avoid importing ttk in display method
-        self.ttk_label = ttk.Label
+        self._ttk_label = ttk.Label
         if self.desc:
-            self.tk_desc_label = self.ttk_label(
-                self.tk_desc_frame,
-                textvariable=self.tk_desc_var,
+            self._tk_desc_label = self._ttk_label(
+                self._tk_desc_frame,
+                textvariable=self._tk_desc_var,
                 wraplength=600,
                 anchor="center",
                 justify="center",
             )
-            self.tk_desc_label.pack()
+            self._tk_desc_label.pack()
         else:
-            self.tk_desc_label = None
-        self.tk_label = self.ttk_label(
+            self._tk_desc_label = None
+        self._tk_label = self._ttk_label(
             pbar_frame,
-            textvariable=self.tk_text_var,
+            textvariable=self._tk_text_var,
             wraplength=600,
             anchor="center",
             justify="center",
         )
-        self.tk_label.pack()
-        self.tk_pbar = ttk.Progressbar(
+        self._tk_label.pack()
+        self._tk_pbar = ttk.Progressbar(
             pbar_frame,
-            variable=self.tk_n_var,
+            variable=self._tk_n_var,
             length=450,
         )
         if self.total is not None:
-            self.tk_pbar.configure(maximum=self.total)
+            self._tk_pbar.configure(maximum=self.total)
         else:
-            self.tk_pbar.configure(mode="indeterminate")
-        self.tk_pbar.pack()
+            self._tk_pbar.configure(mode="indeterminate")
+        self._tk_pbar.pack()
         if self._cancel_callback is not None:
-            self.tk_button = ttk.Button(
+            self._tk_button = ttk.Button(
                 pbar_frame,
                 text="Cancel",
                 command=self.cancel,
             )
-            self.tk_button.pack()
+            self._tk_button.pack()
         if grab:
-            self.tk_window.grab_set()
+            self._tk_window.grab_set()
 
     def refresh(self, nolock=True, lock_args=None):
         """
@@ -332,23 +332,23 @@ class tqdm_tk(std_tqdm):
         return super(tqdm_tk, self).refresh(nolock, lock_args)
 
     def display(self):
-        self.tk_n_var.set(self.n)
+        self._tk_n_var.set(self.n)
         if self.desc:
-            if self.tk_desc_label is None:
-                self.tk_desc_label = self.ttk_label(
-                    self.tk_desc_frame,
-                    textvariable=self.tk_desc_var,
+            if self._tk_desc_label is None:
+                self._tk_desc_label = self._ttk_label(
+                    self._tk_desc_frame,
+                    textvariable=self._tk_desc_var,
                     wraplength=600,
                     anchor="center",
                     justify="center",
                 )
-                self.tk_desc_label.pack()
-            self.tk_desc_var.set(self.desc)
+                self._tk_desc_label.pack()
+            self._tk_desc_var.set(self.desc)
         else:
-            if self.tk_desc_label is not None:
-                self.tk_desc_label.destroy()
-                self.tk_desc_label = None
-        self.tk_text_var.set(
+            if self._tk_desc_label is not None:
+                self._tk_desc_label.destroy()
+                self._tk_desc_label = None
+        self._tk_text_var.set(
             self.format_meter(
                 n=self.n,
                 total=self.total,
@@ -364,8 +364,8 @@ class tqdm_tk(std_tqdm):
                 unit_divisor=self.unit_divisor,
             )
         )
-        if not self.tk_dispatching:
-            self.tk_window.update()
+        if not self._tk_dispatching:
+            self._tk_window.update()
 
     def cancel(self):
         """Call cancel_callback and close the progress bar"""
@@ -375,7 +375,7 @@ class tqdm_tk(std_tqdm):
 
     def reset(self, total=None):
         if total is not None and not self.disable:
-            self.tk_pbar.configure(maximum=total)
+            self._tk_pbar.configure(maximum=total)
         super(tqdm_tk, self).reset(total)
 
     def close(self):
@@ -388,19 +388,19 @@ class tqdm_tk(std_tqdm):
             self._instances.remove(self)
 
         def _close():
-            self.tk_window.after(0, self.tk_window.destroy)
-            if not self.tk_dispatching:
-                self.tk_window.update()
+            self._tk_window.after(0, self._tk_window.destroy)
+            if not self._tk_dispatching:
+                self._tk_window.update()
 
-        self.tk_window.protocol("WM_DELETE_WINDOW", _close)
+        self._tk_window.protocol("WM_DELETE_WINDOW", _close)
         if not self.leave:
             _close()
 
-    def tk_dispatching_helper(self):
+    def _tk_dispatching_helper(self):
         """determine if Tkinter mainloop is dispatching events"""
         try:
             # Landing in CPython 3.10
-            return self.tk_window.dispatching()
+            return self._tk_window.dispatching()
         except AttributeError:
             pass
 

--- a/tqdm/tk.py
+++ b/tqdm/tk.py
@@ -7,16 +7,20 @@ Usage:
 >>> for i in trange(10):
 ...     ...
 """
-# future division is important to divide integers and get as
-# a result precise floating numbers (instead of truncated int)
 from __future__ import absolute_import, division
 
+import sys
 from warnings import warn
 
-# to inherit from the tqdm class
+try:
+    import tkinter
+    import tkinter.ttk as ttk
+except ImportError:
+    import Tkinter as tkinter
+    import ttk as ttk
+
 from .std import TqdmExperimentalWarning, TqdmWarning
 from .std import tqdm as std_tqdm
-# import compatibility functions and utilities
 from .utils import _range
 
 __author__ = {"github.com/": ["richardsheridan", "casperdcl"]}
@@ -32,194 +36,81 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
     consider calling `tqdm_tk.refresh()` frequently in the Tk thread.
     """
 
-    # TODO: @classmethod: write() on GUI?
+    # TODO: @classmethod: write()?
 
     def __init__(self, *args, **kwargs):
         """
         This class accepts the following parameters *in addition* to
-        the parameters accepted by tqdm.
+        the parameters accepted by `tqdm`.
 
         Parameters
         ----------
         grab  : bool, optional
             Grab the input across all windows of the process.
-        tk_parent  : tkinter.Wm, optional
+        tk_parent  : `tkinter.Wm`, optional
             Parent Tk window.
         cancel_callback  : Callable, optional
-            Create a cancel button and set cancel_callback to be called
+            Create a cancel button and set `cancel_callback` to be called
             when the cancel or window close button is clicked.
         """
-        # only meaningful to set this warning if someone sets the flag
-        self._warn_leave = "leave" in kwargs
-        try:
-            grab = kwargs.pop("grab")
-        except KeyError:
-            grab = False
-        try:
-            tk_parent = kwargs.pop("tk_parent")
-        except KeyError:
-            tk_parent = None
-        try:
-            self._cancel_callback = kwargs.pop("cancel_callback")
-        except KeyError:
-            self._cancel_callback = None
-        try:
-            bar_format = kwargs.pop("bar_format")
-        except KeyError:
-            bar_format = None
-
-        # Tkinter specific default bar format
-        if bar_format is None:
-            kwargs["bar_format"] = (
-                "{n_fmt}/{total_fmt}, {rate_noinv_fmt}\n"
-                "{elapsed} elapsed, {remaining} ETA\n\n"
-                "{percentage:3.0f}%"
-            )
-
-        # This signals std_tqdm that it's a GUI but no need to crash
-        # Maybe there is a better way?
-        self.sp = object()
-        kwargs["gui"] = True
-
+        kwargs = kwargs.copy()
+        kwargs['gui'] = True
+        kwargs['bar_format'] = kwargs.get(
+            'bar_format', "{l_bar}{r_bar}").replace("{bar}", "")
+        # convert disable = None to False
+        kwargs['disable'] = bool(kwargs.get('disable', False))
+        colour = kwargs.pop('colour', "blue")
+        self._warn_leave = 'leave' in kwargs
+        grab = kwargs.pop('grab', False)
+        tk_parent = kwargs.pop('tk_parent', None)
+        self._cancel_callback = kwargs.pop('cancel_callback', None)
         super(tqdm_tk, self).__init__(*args, **kwargs)
 
         if self.disable:
             return
 
-        try:
-            import tkinter
-            import tkinter.ttk as ttk
-        except ImportError:
-            import Tkinter as tkinter
-            import ttk as ttk
-
-        # Discover parent widget
-        if tk_parent is None:
-            # this will error if tkinter.NoDefaultRoot() called
+        if tk_parent is None:  # Discover parent widget
             try:
                 tk_parent = tkinter._default_root
             except AttributeError:
-                raise ValueError("tk_parent required when using NoDefaultRoot")
-            if tk_parent is None:
-                # use new default root window as display
+                raise AttributeError(
+                    "`tk_parent` required when using `tkinter.NoDefaultRoot()`")
+            if tk_parent is None:  # use new default root window as display
                 self._tk_window = tkinter.Tk()
-            else:
-                # some other windows already exist
+            else:  # some other windows already exist
                 self._tk_window = tkinter.Toplevel()
         else:
             self._tk_window = tkinter.Toplevel(tk_parent)
 
-        warn('GUI is experimental/alpha', TqdmExperimentalWarning, stacklevel=2
-             )
+        warn('GUI is experimental/alpha', TqdmExperimentalWarning, stacklevel=2)
         self._tk_dispatching = self._tk_dispatching_helper()
 
         self._tk_window.protocol("WM_DELETE_WINDOW", self.cancel)
         self._tk_window.wm_title(self.desc)
         self._tk_window.wm_attributes("-topmost", 1)
-        self._tk_window.after(
-            0,
-            lambda: self._tk_window.wm_attributes("-topmost", 0),
-        )
+        self._tk_window.after(0, lambda: self._tk_window.wm_attributes("-topmost", 0))
         self._tk_n_var = tkinter.DoubleVar(self._tk_window, value=0)
         self._tk_text_var = tkinter.StringVar(self._tk_window)
         pbar_frame = ttk.Frame(self._tk_window, padding=5)
         pbar_frame.pack()
-        _tk_label = ttk.Label(
-            pbar_frame,
-            textvariable=self._tk_text_var,
-            wraplength=600,
-            anchor="center",
-            justify="center",
-        )
+        _tk_label = ttk.Label(pbar_frame, textvariable=self._tk_text_var,
+                              wraplength=600, anchor="center", justify="center")
         _tk_label.pack()
         self._tk_pbar = ttk.Progressbar(
-            pbar_frame,
-            variable=self._tk_n_var,
-            length=450,
-        )
+            pbar_frame, variable=self._tk_n_var, length=450)
+        # WIP: is this the best way to set colour?
+        # WIP: what about error/complete (green/red) as with notebook?
+        self._tk_pbar.tk_setPalette(colour)
         if self.total is not None:
             self._tk_pbar.configure(maximum=self.total)
         else:
             self._tk_pbar.configure(mode="indeterminate")
         self._tk_pbar.pack()
         if self._cancel_callback is not None:
-            _tk_button = ttk.Button(
-                pbar_frame,
-                text="Cancel",
-                command=self.cancel,
-            )
+            _tk_button = ttk.Button(pbar_frame, text="Cancel", command=self.cancel)
             _tk_button.pack()
         if grab:
             self._tk_window.grab_set()
-
-    def set_description(self, desc=None, refresh=True):
-        self.set_description_str(desc, refresh)
-
-    def set_description_str(self, desc=None, refresh=True):
-        self.desc = desc
-        if not self.disable:
-            self._tk_window.wm_title(desc)
-            if refresh and not self._tk_dispatching:
-                self._tk_window.update()
-
-    def refresh(self, nolock=True, lock_args=None):
-        """
-        Force refresh the display of this bar.
-
-        Parameters
-        ----------
-        nolock  : bool, optional
-            Ignored, behaves as if always set True
-        lock_args  : tuple, optional
-            Ignored
-        """
-        nolock = True  # necessary to force true or is default true enough?
-        return super(tqdm_tk, self).refresh(nolock, lock_args)
-
-    def display(self):
-        self._tk_n_var.set(self.n)
-        self._tk_text_var.set(
-            self.format_meter(
-                n=self.n,
-                total=self.total,
-                elapsed=self._time() - self.start_t,
-                ncols=None,
-                prefix=self.desc,
-                ascii=self.ascii,
-                unit=self.unit,
-                unit_scale=self.unit_scale,
-                rate=1 / self.avg_time if self.avg_time else None,
-                bar_format=self.bar_format,
-                postfix=self.postfix,
-                unit_divisor=self.unit_divisor,
-            )
-        )
-        if not self._tk_dispatching:
-            self._tk_window.update()
-
-    def cancel(self):
-        """Call cancel_callback and then close the progress bar
-
-        Called when the window close or cancel buttons are clicked."""
-        if self._cancel_callback is not None:
-            self._cancel_callback()
-        self.close()
-
-    def reset(self, total=None):
-        """
-        Resets to 0 iterations for repeated use.
-
-        Parameters
-        ----------
-        total  : int or float, optional. Total to use for the new bar.
-                 If not set, transform progress bar to indeterminate mode.
-        """
-        if not self.disable:
-            if total is None:
-                self._tk_pbar.configure(maximum=100, mode="indeterminate")
-            else:
-                self._tk_pbar.configure(maximum=total, mode="determinate")
-        super(tqdm_tk, self).reset(total)
 
     def close(self):
         if self.disable:
@@ -247,17 +138,66 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
                      TqdmWarning, stacklevel=2)
             _close()
 
+    def clear(self, *_, **__):
+        pass
+
+    def display(self):
+        self._tk_n_var.set(self.n)
+        d = self.format_dict
+        d['ncols'] = None
+        self._tk_text_var.set(self.format_meter(**d))
+        if not self._tk_dispatching:
+            self._tk_window.update()
+
+    def set_description(self, desc=None, refresh=True):
+        self.set_description_str(desc, refresh)
+
+    def set_description_str(self, desc=None, refresh=True):
+        self.desc = desc
+        if not self.disable:
+            self._tk_window.wm_title(desc)
+            if refresh and not self._tk_dispatching:
+                self._tk_window.update()
+
+    def refresh(self, nolock=True, **kwargs):  # WIP: why is this needed?
+        """
+        Force refresh the display of this bar.
+
+        Parameters
+        ----------
+        nolock  : bool, optional
+            Ignored, behaves as if always `True`.
+        """
+        return super(tqdm_tk, self).refresh(nolock=True, **kwargs)
+
+    def cancel(self):
+        """
+        `cancel_callback()` followed by `close()`
+        when close/cancel buttons clicked.
+        """
+        if self._cancel_callback is not None:
+            self._cancel_callback()
+        self.close()
+
+    def reset(self, total=None):
+        """
+        Resets to 0 iterations for repeated use.
+
+        Parameters
+        ----------
+        total  : int or float, optional. Total to use for the new bar.
+        """
+        if hasattr(self, '_tk_pbar'):
+            if total is None:
+                self._tk_pbar.configure(maximum=100, mode="indeterminate")
+            else:
+                self._tk_pbar.configure(maximum=total, mode="determinate")
+        super(tqdm_tk, self).reset(total=total)
+
     @staticmethod
     def _tk_dispatching_helper():
         """determine if Tkinter mainloop is dispatching events"""
-        try:
-            import tkinter
-        except ImportError:
-            import Tkinter as tkinter
-        import sys
-
-        codes = set((tkinter.mainloop.__code__,
-                     tkinter.Misc.mainloop.__code__))
+        codes = {tkinter.mainloop.__code__, tkinter.Misc.mainloop.__code__}
         for frame in sys._current_frames().values():
             while frame:
                 if frame.f_code in codes:

--- a/tqdm/tk.py
+++ b/tqdm/tk.py
@@ -141,7 +141,11 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
         self._tk_n_var.set(self.n)
         d = self.format_dict
         d['ncols'] = None
-        self._tk_text_var.set(self.format_meter(**d))
+        text = self.format_meter(**d)
+        # fixup only default bar format
+        if self.bar_format == "{l_bar}{r_bar}":
+            text = text.replace("||", "", 1)
+        self._tk_text_var.set(text)
         if not self._tk_dispatching:
             self._tk_window.update()
 

--- a/tqdm/tk.py
+++ b/tqdm/tk.py
@@ -1,0 +1,279 @@
+"""
+GUI progressbar decorator for iterators.
+Includes a default `range` iterator printing to `stderr`.
+
+Usage:
+>>> from tqdm.gui import trange, tqdm
+>>> for i in trange(10):
+...     ...
+"""
+# future division is important to divide integers and get as
+# a result precise floating numbers (instead of truncated int)
+from __future__ import absolute_import, division
+
+from warnings import warn
+
+# to inherit from the tqdm class
+from .std import TqdmExperimentalWarning, TqdmWarning
+from .std import tqdm as std_tqdm
+# import compatibility functions and utilities
+from .utils import _range
+
+__author__ = {"github.com/": ["richardsheridan", "casperdcl"]}
+__all__ = ['tqdm_tk', 'ttkrange', 'tqdm', 'trange']
+
+
+class tqdm_tk(std_tqdm):  # pragma: no cover
+    """
+    Experimental Tkinter GUI version of tqdm!
+
+    Note: Window interactivity suffers if `tqdm_tk` is not running within
+    a Tkinter mainloop and values are generated infrequently. In this case,
+    consider calling `tqdm_tk.refresh()` frequently in the Tk thread.
+    """
+
+    # TODO: @classmethod: write() on GUI?
+
+    def __init__(self, *args, **kwargs):
+        """
+        This class accepts the following parameters *in addition* to
+        the parameters accepted by tqdm.
+
+        Parameters
+        ----------
+        grab  : bool, optional
+            Grab the input across all windows of the process.
+        tk_parent  : tkinter.Wm, optional
+            Parent Tk window.
+        cancel_callback  : Callable, optional
+            Create a cancel button and set cancel_callback to be called
+            when the cancel or window close button is clicked.
+        """
+        # only meaningful to set this warning if someone sets the flag
+        self._warn_leave = "leave" in kwargs
+        try:
+            grab = kwargs.pop("grab")
+        except KeyError:
+            grab = False
+        try:
+            tk_parent = kwargs.pop("tk_parent")
+        except KeyError:
+            tk_parent = None
+        try:
+            self._cancel_callback = kwargs.pop("cancel_callback")
+        except KeyError:
+            self._cancel_callback = None
+        try:
+            bar_format = kwargs.pop("bar_format")
+        except KeyError:
+            bar_format = None
+
+        # Tkinter specific default bar format
+        if bar_format is None:
+            kwargs["bar_format"] = (
+                "{n_fmt}/{total_fmt}, {rate_noinv_fmt}\n"
+                "{elapsed} elapsed, {remaining} ETA\n\n"
+                "{percentage:3.0f}%"
+            )
+
+        # This signals std_tqdm that it's a GUI but no need to crash
+        # Maybe there is a better way?
+        self.sp = object()
+        kwargs["gui"] = True
+
+        super(tqdm_tk, self).__init__(*args, **kwargs)
+
+        if self.disable:
+            return
+
+        try:
+            import tkinter
+            import tkinter.ttk as ttk
+        except ImportError:
+            import Tkinter as tkinter
+            import ttk as ttk
+
+        # Discover parent widget
+        if tk_parent is None:
+            # this will error if tkinter.NoDefaultRoot() called
+            try:
+                tk_parent = tkinter._default_root
+            except AttributeError:
+                raise ValueError("tk_parent required when using NoDefaultRoot")
+            if tk_parent is None:
+                # use new default root window as display
+                self._tk_window = tkinter.Tk()
+            else:
+                # some other windows already exist
+                self._tk_window = tkinter.Toplevel()
+        else:
+            self._tk_window = tkinter.Toplevel(tk_parent)
+
+        warn('GUI is experimental/alpha', TqdmExperimentalWarning, stacklevel=2
+             )
+        self._tk_dispatching = self._tk_dispatching_helper()
+
+        self._tk_window.protocol("WM_DELETE_WINDOW", self.cancel)
+        self._tk_window.wm_title(self.desc)
+        self._tk_window.wm_attributes("-topmost", 1)
+        self._tk_window.after(
+            0,
+            lambda: self._tk_window.wm_attributes("-topmost", 0),
+        )
+        self._tk_n_var = tkinter.DoubleVar(self._tk_window, value=0)
+        self._tk_text_var = tkinter.StringVar(self._tk_window)
+        pbar_frame = ttk.Frame(self._tk_window, padding=5)
+        pbar_frame.pack()
+        _tk_label = ttk.Label(
+            pbar_frame,
+            textvariable=self._tk_text_var,
+            wraplength=600,
+            anchor="center",
+            justify="center",
+        )
+        _tk_label.pack()
+        self._tk_pbar = ttk.Progressbar(
+            pbar_frame,
+            variable=self._tk_n_var,
+            length=450,
+        )
+        if self.total is not None:
+            self._tk_pbar.configure(maximum=self.total)
+        else:
+            self._tk_pbar.configure(mode="indeterminate")
+        self._tk_pbar.pack()
+        if self._cancel_callback is not None:
+            _tk_button = ttk.Button(
+                pbar_frame,
+                text="Cancel",
+                command=self.cancel,
+            )
+            _tk_button.pack()
+        if grab:
+            self._tk_window.grab_set()
+
+    def set_description(self, desc=None, refresh=True):
+        self.set_description_str(desc, refresh)
+
+    def set_description_str(self, desc=None, refresh=True):
+        self.desc = desc
+        if not self.disable:
+            self._tk_window.wm_title(desc)
+            if refresh and not self._tk_dispatching:
+                self._tk_window.update()
+
+    def refresh(self, nolock=True, lock_args=None):
+        """
+        Force refresh the display of this bar.
+
+        Parameters
+        ----------
+        nolock  : bool, optional
+            Ignored, behaves as if always set True
+        lock_args  : tuple, optional
+            Ignored
+        """
+        nolock = True  # necessary to force true or is default true enough?
+        return super(tqdm_tk, self).refresh(nolock, lock_args)
+
+    def display(self):
+        self._tk_n_var.set(self.n)
+        self._tk_text_var.set(
+            self.format_meter(
+                n=self.n,
+                total=self.total,
+                elapsed=self._time() - self.start_t,
+                ncols=None,
+                prefix=self.desc,
+                ascii=self.ascii,
+                unit=self.unit,
+                unit_scale=self.unit_scale,
+                rate=1 / self.avg_time if self.avg_time else None,
+                bar_format=self.bar_format,
+                postfix=self.postfix,
+                unit_divisor=self.unit_divisor,
+            )
+        )
+        if not self._tk_dispatching:
+            self._tk_window.update()
+
+    def cancel(self):
+        """Call cancel_callback and then close the progress bar
+
+        Called when the window close or cancel buttons are clicked."""
+        if self._cancel_callback is not None:
+            self._cancel_callback()
+        self.close()
+
+    def reset(self, total=None):
+        """
+        Resets to 0 iterations for repeated use.
+
+        Parameters
+        ----------
+        total  : int or float, optional. Total to use for the new bar.
+                 If not set, transform progress bar to indeterminate mode.
+        """
+        if not self.disable:
+            if total is None:
+                self._tk_pbar.configure(maximum=100, mode="indeterminate")
+            else:
+                self._tk_pbar.configure(maximum=total, mode="determinate")
+        super(tqdm_tk, self).reset(total)
+
+    def close(self):
+        if self.disable:
+            return
+
+        self.disable = True
+
+        with self.get_lock():
+            self._instances.remove(self)
+
+        def _close():
+            self._tk_window.after('idle', self._tk_window.destroy)
+            if not self._tk_dispatching:
+                self._tk_window.update()
+
+        self._tk_window.protocol("WM_DELETE_WINDOW", _close)
+
+        # if leave is set but we are self-dispatching, the left window is
+        # totally unresponsive unless the user manually dispatches
+        if not self.leave:
+            _close()
+        elif not self._tk_dispatching:
+            if self._warn_leave:
+                warn('leave flag ignored if not in tkinter mainloop',
+                     TqdmWarning, stacklevel=2)
+            _close()
+
+    @staticmethod
+    def _tk_dispatching_helper():
+        """determine if Tkinter mainloop is dispatching events"""
+        try:
+            import tkinter
+        except ImportError:
+            import Tkinter as tkinter
+        import sys
+
+        codes = set((tkinter.mainloop.__code__,
+                     tkinter.Misc.mainloop.__code__))
+        for frame in sys._current_frames().values():
+            while frame:
+                if frame.f_code in codes:
+                    return True
+                frame = frame.f_back
+        return False
+
+
+def ttkrange(*args, **kwargs):
+    """
+    A shortcut for `tqdm.gui.tqdm_tk(xrange(*args), **kwargs)`.
+    On Python3+, `range` is used instead of `xrange`.
+    """
+    return tqdm_tk(_range(*args), **kwargs)
+
+
+# Aliases
+tqdm = tqdm_tk
+trange = ttkrange

--- a/tqdm/tk.py
+++ b/tqdm/tk.py
@@ -143,9 +143,8 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
         d['ncols'] = None
         text = self.format_meter(**d)
         # fixup only default bar format
-        if self.bar_format == "{l_bar}{r_bar}":
-            text = text.replace("||", "", 1)
-        self._tk_text_var.set(text)
+        self._tk_text_var.set(
+            text.replace("||", "", 1) if "{l_bar}{r_bar}" in self.bar_format else text)
         if not self._tk_dispatching:
             self._tk_window.update()
 

--- a/tqdm/tk.py
+++ b/tqdm/tk.py
@@ -59,7 +59,6 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
             'bar_format', "{l_bar}{r_bar}").replace("{bar}", "")
         # convert disable = None to False
         kwargs['disable'] = bool(kwargs.get('disable', False))
-        colour = kwargs.pop('colour', "blue")
         self._warn_leave = 'leave' in kwargs
         grab = kwargs.pop('grab', False)
         tk_parent = kwargs.pop('tk_parent', None)
@@ -98,9 +97,6 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
         _tk_label.pack()
         self._tk_pbar = ttk.Progressbar(
             pbar_frame, variable=self._tk_n_var, length=450)
-        # WIP: is this the best way to set colour?
-        # WIP: what about error/complete (green/red) as with notebook?
-        self._tk_pbar.tk_setPalette(colour)
         if self.total is not None:
             self._tk_pbar.configure(maximum=self.total)
         else:
@@ -158,17 +154,6 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
             self._tk_window.wm_title(desc)
             if refresh and not self._tk_dispatching:
                 self._tk_window.update()
-
-    def refresh(self, nolock=True, **kwargs):  # WIP: why is this needed?
-        """
-        Force refresh the display of this bar.
-
-        Parameters
-        ----------
-        nolock  : bool, optional
-            Ignored, behaves as if always `True`.
-        """
-        return super(tqdm_tk, self).refresh(nolock=True, **kwargs)
 
     def cancel(self):
         """


### PR DESCRIPTION
This PR adds a Tkinter based GUI for tqdm. It does not attempt to provide the graphs of the current `tqdm_gui`, but it is more performant, and suitable for use on the command line, within fully-fledged Tkinter apps, or even crazier cases, like the [trio guest mode async await tkinter app](https://github.com/richardsheridan/magic-afm/blob/048dbb143edd40c80c65e8e4fa8a5a23e3805f00/magic_gui.py#L236-L372) that I originally built it for. One outstanding bug is that Tkinter does not play well with the `Tmonitor` functionality, so I disabled it by default for now by setting the class attribute `monitor_interval=0`.

This PR does not touch the broader, non-experimental functionality of tqdm.

I would boldly suggest making this class the default `tqdm.gui.tqdm`, as it is lighter-weight and has fewer dependencies compared to the `matplotlib.pyplot`-based implementation. That could be renamed to `tqdm_mpl` or something like that, depending on how committed to backwards compatibility you are for these experimental bits.