### PR TITLE
next release v4.49.0

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -298,7 +298,7 @@ of a neat one-line progress bar.
 - Unicode:
 
   * Environments which report that they support unicode will have solid smooth
-    progressbars. The fallback is an ```ascii``-only bar.
+    progressbars. The fallback is an ``ascii``-only bar.
   * Windows consoles often only partially support unicode and thus
     `often require explicit ascii=True <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__
     (also `here <https://github.com/tqdm/tqdm/issues/499>`__). This is due to
@@ -842,10 +842,13 @@ For further customisation,
 Consider overloading ``display()`` to use e.g.
 ``self.frontend(**self.format_dict)`` instead of ``self.sp(repr(self))``.
 
-`tqdm/notebook.py <https://github.com/tqdm/tqdm/blob/master/tqdm/notebook.py>`__
-and `tqdm/gui.py <https://github.com/tqdm/tqdm/blob/master/tqdm/gui.py>`__
-submodules are examples of inheritance which don't (yet) strictly conform to the
-above recommendation.
+Some submodule examples of inheritance which don't (yet) strictly conform to the
+above recommendation:
+
+- `tqdm/notebook.py <https://github.com/tqdm/tqdm/blob/master/tqdm/notebook.py>`__
+- `tqdm/gui.py <https://github.com/tqdm/tqdm/blob/master/tqdm/gui.py>`__
+- `tqdm/contrib/telegram.py <https://github.com/tqdm/tqdm/blob/master/tqdm/contrib/telegram.py>`__
+- `tqdm/contrib/discord.py <https://github.com/tqdm/tqdm/blob/master/tqdm/contrib/discord.py>`__
 
 Dynamic Monitor/Meter
 ~~~~~~~~~~~~~~~~~~~~~

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -272,6 +272,16 @@ Or done on a file level using 7-zip:
       | grep -v Compressing
     100%|██████████████████████████▉| 15327/15327 [01:00<00:00, 712.96files/s]
 
+Pre-existing CLI programs already outputting basic progress information will
+benefit from ``tqdm``'s ``--update`` and ``--update_to`` flags:
+
+.. code:: sh
+
+    seq 3 0.1 5 | tqdm --total 5 --update_to --null
+    100%|████████████████████████████████████| 5.0/5 [00:00<00:00, 9673.21it/s]
+    seq 10 | tqdm --update --null  # 1 + 2 + ... + 10 = 55 iterations
+    55it [00:00, 90006.52it/s]
+
 FAQ and Known Issues
 --------------------
 

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -713,6 +713,26 @@ The ``requests`` equivalent is nearly identical, albeit with a ``total``:
         for chunk in response.iter_content(chunk_size=4096):
             fout.write(chunk)
 
+**Custom callback**
+
+``tqdm`` is known for intelligently skipping unnecessary displays. To make a
+custom callback take advantage of this, simply use the return value of
+``update()``. This is set to ``True`` if a ``display()`` was triggered.
+
+.. code:: python
+
+    from tqdm.auto import tqdm as std_tqdm
+
+    def external_callback(*args, **kwargs):
+        ...
+
+    class TqdmExt(std_tqdm):
+        def update(self, n=1):
+            displayed = super(TqdmExt, self).update(n):
+            if displayed:
+                external_callback(**self.format_dict)
+            return displayed
+
 Pandas Integration
 ~~~~~~~~~~~~~~~~~~
 

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -646,7 +646,7 @@ Here's an example with ``urllib``:
             """
             if tsize is not None:
                 self.total = tsize
-            self.update(b * bsize - self.n)  # will also set self.n = b * bsize
+            return self.update(b * bsize - self.n)  # also sets self.n = b * bsize
 
     eg_link = "https://caspersci.uk.to/matryoshka.zip"
     with TqdmUpTo(unit='B', unit_scale=True, unit_divisor=1024, miniters=1,

--- a/DEMO.ipynb
+++ b/DEMO.ipynb
@@ -703,7 +703,7 @@
     "        \"\"\"\n",
     "        if tsize is not None:\n",
     "            self.total = tsize\n",
-    "        self.update(b * bsize - self.n)  # will also set self.n = b * bsize\n",
+    "        return self.update(b * bsize - self.n)  # also sets self.n = b * bsize\n",
     "\n",
     "eg_link = \"https://caspersci.uk.to/matryoshka.zip\"\n",
     "with TqdmUpTo(unit='B', unit_scale=True, unit_divisor=1024, miniters=1,\n",

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ tqdm/tqdm.1: .meta/.tqdm.1.md tqdm/cli.py tqdm/std.py
 	python -m tqdm --help | tail -n+5 |\
     sed -r -e 's/\\/\\\\/g' \
       -e 's/^  (--.*)=<(.*)>  : (.*)$$/\n\\\1=*\2*\n: \3./' \
+      -e 's/^  (--.*)  : (.*)$$/\n\\\1\n: \2./' \
       -e 's/  (-.*, )(--.*)  /\n\1\\\2\n: /' |\
     cat "$<" - |\
     pandoc -o "$@" -s -t man

--- a/README.rst
+++ b/README.rst
@@ -463,6 +463,8 @@ Extra CLI Options
 * bytes  : bool, optional  
     If true, will count bytes, ignore ``delim``, and default
     ``unit_scale`` to True, ``unit_divisor`` to 1024, and ``unit`` to 'B'.
+* tee  : bool, optional  
+    If true, passes ``stdin`` to both ``stderr`` and ``stdout``.
 * manpath  : str, optional  
     Directory in which to install tqdm man pages.
 * comppath  : str, optional  

--- a/README.rst
+++ b/README.rst
@@ -272,6 +272,16 @@ Or done on a file level using 7-zip:
       | grep -v Compressing
     100%|██████████████████████████▉| 15327/15327 [01:00<00:00, 712.96files/s]
 
+Pre-existing CLI programs already outputting basic progress information will
+benefit from ``tqdm``'s ``--update`` and ``--update_to`` flags:
+
+.. code:: sh
+
+    seq 3 0.1 5 | tqdm --total 5 --update_to --null
+    100%|████████████████████████████████████| 5.0/5 [00:00<00:00, 9673.21it/s]
+    seq 10 | tqdm --update --null  # 1 + 2 + ... + 10 = 55 iterations
+    55it [00:00, 90006.52it/s]
+
 FAQ and Known Issues
 --------------------
 
@@ -465,6 +475,14 @@ Extra CLI Options
     ``unit_scale`` to True, ``unit_divisor`` to 1024, and ``unit`` to 'B'.
 * tee  : bool, optional  
     If true, passes ``stdin`` to both ``stderr`` and ``stdout``.
+* update  : bool, optional  
+    If true, will treat input as newly elapsed iterations,
+    i.e. numbers to pass to ``update()``.
+* update_to  : bool, optional  
+    If true, will treat input as total elapsed iterations,
+    i.e. numbers to assign to ``self.n``.
+* null  : bool, optional  
+    If true, will discard input (no stdout).
 * manpath  : str, optional  
     Directory in which to install tqdm man pages.
 * comppath  : str, optional  

--- a/README.rst
+++ b/README.rst
@@ -500,6 +500,11 @@ Returns
               Increment to add to the internal counter of iterations
               [default: 1]. If using float, consider specifying ``{n:.3f}``
               or similar in ``bar_format``, or specifying ``unit_scale``.
+
+          Returns
+          -------
+          out  : bool or None
+              True if a ``display()`` was triggered.
           """
 
       def close(self):
@@ -912,6 +917,26 @@ The ``requests`` equivalent is nearly identical, albeit with a ``total``:
                        total=int(response.headers.get('content-length', 0))) as fout:
         for chunk in response.iter_content(chunk_size=4096):
             fout.write(chunk)
+
+**Custom callback**
+
+``tqdm`` is known for intelligently skipping unnecessary displays. To make a
+custom callback take advantage of this, simply use the return value of
+``update()``. This is set to ``True`` if a ``display()`` was triggered.
+
+.. code:: python
+
+    from tqdm.auto import tqdm as std_tqdm
+
+    def external_callback(*args, **kwargs):
+        ...
+
+    class TqdmExt(std_tqdm):
+        def update(self, n=1):
+            displayed = super(TqdmExt, self).update(n):
+            if displayed:
+                external_callback(**self.format_dict)
+            return displayed
 
 Pandas Integration
 ~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -298,7 +298,7 @@ of a neat one-line progress bar.
 - Unicode:
 
   * Environments which report that they support unicode will have solid smooth
-    progressbars. The fallback is an ```ascii``-only bar.
+    progressbars. The fallback is an ``ascii``-only bar.
   * Windows consoles often only partially support unicode and thus
     `often require explicit ascii=True <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__
     (also `here <https://github.com/tqdm/tqdm/issues/499>`__). This is due to
@@ -1040,10 +1040,13 @@ For further customisation,
 Consider overloading ``display()`` to use e.g.
 ``self.frontend(**self.format_dict)`` instead of ``self.sp(repr(self))``.
 
-`tqdm/notebook.py <https://github.com/tqdm/tqdm/blob/master/tqdm/notebook.py>`__
-and `tqdm/gui.py <https://github.com/tqdm/tqdm/blob/master/tqdm/gui.py>`__
-submodules are examples of inheritance which don't (yet) strictly conform to the
-above recommendation.
+Some submodule examples of inheritance which don't (yet) strictly conform to the
+above recommendation:
+
+- `tqdm/notebook.py <https://github.com/tqdm/tqdm/blob/master/tqdm/notebook.py>`__
+- `tqdm/gui.py <https://github.com/tqdm/tqdm/blob/master/tqdm/gui.py>`__
+- `tqdm/contrib/telegram.py <https://github.com/tqdm/tqdm/blob/master/tqdm/contrib/telegram.py>`__
+- `tqdm/contrib/discord.py <https://github.com/tqdm/tqdm/blob/master/tqdm/contrib/discord.py>`__
 
 Dynamic Monitor/Meter
 ~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -846,7 +846,7 @@ Here's an example with ``urllib``:
             """
             if tsize is not None:
                 self.total = tsize
-            self.update(b * bsize - self.n)  # will also set self.n = b * bsize
+            return self.update(b * bsize - self.n)  # also sets self.n = b * bsize
 
     eg_link = "https://caspersci.uk.to/matryoshka.zip"
     with TqdmUpTo(unit='B', unit_scale=True, unit_divisor=1024, miniters=1,

--- a/examples/tqdm_wget.py
+++ b/examples/tqdm_wget.py
@@ -55,8 +55,9 @@ def my_hook(t):
         """
         if tsize not in (None, -1):
             t.total = tsize
-        t.update((b - last_b[0]) * bsize)
+        displayed = t.update((b - last_b[0]) * bsize)
         last_b[0] = b
+        return displayed
 
     return update_to
 
@@ -81,7 +82,7 @@ class TqdmUpTo(tqdm):
         """
         if tsize is not None:
             self.total = tsize
-        self.update(b * bsize - self.n)  # will also set self.n = b * bsize
+        return self.update(b * bsize - self.n)  # also sets self.n = b * bsize
 
 
 opts = docopt(__doc__)

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -112,6 +112,8 @@ CLI_EXTRA_DOC = r"""
         bytes  : bool, optional
             If true, will count bytes, ignore `delim`, and default
             `unit_scale` to True, `unit_divisor` to 1024, and `unit` to 'B'.
+        tee  : bool, optional
+            If true, passes `stdin` to both `stderr` and `stdout`.
         manpath  : str, optional
             Directory in which to install tqdm man pages.
         comppath  : str, optional
@@ -204,6 +206,7 @@ Options:
         buf_size = tqdm_args.pop('buf_size', 256)
         delim = tqdm_args.pop('delim', '\n')
         delim_per_char = tqdm_args.pop('bytes', False)
+        tee = tqdm_args.pop('tee', False)
         manpath = tqdm_args.pop('manpath', None)
         comppath = tqdm_args.pop('comppath', None)
         stdin = getattr(sys.stdin, 'buffer', sys.stdin)
@@ -225,6 +228,16 @@ Options:
                                      'tqdm/completion.sh'),
                    path.join(comppath, 'tqdm_completion.sh'))
             sys.exit(0)
+        if tee:
+            stdout_write = stdout.write
+            fp_write = getattr(fp, 'buffer', fp).write
+
+            class stdout(object):
+                @staticmethod
+                def write(x):
+                    with tqdm.external_write_mode(file=fp):
+                        fp_write(x)
+                    stdout_write(x)
         if delim_per_char:
             tqdm_args.setdefault('unit', 'B')
             tqdm_args.setdefault('unit_scale', True)

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -32,12 +32,12 @@ def cast(val, typ):
         return eval(typ + '("' + val + '")')
     except:
         if typ == 'chr':
-            return chr(ord(eval('"' + val + '"')))
+            return chr(ord(eval('"' + val + '"'))).encode()
         else:
             raise TqdmTypeError(val + ' : ' + typ)
 
 
-def posix_pipe(fin, fout, delim='\n', buf_size=256,
+def posix_pipe(fin, fout, delim=b'\\n', buf_size=256,
                callback=lambda int: None  # pragma: no cover
                ):
     """
@@ -49,7 +49,7 @@ def posix_pipe(fin, fout, delim='\n', buf_size=256,
     """
     fp_write = fout.write
 
-    # tmp = ''
+    # tmp = b''
     if not delim:
         while True:
             tmp = fin.read(buf_size)
@@ -63,7 +63,7 @@ def posix_pipe(fin, fout, delim='\n', buf_size=256,
             callback(len(tmp))
         # return
 
-    buf = ''
+    buf = b''
     # n = 0
     while True:
         tmp = fin.read(buf_size)
@@ -85,7 +85,7 @@ def posix_pipe(fin, fout, delim='\n', buf_size=256,
             else:
                 fp_write(buf + tmp[:i + len(delim)])
                 callback(1)  # n += 1
-                buf = ''
+                buf = b''
                 tmp = tmp[i + len(delim):]
 
 
@@ -204,7 +204,7 @@ Options:
         raise
     else:
         buf_size = tqdm_args.pop('buf_size', 256)
-        delim = tqdm_args.pop('delim', '\n')
+        delim = tqdm_args.pop('delim', b'\\n')
         delim_per_char = tqdm_args.pop('bytes', False)
         tee = tqdm_args.pop('tee', False)
         manpath = tqdm_args.pop('manpath', None)
@@ -245,7 +245,7 @@ Options:
             log.debug(tqdm_args)
             with tqdm(**tqdm_args) as t:
                 posix_pipe(stdin, stdout, '', buf_size, t.update)
-        elif delim == '\n':
+        elif delim == b'\\n':
             log.debug(tqdm_args)
             for i in tqdm(stdin, **tqdm_args):
                 stdout.write(i)

--- a/tqdm/completion.sh
+++ b/tqdm/completion.sh
@@ -12,7 +12,7 @@ _tqdm(){
     COMPREPLY=($(compgen -W       'CRITICAL FATAL ERROR WARN WARNING INFO DEBUG NOTSET' -- ${cur}))
     ;;
   *)
-    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_scale --version --write_bytes -h -v' -- ${cur}))
+    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --null --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_scale --update --update_to --version --write_bytes -h -v' -- ${cur}))
     ;;
   esac
 }

--- a/tqdm/completion.sh
+++ b/tqdm/completion.sh
@@ -12,7 +12,7 @@ _tqdm(){
     COMPREPLY=($(compgen -W       'CRITICAL FATAL ERROR WARN WARNING INFO DEBUG NOTSET' -- ${cur}))
     ;;
   *)
-    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --position --postfix --smoothing --total --unit --unit_divisor --unit_scale --version --write_bytes -h -v' -- ${cur}))
+    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_scale --version --write_bytes -h -v' -- ${cur}))
     ;;
   esac
 }

--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -220,6 +220,7 @@ class tqdm_gui(std_tqdm):  # pragma: no cover
                 # Store old values for next call
                 self.last_print_n = self.n
                 self.last_print_t = cur_t
+                return True
 
     def close(self):
         # if not self.gui:

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -237,7 +237,7 @@ class tqdm_notebook(std_tqdm):
 
     def update(self, *args, **kwargs):
         try:
-            super(tqdm_notebook, self).update(*args, **kwargs)
+            return super(tqdm_notebook, self).update(*args, **kwargs)
         # NB: except ... [ as ...] breaks IPython async KeyboardInterrupt
         except:  # NOQA
             # cannot catch KeyboardInterrupt when using manual tqdm

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1257,6 +1257,7 @@ class tqdm(Comparable):
                 # Store old values for next call
                 self.last_print_n = self.n
                 self.last_print_t = cur_t
+                return True
 
     def close(self):
         """Cleanup and (if leave=False) close the progressbar."""

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -23,8 +23,7 @@ from time import time
 import threading as th
 from warnings import warn
 
-__author__ = {"github.com/": ["noamraph", "obiwanus", "kmike", "hadim",
-                              "casperdcl", "lrq3000"]}
+__author__ = "https://github.com/tqdm/tqdm#contributions"
 __all__ = ['tqdm', 'trange',
            'TqdmTypeError', 'TqdmKeyError', 'TqdmWarning',
            'TqdmExperimentalWarning', 'TqdmDeprecationWarning',
@@ -310,7 +309,8 @@ class tqdm(Comparable):
     @staticmethod
     def format_meter(n, total, elapsed, ncols=None, prefix='', ascii=False,
                      unit='it', unit_scale=False, rate=None, bar_format=None,
-                     postfix=None, unit_divisor=1000, **extra_kwargs):
+                     postfix=None, unit_divisor=1000, initial=0,
+                     **extra_kwargs):
         """
         Return a string-based progress bar given some parameters
 
@@ -366,6 +366,8 @@ class tqdm(Comparable):
             However other types are supported (#382).
         unit_divisor  : float, optional
             [default: 1000], ignored unless `unit_scale` is True.
+        initial  : int or float, optional
+            The initial counter value [default: 0].
 
         Returns
         -------
@@ -390,7 +392,7 @@ class tqdm(Comparable):
         # if unspecified, attempt to use rate = average speed
         # (we allow manual override since predicting time is an arcane art)
         if rate is None and elapsed:
-            rate = n / elapsed
+            rate = (n - initial) / elapsed
         inv_rate = 1 / rate if rate else None
         format_sizeof = tqdm.format_sizeof
         rate_noinv_fmt = ((format_sizeof(rate) if unit_scale else
@@ -1019,6 +1021,7 @@ class tqdm(Comparable):
         self.unit = unit
         self.unit_scale = unit_scale
         self.unit_divisor = unit_divisor
+        self.initial = initial
         self.lock_args = lock_args
         self.gui = gui
         self.dynamic_ncols = dynamic_ncols
@@ -1448,7 +1451,7 @@ class tqdm(Comparable):
             unit_scale=self.unit_scale,
             rate=1 / self.avg_time if self.avg_time else None,
             bar_format=self.bar_format, postfix=self.postfix,
-            unit_divisor=self.unit_divisor)
+            unit_divisor=self.unit_divisor, initial=self.initial)
 
     def display(self, msg=None, pos=None):
         """

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1202,6 +1202,11 @@ class tqdm(Comparable):
             Increment to add to the internal counter of iterations
             [default: 1]. If using float, consider specifying `{n:.3f}`
             or similar in `bar_format`, or specifying `unit_scale`.
+
+        Returns
+        -------
+        out  : bool or None
+            True if a `display()` was triggered.
         """
         # N.B.: see __iter__() for more comments.
         if self.disable:

--- a/tqdm/tests/tests_main.py
+++ b/tqdm/tests/tests_main.py
@@ -47,16 +47,17 @@ def test_pipes():
 def test_main():
     """Test misc CLI options"""
     _SYS = sys.stdin, sys.argv
+    N = 123
 
     # test direct import
-    sys.stdin = map(str, _range(int(123)))
+    sys.stdin = map(str, _range(N))
     sys.argv = ['', '--desc', 'Test CLI import',
                 '--ascii', 'True', '--unit_scale', 'True']
     import tqdm.__main__  # NOQA
     sys.stderr.write("Test misc CLI options ... ")
 
     # test --delim
-    IN_DATA = '\0'.join(map(str, _range(int(123))))
+    IN_DATA = '\0'.join(map(str, _range(N)))
     with closing(StringIO()) as sys.stdin:
         sys.argv = ['', '--desc', 'Test CLI delim',
                     '--ascii', 'True', '--delim', r'\0', '--buf_size', '64']
@@ -65,7 +66,7 @@ def test_main():
         sys.stdin.seek(0)
         with closing(UnicodeIO()) as fp:
             main(fp=fp)
-            assert "123it" in fp.getvalue()
+            assert str(N) + "it" in fp.getvalue()
 
     # test --bytes
     IN_DATA = IN_DATA.replace('\0', '\n')
@@ -78,7 +79,7 @@ def test_main():
             assert str(len(IN_DATA)) in fp.getvalue()
 
     # test --log
-    sys.stdin = map(str, _range(int(123)))
+    sys.stdin = map(str, _range(N))
     # with closing(UnicodeIO()) as fp:
     main(argv=['--log', 'DEBUG'], fp=NULL)
     # assert "DEBUG:" in sys.stdout.getvalue()
@@ -98,6 +99,85 @@ def test_main():
             main(argv=['--tee', '--mininterval', '0', '--miniters', '1'], fp=fp)
             # spaces to clear intermediate lines could increase length
             assert len(fp.getvalue()) >= res + len(IN_DATA)
+
+    # test --null
+    _STDOUT = sys.stdout
+    try:
+        with closing(StringIO()) as sys.stdout:
+            with closing(StringIO()) as sys.stdin:
+                sys.stdin.write(IN_DATA)
+
+                sys.stdin.seek(0)
+                with closing(UnicodeIO()) as fp:
+                    main(argv=['--null'], fp=fp)
+                    assert not sys.stdout.getvalue()
+
+            with closing(StringIO()) as sys.stdin:
+                sys.stdin.write(IN_DATA)
+
+                sys.stdin.seek(0)
+                with closing(UnicodeIO()) as fp:
+                    main(argv=[], fp=fp)
+                    assert sys.stdout.getvalue()
+    except:
+        sys.stdout = _STDOUT
+        raise
+    else:
+        sys.stdout = _STDOUT
+
+    # test integer --update
+    with closing(StringIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA)
+
+        sys.stdin.seek(0)
+        with closing(UnicodeIO()) as fp:
+            main(argv=['--update'], fp=fp)
+            res = fp.getvalue()
+            assert str(N // 2 * N) + "it" in res  # arithmetic sum formula
+
+    # test integer --update --delim
+    with closing(StringIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA.replace('\n', 'D'))
+
+        sys.stdin.seek(0)
+        with closing(UnicodeIO()) as fp:
+            main(argv=['--update', '--delim', 'D'], fp=fp)
+            res = fp.getvalue()
+            assert str(N // 2 * N) + "it" in res  # arithmetic sum formula
+
+    # test integer --update_to
+    with closing(StringIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA)
+
+        sys.stdin.seek(0)
+        with closing(UnicodeIO()) as fp:
+            main(argv=['--update-to'], fp=fp)
+            res = fp.getvalue()
+            assert str(N - 1) + "it" in res
+            assert str(N) + "it" not in res
+
+    # test integer --update_to --delim
+    with closing(StringIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA.replace('\n', 'D'))
+
+        sys.stdin.seek(0)
+        with closing(UnicodeIO()) as fp:
+            main(argv=['--update-to', '--delim', 'D'], fp=fp)
+            res = fp.getvalue()
+            assert str(N - 1) + "it" in res
+            assert str(N) + "it" not in res
+
+    # test float --update_to
+    IN_DATA = '\n'.join((str(i / 2.0) for i in _range(N)))
+    with closing(StringIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA)
+
+        sys.stdin.seek(0)
+        with closing(UnicodeIO()) as fp:
+            main(argv=['--update-to'], fp=fp)
+            res = fp.getvalue()
+            assert str((N - 1) / 2.0) + "it" in res
+            assert str(N / 2.0) + "it" not in res
 
     # clean up
     sys.stdin, sys.argv = _SYS
@@ -150,7 +230,7 @@ def test_comppath():
 def test_exceptions():
     """Test CLI Exceptions"""
     _SYS = sys.stdin, sys.argv
-    sys.stdin = map(str, _range(int(123)))
+    sys.stdin = map(str, _range(123))
 
     sys.argv = ['', '-ascii', '-unit_scale', '--bad_arg_u_ment', 'foo']
     try:
@@ -178,6 +258,15 @@ def test_exceptions():
             raise
     else:
         raise TqdmTypeError('invalid_int_value')
+
+    sys.argv = ['', '--update', '--update_to']
+    try:
+        main(fp=NULL)
+    except TqdmKeyError as e:
+        if 'Can only have one of --' not in str(e):
+            raise
+    else:
+        raise TqdmKeyError('Cannot have both --update --update_to')
 
     # test SystemExits
     for i in ('-h', '--help', '-v', '--version'):

--- a/tqdm/tests/tests_tqdm.py
+++ b/tqdm/tests/tests_tqdm.py
@@ -1975,3 +1975,15 @@ def test_screen_shape():
 
         res = our_file.getvalue()
         assert "two" in res
+
+
+@with_setup(pretest, posttest)
+def test_initial():
+    """Test `initial`"""
+    with closing(StringIO()) as our_file:
+        for _ in tqdm(_range(9), initial=10, total=19, file=our_file,
+                      miniters=1, mininterval=0):
+            pass
+        out = our_file.getvalue()
+        assert '10/19' in out
+        assert '19/19' in out

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -36,12 +36,12 @@ counting:\ 100%|█████████|\ 432/432\ [00:00<00:00,\ 794361.83f
 .SH OPTIONS
 .TP
 .B \-h, \-\-help
-Print this help and exit
+Print this help and exit.
 .RS
 .RE
 .TP
 .B \-v, \-\-version
-Print version and exit
+Print version and exit.
 .RS
 .RE
 .TP
@@ -63,7 +63,7 @@ specify an initial arbitrary large positive number, e.g.
 .RS
 .RE
 .TP
-.B \-\-leave=\f[I]leave\f[]
+.B \-\-leave
 bool, optional.
 If [default: True], keeps all traces of the progressbar upon termination
 of iteration.
@@ -117,7 +117,7 @@ The fallback is to use ASCII characters " 123456789#".
 .RS
 .RE
 .TP
-.B \-\-disable=\f[I]disable\f[]
+.B \-\-disable
 bool, optional.
 Whether to disable the entire progressbar wrapper [default: False].
 If set to None, disable on non\-TTY.
@@ -131,7 +131,7 @@ it].
 .RS
 .RE
 .TP
-.B \-\-unit_scale=\f[I]unit_scale\f[]
+.B \-\-unit\-scale=\f[I]unit_scale\f[]
 bool or int or float, optional.
 If 1 or True, the number of iterations will be reduced/scaled
 automatically and a metric prefix following the International System of
@@ -140,7 +140,7 @@ If any other non\-zero number, will scale \f[C]total\f[] and \f[C]n\f[].
 .RS
 .RE
 .TP
-.B \-\-dynamic_ncols=\f[I]dynamic_ncols\f[]
+.B \-\-dynamic\-ncols
 bool, optional.
 If set, constantly alters \f[C]ncols\f[] and \f[C]nrows\f[] to the
 environment (allowing for window resizes) [default: False].
@@ -156,7 +156,7 @@ Ranges from 0 (average speed) to 1 (current/instantaneous speed)
 .RS
 .RE
 .TP
-.B \-\-bar_format=\f[I]bar_format\f[]
+.B \-\-bar\-format=\f[I]bar_format\f[]
 str, optional.
 Specify a custom bar string formatting.
 May impact performance.
@@ -196,13 +196,13 @@ Calls \f[C]set_postfix(**postfix)\f[] if possible (dict).
 .RS
 .RE
 .TP
-.B \-\-unit_divisor=\f[I]unit_divisor\f[]
+.B \-\-unit\-divisor=\f[I]unit_divisor\f[]
 float, optional.
 [default: 1000], ignored unless \f[C]unit_scale\f[] is True.
 .RS
 .RE
 .TP
-.B \-\-write_bytes=\f[I]write_bytes\f[]
+.B \-\-write\-bytes
 bool, optional.
 If (default: None) and \f[C]file\f[] is unspecified, bytes will be
 written in Python 2.
@@ -211,7 +211,7 @@ In all other cases will default to unicode.
 .RS
 .RE
 .TP
-.B \-\-lock_args=\f[I]lock_args\f[]
+.B \-\-lock\-args=\f[I]lock_args\f[]
 tuple, optional.
 Passed to \f[C]refresh\f[] for intermediate output (initialisation,
 iterating, and updating).
@@ -236,14 +236,14 @@ N.B.: on Windows systems, Python converts \[aq]\\n\[aq] to
 .RS
 .RE
 .TP
-.B \-\-buf_size=\f[I]buf_size\f[]
+.B \-\-buf\-size=\f[I]buf_size\f[]
 int, optional.
 String buffer size in bytes [default: 256] used when \f[C]delim\f[] is
 specified.
 .RS
 .RE
 .TP
-.B \-\-bytes=\f[I]bytes\f[]
+.B \-\-bytes
 bool, optional.
 If true, will count bytes, ignore \f[C]delim\f[], and default
 \f[C]unit_scale\f[] to True, \f[C]unit_divisor\f[] to 1024, and
@@ -251,10 +251,30 @@ If true, will count bytes, ignore \f[C]delim\f[], and default
 .RS
 .RE
 .TP
-.B \-\-tee=\f[I]tee\f[]
+.B \-\-tee
 bool, optional.
 If true, passes \f[C]stdin\f[] to both \f[C]stderr\f[] and
 \f[C]stdout\f[].
+.RS
+.RE
+.TP
+.B \-\-update
+bool, optional.
+If true, will treat input as newly elapsed iterations, i.e.
+numbers to pass to \f[C]update()\f[].
+.RS
+.RE
+.TP
+.B \-\-update\-to
+bool, optional.
+If true, will treat input as total elapsed iterations, i.e.
+numbers to assign to \f[C]self.n\f[].
+.RS
+.RE
+.TP
+.B \-\-null
+bool, optional.
+If true, will discard input (no stdout).
 .RS
 .RE
 .TP

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -251,6 +251,13 @@ If true, will count bytes, ignore \f[C]delim\f[], and default
 .RS
 .RE
 .TP
+.B \-\-tee=\f[I]tee\f[]
+bool, optional.
+If true, passes \f[C]stdin\f[] to both \f[C]stderr\f[] and
+\f[C]stdout\f[].
+.RS
+.RE
+.TP
 .B \-\-manpath=\f[I]manpath\f[]
 str, optional.
 Directory in which to install tqdm man pages.


### PR DESCRIPTION
- CLI: add `--tee` (#1014 <- #1013)
- CLI: add `--update` and `--update_to` (#996 <- #975)
- CLI: add `--null` (#996)
- make `update()` return `True` on `display` to ease efficient use of custom callbacks (#845)
- fix `py>=3` CLI `--delim` encoding error
- fix `py>=3.5` version detection in `tqdm.auto` (#1029 <- #1028)
- fix final ETA when using `initial` (#1021 <- #689)
- update documentation
  + add & update custom callback examples
  + improve help formatting of boolean CLI options
- add & update tests

---

- closes #1014
- fixes #1013
- closes #996
- fixes #975
- fixes #845
  + related (but actually opposite) #518
- closes #1029
- fixes #1028
- closes #1021
- fixes #689