### PR TITLE
notebook: fix description width for unknown `total`

### DIFF
--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -106,14 +106,11 @@ class tqdm_notebook(std_tqdm):
             if ncols is None:
                 pbar.layout.width = "20px"
 
+        ltext = HTML()
+        rtext = HTML()
         if desc:
-            pbar.description = desc
-            if IPYW >= 7:
-                pbar.style.description_width = 'initial'
-        # Prepare status text
-        ptext = HTML()
-        # Only way to place text to the right of the bar is to use a container
-        container = HBox(children=[pbar, ptext])
+            ltext.value = desc
+        container = HBox(children=[ltext, pbar, rtext])
         # Prepare layout
         if ncols is not None:  # use default style of ipywidgets
             # ncols could be 100, "100px", "100%"
@@ -151,7 +148,7 @@ class tqdm_notebook(std_tqdm):
         if not msg and not close:
             msg = self.__repr__()
 
-        pbar, ptext = self.container.children
+        ltext, pbar, rtext = self.container.children
         pbar.value = self.n
 
         if msg:
@@ -168,13 +165,10 @@ class tqdm_notebook(std_tqdm):
                 right = right[1:]
 
             # Update description
-            pbar.description = left
-            if IPYW >= 7:
-                pbar.style.description_width = 'initial'
-
+            ltext.value = left
             # never clear the bar (signal: msg='')
             if right:
-                ptext.value = right
+                rtext.value = right
 
         # Change bar style
         if bar_style:
@@ -273,9 +267,12 @@ class tqdm_notebook(std_tqdm):
         ----------
         total  : int or float, optional. Total to use for the new bar.
         """
+        _, pbar, _ = self.container.children
+        pbar.bar_style = ''
         if total is not None:
-            pbar, _ = self.container.children
             pbar.max = total
+            if not self.total and self.ncols is None:  # no longer unknown total
+                pbar.layout.width = None  # reset width
         return super(tqdm_notebook, self).reset(total=total)
 
 


### PR DESCRIPTION
- split bar description into separate widget (fixes #1031)
- improve `reset()`
  + reset bar width if needed
  + reset bar colour
- related #1015

Unfortunately this may break code of a handful of people parsing `tqdm.notebook.tqdm.container.children` since it's changed from `[IProgress(), HTML()]` to `[HTML(), IProgress(), HTML()]`. Technically a breaking change but don't think it affects the vast majority of users.