### PR TITLE
Accidental strongref

### DIFF
--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -90,12 +90,14 @@ class TMonitor(Thread):
                         instance.miniters = 1
                         # Refresh now! (works only for manual tqdm)
                         instance.refresh(nolock=True)
-                # Remove accidental long-lived strong reference
-                del instance
+                    # Remove accidental long-lived strong reference
+                    del instance
                 if instances != self.get_instances():  # pragma: nocover
                     warn("Set changed size during iteration" +
                          " (see https://github.com/tqdm/tqdm/issues/481)",
                          TqdmSynchronisationWarning, stacklevel=2)
+                # Remove accidental long-lived strong references
+                del instances
 
     def report(self):
         return not self.was_killed.is_set()

--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -90,6 +90,8 @@ class TMonitor(Thread):
                         instance.miniters = 1
                         # Refresh now! (works only for manual tqdm)
                         instance.refresh(nolock=True)
+                # Remove accidental long-lived strong reference
+                del instance
                 if instances != self.get_instances():  # pragma: nocover
                     warn("Set changed size during iteration" +
                          " (see https://github.com/tqdm/tqdm/issues/481)",


### PR DESCRIPTION
This PR fixes a bug in `tqdm_tk` #1006 that prevents using the monitor thread. The thread was holding on to references to Tkinter objects longer than they lived in the main thread, and the `__del__` methods of said objects cannot be called from threads that don't host the `_tkinter.tkapp` instance. This falls afoul of a [known bug](https://bugs.python.org/issue39093) in CPython that I may fix later, and causes the whole interpreter to crash (even at the REPL), but for now this is a correctness issue of tqdm in its own right.

Apologies, but I haven't been able to get the test suite working on my machine so I hope CI will check it out.

- [X] I have marked all applicable categories:
    + [X] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [X] I have visited the [source website], and in particular
  read the [known issues]
- [ ] I have searched through the [issue tracker] for duplicates
- [ ] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
