### PR TITLE
next release v4.48.1

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -56,7 +56,7 @@ jobs:
         pip install -U virtualenv asv
         asv machine --machine github-actions --yes
         git fetch --tags
-        git fetch origin master:master
+        [ "$(git symbolic-ref --short HEAD)" == master ] || git fetch origin master:master
     - name: Restore previous results
       uses: actions/cache@v2
       with:
@@ -66,7 +66,9 @@ jobs:
           asv-
     - name: Benchmark
       run: |
-        asv continuous --interleave-processes --only-changed -f 1.25 master HEAD
-        CHANGES="$(asv compare --only-changed -f 1.25 master HEAD)"
-        echo "$CHANGES"
-        [ -z "$CHANGES" ] || exit 1
+        if [ "$(git symbolic-ref --short HEAD)" != master ]; then
+          asv continuous --interleave-processes --only-changed -f 1.25 master HEAD
+          CHANGES="$(asv compare --only-changed -f 1.25 master HEAD)"
+          echo "$CHANGES"
+          [ -z "$CHANGES" ] || exit 1
+        fi

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,7 +42,7 @@ jobs:
         GIT_AUTHOR_NAME: ${{ github.actor }}
         GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
   testasv:
-    if: github.event_name == 'push' && ! startsWith(github.event.ref, 'refs/tags')
+    if: github.event_name == 'push' && ! startsWith(github.event.ref, 'refs/tags') && github.event.ref != 'refs/heads/master'
     name: Branch
     runs-on: ubuntu-latest
     steps:
@@ -56,7 +56,7 @@ jobs:
         pip install -U virtualenv asv
         asv machine --machine github-actions --yes
         git fetch --tags
-        [ "$(git symbolic-ref --short HEAD)" == master ] || git fetch origin master:master
+        git fetch origin master:master
     - name: Restore previous results
       uses: actions/cache@v2
       with:
@@ -66,9 +66,11 @@ jobs:
           asv-
     - name: Benchmark
       run: |
-        if [ "$(git symbolic-ref --short HEAD)" != master ]; then
-          asv continuous --interleave-processes --only-changed -f 1.25 master HEAD
-          CHANGES="$(asv compare --only-changed -f 1.25 master HEAD)"
-          echo "$CHANGES"
-          [ -z "$CHANGES" ] || exit 1
-        fi
+        asv continuous --interleave-processes --only-changed -f 1.25 master HEAD
+        CHANGES="$(asv compare --only-changed -f 1.25 master HEAD)"
+        echo "$CHANGES"
+        [ -z "$CHANGES" ] || exit 1
+  always:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo prevent failure when other jobs are skipped

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -320,6 +320,8 @@ of a neat one-line progress bar.
 - `Hanging pipes in python2 <https://github.com/tqdm/tqdm/issues/359>`__:
   when using ``tqdm`` on the CLI, you may need to use Python 3.5+ for correct
   buffering.
+- `No intermediate output in docker-compose <https://github.com/tqdm/tqdm/issues/771>`__:
+  use ``docker-compose run`` instead of ``docker-compose up`` and ``tty: true``.
 
 If you come across any other difficulties, browse and file |GitHub-Issues|.
 

--- a/README.rst
+++ b/README.rst
@@ -320,6 +320,8 @@ of a neat one-line progress bar.
 - `Hanging pipes in python2 <https://github.com/tqdm/tqdm/issues/359>`__:
   when using ``tqdm`` on the CLI, you may need to use Python 3.5+ for correct
   buffering.
+- `No intermediate output in docker-compose <https://github.com/tqdm/tqdm/issues/771>`__:
+  use ``docker-compose run`` instead of ``docker-compose up`` and ``tty: true``.
 
 If you come across any other difficulties, browse and file |GitHub-Issues|.
 

--- a/examples/async_coroutines.py
+++ b/examples/async_coroutines.py
@@ -27,8 +27,9 @@ async def main():
             elif row < 0:
                 assert row == -9
                 break
-    # should be under 10 seconds
-    for i in tqdm.as_completed(list(map(asyncio.sleep, [1] * 10)),
+    # should be ~1sec rather than ~50s due to async scheduling
+    for i in tqdm.as_completed([asyncio.sleep(0.01 * i)
+                                for i in range(100, 0, -1)],
                                desc="as_completed"):
         await i
 

--- a/tqdm/_version.py
+++ b/tqdm/_version.py
@@ -15,45 +15,48 @@ __version__ = '.'.join(map(str, version_info))
 scriptdir = os.path.dirname(__file__)
 gitdir = os.path.abspath(os.path.join(scriptdir, "..", ".git"))
 if os.path.isdir(gitdir):  # pragma: nocover
-    extra = None
-    # Open config file to check if we are in tqdm project
-    with io_open(os.path.join(gitdir, "config"), 'r') as fh_config:
-        if 'tqdm' in fh_config.read():
-            # Open the HEAD file
-            with io_open(os.path.join(gitdir, "HEAD"), 'r') as fh_head:
-                extra = fh_head.readline().strip()
-            # in a branch => HEAD points to file containing last commit
-            if 'ref:' in extra:
-                # reference file path
-                ref_file = extra[5:]
-                branch_name = ref_file.rsplit('/', 1)[-1]
+    try:
+        extra = None
+        # Open config file to check if we are in tqdm project
+        with io_open(os.path.join(gitdir, "config"), 'r') as fh_config:
+            if 'tqdm' in fh_config.read():
+                # Open the HEAD file
+                with io_open(os.path.join(gitdir, "HEAD"), 'r') as fh_head:
+                    extra = fh_head.readline().strip()
+                # in a branch => HEAD points to file containing last commit
+                if 'ref:' in extra:
+                    # reference file path
+                    ref_file = extra[5:]
+                    branch_name = ref_file.rsplit('/', 1)[-1]
 
-                ref_file_path = os.path.abspath(os.path.join(gitdir, ref_file))
-                # check that we are in git folder
-                # (by stripping the git folder from the ref file path)
-                if os.path.relpath(
-                        ref_file_path, gitdir).replace('\\', '/') != ref_file:
-                    # out of git folder
-                    extra = None
+                    ref_file_path = os.path.abspath(os.path.join(
+                        gitdir, ref_file))
+                    # check that we are in git folder
+                    # (by stripping the git folder from the ref file path)
+                    if os.path.relpath(ref_file_path, gitdir).replace(
+                            '\\', '/') != ref_file:
+                        # out of git folder
+                        extra = None
+                    else:
+                        # open the ref file
+                        with io_open(ref_file_path, 'r') as fh_branch:
+                            commit_hash = fh_branch.readline().strip()
+                            extra = commit_hash[:8]
+                            if branch_name != "master":
+                                extra += '.' + branch_name
+
+                # detached HEAD mode, already have commit hash
                 else:
-                    # open the ref file
-                    with io_open(ref_file_path, 'r') as fh_branch:
-                        commit_hash = fh_branch.readline().strip()
-                        extra = commit_hash[:8]
-                        if branch_name != "master":
-                            extra += '.' + branch_name
+                    extra = extra[:8]
 
-            # detached HEAD mode, already have commit hash
-            else:
-                extra = extra[:8]
-
-    # Append commit hash (and branch) to version string if not tagged
-    if extra is not None:
-        try:
+        # Append commit hash (and branch) to version string if not tagged
+        if extra is not None:
             with io_open(os.path.join(gitdir, "refs", "tags",
                                       'v' + __version__)) as fdv:
                 if fdv.readline().strip()[:8] != extra[:8]:
                     __version__ += '-' + extra
-        except Exception as e:
-            if "No such file" not in str(e):
-                raise
+    except Exception as e:
+        if "No such file" in str(e):
+            __version__ += "-git.UNKNOWN"
+        else:
+            raise

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -7,13 +7,13 @@ Usage:
 >>> async for i in trange(10):
 ...     ...
 """
-from .auto import tqdm as tqdm_auto
+from .std import tqdm as std_tqdm
 import asyncio
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['tqdm_asyncio', 'tarange', 'tqdm', 'trange']
 
 
-class tqdm_asyncio(tqdm_auto):
+class tqdm_asyncio(std_tqdm):
     def __init__(self, iterable=None, *args, **kwargs):
         super(tqdm_asyncio, self).__init__(iterable, *args, **kwargs)
         self.iterable_awaitable = False

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -14,6 +14,9 @@ __all__ = ['tqdm_asyncio', 'tarange', 'tqdm', 'trange']
 
 
 class tqdm_asyncio(std_tqdm):
+    """
+    Asynchronous-friendly version of tqdm (Python 3.5+).
+    """
     def __init__(self, iterable=None, *args, **kwargs):
         super(tqdm_asyncio, self).__init__(iterable, *args, **kwargs)
         self.iterable_awaitable = False

--- a/tqdm/auto.py
+++ b/tqdm/auto.py
@@ -4,7 +4,7 @@ Enables multiple commonly used features.
 Method resolution order:
 
 - `tqdm.autonotebook` without import warnings
-- `tqdm.asyncio` on Python3+
+- `tqdm.asyncio` on Python3.5+
 - `tqdm.std` base class
 
 Usage:
@@ -20,7 +20,7 @@ with warnings.catch_warnings():
     from .autonotebook import tqdm as notebook_tqdm
     from .autonotebook import trange as notebook_trange
 
-if sys.version_info[:1] < (3,):
+if sys.version_info[:1] < (3, 4):
     tqdm = notebook_tqdm
     trange = notebook_trange
 else:  # Python3+

--- a/tqdm/auto.py
+++ b/tqdm/auto.py
@@ -2,6 +2,7 @@
 Enables multiple commonly used features.
 
 Method resolution order:
+
 - `tqdm.autonotebook` without import warnings
 - `tqdm.asyncio` on Python3+
 - `tqdm.std` base class

--- a/tqdm/auto.py
+++ b/tqdm/auto.py
@@ -23,7 +23,7 @@ with warnings.catch_warnings():
 if sys.version_info[:1] < (3, 4):
     tqdm = notebook_tqdm
     trange = notebook_trange
-else:  # Python3+
+else:  # Python3.5+
     from .asyncio import tqdm as asyncio_tqdm
     from .std import tqdm as std_tqdm
 

--- a/tqdm/auto.py
+++ b/tqdm/auto.py
@@ -1,14 +1,41 @@
 """
-`tqdm.autonotebook` but without import warnings.
+Enables multiple commonly used features.
+
+Method resolution order:
+- `tqdm.autonotebook` without import warnings
+- `tqdm.asyncio` on Python3+
+- `tqdm.std` base class
 
 Usage:
 >>> from tqdm.auto import trange, tqdm
 >>> for i in trange(10):
 ...     ...
 """
+import sys
 import warnings
 from .std import TqdmExperimentalWarning
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", category=TqdmExperimentalWarning)
-    from .autonotebook import tqdm, trange
+    from .autonotebook import tqdm as notebook_tqdm
+    from .autonotebook import trange as notebook_trange
+
+if sys.version_info[:1] < (3,):
+    tqdm = notebook_tqdm
+    trange = notebook_trange
+else:  # Python3+
+    from .asyncio import tqdm as asyncio_tqdm
+    from .std import tqdm as std_tqdm
+
+    if notebook_tqdm != std_tqdm:
+        class tqdm(notebook_tqdm, asyncio_tqdm):
+            pass
+    else:
+        tqdm = asyncio_tqdm
+
+    def trange(*args, **kwargs):
+        """
+        A shortcut for `tqdm.auto.tqdm(range(*args), **kwargs)`.
+        """
+        return tqdm(range(*args), **kwargs)
+
 __all__ = ["tqdm", "trange"]

--- a/tqdm/contrib/__init__.py
+++ b/tqdm/contrib/__init__.py
@@ -47,7 +47,7 @@ def tenumerate(iterable, start=0, total=None, tqdm_class=tqdm_auto,
         if isinstance(iterable, np.ndarray):
             return tqdm_class(np.ndenumerate(iterable),
                               total=total or iterable.size, **tqdm_kwargs)
-    return enumerate(tqdm_class(iterable, **tqdm_kwargs), start)
+    return enumerate(tqdm_class(iterable, total=total, **tqdm_kwargs), start)
 
 
 @builtin_iterable

--- a/tqdm/contrib/__init__.py
+++ b/tqdm/contrib/__init__.py
@@ -6,7 +6,6 @@ Subpackages contain potentially unstable extensions.
 from tqdm import tqdm
 from tqdm.auto import tqdm as tqdm_auto
 from tqdm.utils import ObjectWrapper
-from copy import deepcopy
 from functools import wraps
 import sys
 __author__ = {"github.com/": ["casperdcl"]}
@@ -60,7 +59,7 @@ def tzip(iter1, *iter2plus, **tqdm_kwargs):
     ----------
     tqdm_class  : [default: tqdm.auto.tqdm].
     """
-    kwargs = deepcopy(tqdm_kwargs)
+    kwargs = tqdm_kwargs.copy()
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
     for i in zip(tqdm_class(iter1, **tqdm_kwargs), *iter2plus):
         yield i

--- a/tqdm/contrib/bells.py
+++ b/tqdm/contrib/bells.py
@@ -1,5 +1,5 @@
 """
-All the bells & whistles:
+Even more features than `tqdm.auto` (all the bells & whistles):
 
 - `tqdm.auto`
 - `tqdm.tqdm.pandas`

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -4,7 +4,6 @@ Thin wrappers around `concurrent.futures`.
 from __future__ import absolute_import
 from tqdm import TqdmWarning
 from tqdm.auto import tqdm as tqdm_auto
-from copy import deepcopy
 try:
     from operator import length_hint
 except ImportError:
@@ -37,7 +36,7 @@ def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
     max_workers  : [default: min(32, cpu_count() + 4)].
     chunksize  : [default: 1].
     """
-    kwargs = deepcopy(tqdm_kwargs)
+    kwargs = tqdm_kwargs.copy()
     if "total" not in kwargs:
         kwargs["total"] = len(iterables[0])
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -10,7 +10,6 @@ Usage:
 https://raw.githubusercontent.com/tqdm/img/src/screenshot-discord.png)
 """
 from __future__ import absolute_import
-from copy import deepcopy
 import logging
 from os import getenv
 
@@ -84,7 +83,7 @@ class tqdm_discord(tqdm_auto):
 
         See `tqdm.auto.tqdm.__init__` for other parameters.
         """
-        kwargs = deepcopy(kwargs)
+        kwargs = kwargs.copy()
         logging.getLogger("HTTPClient").setLevel(logging.WARNING)
         self.dio = DiscordIO(
             kwargs.pop('token', getenv("TQDM_DISCORD_TOKEN")),

--- a/tqdm/contrib/itertools.py
+++ b/tqdm/contrib/itertools.py
@@ -3,7 +3,6 @@ Thin wrappers around `itertools`.
 """
 from __future__ import absolute_import
 from tqdm.auto import tqdm as tqdm_auto
-from copy import deepcopy
 import itertools
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['product']
@@ -17,7 +16,7 @@ def product(*iterables, **tqdm_kwargs):
     ----------
     tqdm_class  : [default: tqdm.auto.tqdm].
     """
-    kwargs = deepcopy(tqdm_kwargs)
+    kwargs = tqdm_kwargs.copy()
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
     try:
         lens = list(map(len, iterables))

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -10,7 +10,6 @@ Usage:
 https://raw.githubusercontent.com/tqdm/img/src/screenshot-telegram.gif)
 """
 from __future__ import absolute_import
-from copy import deepcopy
 from os import getenv
 
 from requests import Session
@@ -91,7 +90,7 @@ class tqdm_telegram(tqdm_auto):
 
         See `tqdm.auto.tqdm.__init__` for other parameters.
         """
-        kwargs = deepcopy(kwargs)
+        kwargs = kwargs.copy()
         self.tgio = TelegramIO(
             kwargs.pop('token', getenv('TQDM_TELEGRAM_TOKEN')),
             kwargs.pop('chat_id', getenv('TQDM_TELEGRAM_CHAT_ID')))

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division
 from .auto import tqdm as tqdm_auto
-from copy import deepcopy
+from copy import copy
 try:
     import keras
 except ImportError as e:
@@ -20,7 +20,7 @@ class TqdmCallback(keras.callbacks.Callback):
             n = delta(logs)
             if logs:
                 if pop:
-                    logs = deepcopy(logs)
+                    logs = copy(logs)
                     [logs.pop(i, 0) for i in pop]
                 bar.set_postfix(logs, refresh=False)
             bar.update(n)

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -103,6 +103,8 @@ class tqdm_notebook(std_tqdm):
             pbar = IProgress(min=0, max=1)
             pbar.value = 1
             pbar.bar_style = 'info'
+            if ncols is None:
+                pbar.layout.width = "20px"
 
         if desc:
             pbar.description = desc
@@ -128,6 +130,13 @@ class tqdm_notebook(std_tqdm):
         display(container)
 
         return container
+
+    @staticmethod
+    def format_meter(n, total, *args, **kwargs):
+        if total and 'bar_format' not in kwargs:
+            kwargs = kwargs.copy()
+            kwargs['bar_format'] = "{l_bar}<bar/>{r_bar}"
+        return std_tqdm.format_meter(n, total, *args, **kwargs)
 
     def display(self, msg=None, pos=None,
                 # additional signals
@@ -182,6 +191,7 @@ class tqdm_notebook(std_tqdm):
                 self.container.visible = False
 
     def __init__(self, *args, **kwargs):
+        kwargs = kwargs.copy()
         # Setup default output
         file_kwarg = kwargs.get('file', sys.stderr)
         if file_kwarg is sys.stderr or file_kwarg is None:
@@ -189,8 +199,9 @@ class tqdm_notebook(std_tqdm):
 
         # Initialize parent class + avoid printing by using gui=True
         kwargs['gui'] = True
-        kwargs.setdefault('bar_format', '{l_bar}{bar}{r_bar}')
-        kwargs['bar_format'] = kwargs['bar_format'].replace('{bar}', '<bar/>')
+        if 'bar_format' in kwargs:
+            kwargs['bar_format'] = kwargs['bar_format'].replace(
+                '{bar}', '<bar/>')
         # convert disable = None to False
         kwargs['disable'] = bool(kwargs.get('disable', False))
         super(tqdm_notebook, self).__init__(*args, **kwargs)

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -301,7 +301,7 @@ class tqdm(Comparable):
         last_len = [0]
 
         def print_status(s):
-            len_s = len(s)
+            len_s = disp_len(s)
             fp_write('\r' + s + (' ' * max(last_len[0] - len_s, 0)))
             last_len[0] = len_s
 

--- a/tqdm/tests/py37_asyncio.py
+++ b/tqdm/tests/py37_asyncio.py
@@ -37,15 +37,15 @@ async def acount(*args, **kwargs):
 async def test_generators():
     """Test asyncio generators"""
     with closing(StringIO()) as our_file:
-        async for row in tqdm(count(), desc="counter", file=our_file):
-            if row >= 8:
+        async for i in tqdm(count(), desc="counter", file=our_file):
+            if i >= 8:
                 break
         assert '9it' in our_file.getvalue()
         our_file.seek(0)
         our_file.truncate()
 
-        async for row in tqdm(acount(), desc="async_counter", file=our_file):
-            if row >= 8:
+        async for i in tqdm(acount(), desc="async_counter", file=our_file):
+            if i >= 8:
                 break
         assert '9it' in our_file.getvalue()
 
@@ -54,13 +54,13 @@ async def test_generators():
 async def test_range():
     """Test asyncio range"""
     with closing(StringIO()) as our_file:
-        async for row in tqdm(range(9), desc="range", file=our_file):
+        async for _ in tqdm(range(9), desc="range", file=our_file):
             pass
         assert '9/9' in our_file.getvalue()
         our_file.seek(0)
         our_file.truncate()
 
-        async for row in trange(9, desc="trange", file=our_file):
+        async for _ in trange(9, desc="trange", file=our_file):
             pass
         assert '9/9' in our_file.getvalue()
 
@@ -69,8 +69,8 @@ async def test_range():
 async def test_nested():
     """Test asyncio nested"""
     with closing(StringIO()) as our_file:
-        async for row in tqdm(trange(9, desc="inner", file=our_file),
-                              desc="outer", file=our_file):
+        async for _ in tqdm(trange(9, desc="inner", file=our_file),
+                            desc="outer", file=our_file):
             pass
         assert 'inner: 100%' in our_file.getvalue()
         assert 'outer: 100%' in our_file.getvalue()
@@ -81,11 +81,11 @@ async def test_coroutines():
     """Test asyncio coroutine.send"""
     with closing(StringIO()) as our_file:
         with tqdm(count(), file=our_file) as pbar:
-            async for row in pbar:
-                if row == 9:
+            async for i in pbar:
+                if i == 9:
                     pbar.send(-10)
-                elif row < 0:
-                    assert row == -9
+                elif i < 0:
+                    assert i == -9
                     break
         assert '10it' in our_file.getvalue()
 

--- a/tqdm/tests/py37_asyncio.py
+++ b/tqdm/tests/py37_asyncio.py
@@ -96,8 +96,8 @@ async def test_as_completed():
     with closing(StringIO()) as our_file:
         t = time()
         skew = time() - t
-        for i in as_completed([asyncio.sleep(0.01) for _ in range(100)],
-                              file=our_file):
+        for i in as_completed([asyncio.sleep(0.01 * i)
+                               for i in range(30, 0, -1)], file=our_file):
             await i
-        assert time() - t - 2 * skew < (0.01 * 100) / 2, "Assuming >= 2 cores"
-        assert '100/100' in our_file.getvalue()
+        assert 0.29 < time() - t - 2 * skew < 0.31
+        assert '30/30' in our_file.getvalue()

--- a/tqdm/tests/tests_contrib.py
+++ b/tqdm/tests/tests_contrib.py
@@ -19,6 +19,12 @@ def test_enumerate():
         a = range(9)
         assert list(tenumerate(a, file=our_file)) == list(enumerate(a))
         assert list(tenumerate(a, 42, file=our_file)) == list(enumerate(a, 42))
+    with closing(StringIO()) as our_file:
+        _ = list(tenumerate((i for i in a), file=our_file))
+        assert "100%" not in our_file.getvalue()
+    with closing(StringIO()) as our_file:
+        _ = list(tenumerate((i for i in a), file=our_file, total=len(a)))
+        assert "100%" in our_file.getvalue()
 
 
 @with_setup(pretest, posttest)

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -268,6 +268,12 @@ def test_iter_overhead_hard():
     total = int(1e5)
 
     with closing(MockIO()) as our_file:
+        with trange(1, file=our_file, leave=True, miniters=1,
+                    mininterval=0, maxinterval=0) as t:
+            with relative_timer() as prime:
+                for i in t:
+                    pass
+
         a = 0
         with trange(total, file=our_file, leave=True, miniters=1,
                     mininterval=0, maxinterval=0) as t:
@@ -282,7 +288,8 @@ def test_iter_overhead_hard():
                 a += i
                 our_file.write(("%i" % a) * 40)
 
-    assert_performance(85, 'trange', time_tqdm(), 'range', time_bench())
+    assert_performance(
+        85, 'trange', time_tqdm() - prime(), 'range', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -293,6 +300,12 @@ def test_manual_overhead_hard():
     total = int(1e5)
 
     with closing(MockIO()) as our_file:
+        with trange(1, file=our_file, leave=True, miniters=1,
+                    mininterval=0, maxinterval=0) as t:
+            with relative_timer() as prime:
+                for i in t:
+                    pass
+
         t = tqdm(total=total * 10, file=our_file, leave=True, miniters=1,
                  mininterval=0, maxinterval=0)
         a = 0
@@ -307,7 +320,8 @@ def test_manual_overhead_hard():
                 a += i
                 our_file.write(("%i" % a) * 40)
 
-    assert_performance(85, 'tqdm', time_tqdm(), 'range', time_bench())
+    assert_performance(
+        85, 'tqdm', time_tqdm() - prime(), 'range', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -318,6 +332,12 @@ def test_iter_overhead_simplebar_hard():
     total = int(1e4)
 
     with closing(MockIO()) as our_file:
+        with trange(1, file=our_file, leave=True, miniters=1,
+                    mininterval=0, maxinterval=0) as t:
+            with relative_timer() as prime:
+                for i in t:
+                    pass
+
         a = 0
         with trange(total, file=our_file, leave=True, miniters=1,
                     mininterval=0, maxinterval=0) as t:
@@ -334,7 +354,7 @@ def test_iter_overhead_simplebar_hard():
                 a += i
 
     assert_performance(
-        5, 'trange', time_tqdm(), 'simple_progress', time_bench())
+        5, 'trange', time_tqdm() - prime(), 'simple_progress', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -345,6 +365,12 @@ def test_manual_overhead_simplebar_hard():
     total = int(1e4)
 
     with closing(MockIO()) as our_file:
+        with trange(1, file=our_file, leave=True, miniters=1,
+                    mininterval=0, maxinterval=0) as t:
+            with relative_timer() as prime:
+                for i in t:
+                    pass
+
         t = tqdm(total=total * 10, file=our_file, leave=True, miniters=1,
                  mininterval=0, maxinterval=0)
         a = 0
@@ -363,4 +389,4 @@ def test_manual_overhead_simplebar_hard():
                 simplebar_update(10)
 
     assert_performance(
-        5, 'tqdm', time_tqdm(), 'simple_progress', time_bench())
+        5, 'tqdm', time_tqdm() - prime(), 'simple_progress', time_bench())

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -268,12 +268,6 @@ def test_iter_overhead_hard():
     total = int(1e5)
 
     with closing(MockIO()) as our_file:
-        with trange(1, file=our_file, leave=True, miniters=1,
-                    mininterval=0, maxinterval=0) as t:
-            with relative_timer() as prime:
-                for i in t:
-                    pass
-
         a = 0
         with trange(total, file=our_file, leave=True, miniters=1,
                     mininterval=0, maxinterval=0) as t:
@@ -288,8 +282,7 @@ def test_iter_overhead_hard():
                 a += i
                 our_file.write(("%i" % a) * 40)
 
-    assert_performance(
-        85, 'trange', time_tqdm() - prime(), 'range', time_bench())
+    assert_performance(125, 'trange', time_tqdm(), 'range', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -300,12 +293,6 @@ def test_manual_overhead_hard():
     total = int(1e5)
 
     with closing(MockIO()) as our_file:
-        with trange(1, file=our_file, leave=True, miniters=1,
-                    mininterval=0, maxinterval=0) as t:
-            with relative_timer() as prime:
-                for i in t:
-                    pass
-
         t = tqdm(total=total * 10, file=our_file, leave=True, miniters=1,
                  mininterval=0, maxinterval=0)
         a = 0
@@ -320,8 +307,7 @@ def test_manual_overhead_hard():
                 a += i
                 our_file.write(("%i" % a) * 40)
 
-    assert_performance(
-        85, 'tqdm', time_tqdm() - prime(), 'range', time_bench())
+    assert_performance(125, 'tqdm', time_tqdm(), 'range', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -332,12 +318,6 @@ def test_iter_overhead_simplebar_hard():
     total = int(1e4)
 
     with closing(MockIO()) as our_file:
-        with trange(1, file=our_file, leave=True, miniters=1,
-                    mininterval=0, maxinterval=0) as t:
-            with relative_timer() as prime:
-                for i in t:
-                    pass
-
         a = 0
         with trange(total, file=our_file, leave=True, miniters=1,
                     mininterval=0, maxinterval=0) as t:
@@ -354,7 +334,7 @@ def test_iter_overhead_simplebar_hard():
                 a += i
 
     assert_performance(
-        5, 'trange', time_tqdm() - prime(), 'simple_progress', time_bench())
+        7.5, 'trange', time_tqdm(), 'simple_progress', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -365,12 +345,6 @@ def test_manual_overhead_simplebar_hard():
     total = int(1e4)
 
     with closing(MockIO()) as our_file:
-        with trange(1, file=our_file, leave=True, miniters=1,
-                    mininterval=0, maxinterval=0) as t:
-            with relative_timer() as prime:
-                for i in t:
-                    pass
-
         t = tqdm(total=total * 10, file=our_file, leave=True, miniters=1,
                  mininterval=0, maxinterval=0)
         a = 0
@@ -389,4 +363,4 @@ def test_manual_overhead_simplebar_hard():
                 simplebar_update(10)
 
     assert_performance(
-        5, 'tqdm', time_tqdm() - prime(), 'simple_progress', time_bench())
+        7.5, 'tqdm', time_tqdm(), 'simple_progress', time_bench())

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -240,7 +240,6 @@ def test_lock_args():
         from threading import RLock
     except ImportError:
         raise SkipTest
-    import sys
 
     total = 8
     subtotal = 1000

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -925,7 +925,7 @@ def test_nototal():
         assert "100it" in our_file.getvalue()
 
     with closing(StringIO()) as our_file:
-        for i in tqdm((i for i in range(10)), file=our_file,
+        for _ in tqdm((i for i in range(10)), file=our_file,
                       bar_format="{l_bar}{bar}{r_bar}"):
             pass
         assert "10/?" in our_file.getvalue()

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -920,7 +920,7 @@ def test_infinite_total():
 def test_nototal():
     """Test unknown total length"""
     with closing(StringIO()) as our_file:
-        for i in tqdm((i for i in range(10)), file=our_file, unit_scale=10):
+        for _ in tqdm((i for i in range(10)), file=our_file, unit_scale=10):
             pass
         assert "100it" in our_file.getvalue()
 
@@ -1196,7 +1196,7 @@ def test_custom_format():
             return d
 
     with closing(StringIO()) as our_file:
-        for i in TqdmExtraFormat(
+        for _ in TqdmExtraFormat(
                 range(10), file=our_file,
                 bar_format="{total_time}: {percentage:.0f}%|{bar}{r_bar}"):
             pass


### PR DESCRIPTION
- fix ANSI escape codes breaking `tqdm.write` (#692, #777)
- fix long-lived strongref (#1007, https://bugs.python.org/issue39093)
- fix cli `--version` crash on missing `git/refs/heads` (#635)
- fix `contrib.tenumerate` ignoring `total` (#1017)
- fix potential deep => shallow `kwargs` copy issues
- improve `notebook` display for unknown `total` (#1015)
- make `asyncio` inherit from `std` rather than `auto`
- make `auto` multi-inherit from `autonotebook`, `asyncio` on Python3.5+
- misc documentation & examples updates
  + mention `docker-compose` requirements (#771)
- misc linting & tidy
- misc minor testing framework updates

---

- fixes #777
- fixes #692
- related #591
- closes #1007
- fixes #771
- fixes #635
- fixes #1017
- fixes #1015