### PR TITLE
cli: add `--tee`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -464,7 +464,7 @@ Extra CLI Options
     If true, will count bytes, ignore ``delim``, and default
     ``unit_scale`` to True, ``unit_divisor`` to 1024, and ``unit`` to 'B'.
 * tee  : bool, optional  
-    If true, outputs to both ``stdin`` and ``stdout``.
+    If true, passes ``stdin`` to both ``stderr`` and ``stdout``.
 * manpath  : str, optional  
     Directory in which to install tqdm man pages.
 * comppath  : str, optional  

--- a/README.rst
+++ b/README.rst
@@ -463,6 +463,8 @@ Extra CLI Options
 * bytes  : bool, optional  
     If true, will count bytes, ignore ``delim``, and default
     ``unit_scale`` to True, ``unit_divisor`` to 1024, and ``unit`` to 'B'.
+* tee  : bool, optional  
+    If true, outputs to both ``stdin`` and ``stdout``.
 * manpath  : str, optional  
     Directory in which to install tqdm man pages.
 * comppath  : str, optional  

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -113,7 +113,7 @@ CLI_EXTRA_DOC = r"""
             If true, will count bytes, ignore `delim`, and default
             `unit_scale` to True, `unit_divisor` to 1024, and `unit` to 'B'.
         tee  : bool, optional
-            If true, outputs to both `stdin` and `stdout`.
+            If true, passes `stdin` to both `stderr` and `stdout`.
         manpath  : str, optional
             Directory in which to install tqdm man pages.
         comppath  : str, optional

--- a/tqdm/completion.sh
+++ b/tqdm/completion.sh
@@ -12,7 +12,7 @@ _tqdm(){
     COMPREPLY=($(compgen -W       'CRITICAL FATAL ERROR WARN WARNING INFO DEBUG NOTSET' -- ${cur}))
     ;;
   *)
-    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --position --postfix --smoothing --total --unit --unit_divisor --unit_scale --version --write_bytes -h -v' -- ${cur}))
+    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_scale --version --write_bytes -h -v' -- ${cur}))
     ;;
   esac
 }

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -251,6 +251,12 @@ If true, will count bytes, ignore \f[C]delim\f[], and default
 .RS
 .RE
 .TP
+.B \-\-tee=\f[I]tee\f[]
+bool, optional.
+If true, outputs to both \f[C]stdin\f[] and \f[C]stdout\f[].
+.RS
+.RE
+.TP
 .B \-\-manpath=\f[I]manpath\f[]
 str, optional.
 Directory in which to install tqdm man pages.

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -253,7 +253,8 @@ If true, will count bytes, ignore \f[C]delim\f[], and default
 .TP
 .B \-\-tee=\f[I]tee\f[]
 bool, optional.
-If true, outputs to both \f[C]stdin\f[] and \f[C]stdout\f[].
+If true, passes \f[C]stdin\f[] to both \f[C]stderr\f[] and
+\f[C]stdout\f[].
 .RS
 .RE
 .TP


### PR DESCRIPTION
- [x] add `--tee` argument
- [x] ~~add `{line}` parameter for use in `bar_format`?~~
  + bad idea since there are modes (e.g. `bytes`) which don't do line buffering
- [x] test

---

- fixes #1013
