### PR TITLE
fix write errors when disowned

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, division
 from .utils import _supports_unicode, _screen_shape_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
     Comparable, _is_ascii, FormatReplace, disp_len, disp_trim, \
-    SimpleTextIOWrapper, CallbackIOWrapper
+    SimpleTextIOWrapper, DisableOnWriteError, CallbackIOWrapper
 from ._monitor import TMonitor
 # native libraries
 from contextlib import contextmanager
@@ -928,6 +928,8 @@ class tqdm(Comparable):
             # should have bytes written to them.
             file = SimpleTextIOWrapper(
                 file, encoding=getattr(file, 'encoding', None) or 'utf-8')
+
+        file = DisableOnWriteError(file, tqdm_instance=self)
 
         if disable is None and hasattr(file, "isatty") and not file.isatty():
             disable = True

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -334,7 +334,7 @@ def test_iter_overhead_simplebar_hard():
                 a += i
 
     assert_performance(
-        7.5, 'trange', time_tqdm(), 'simple_progress', time_bench())
+        8, 'trange', time_tqdm(), 'simple_progress', time_bench())
 
 
 @with_setup(pretest, posttest)
@@ -363,4 +363,4 @@ def test_manual_overhead_simplebar_hard():
                 simplebar_update(10)
 
     assert_performance(
-        7.5, 'tqdm', time_tqdm(), 'simple_progress', time_bench())
+        8, 'tqdm', time_tqdm(), 'simple_progress', time_bench())

--- a/tqdm/tests/tests_perf.py
+++ b/tqdm/tests/tests_perf.py
@@ -293,13 +293,13 @@ def test_manual_overhead_hard():
     total = int(1e5)
 
     with closing(MockIO()) as our_file:
-        t = tqdm(total=total * 10, file=our_file, leave=True, miniters=1,
-                 mininterval=0, maxinterval=0)
-        a = 0
-        with relative_timer() as time_tqdm:
-            for i in _range(total):
-                a += i
-                t.update(10)
+        with tqdm(total=total * 10, file=our_file, leave=True, miniters=1,
+                  mininterval=0, maxinterval=0) as t:
+            a = 0
+            with relative_timer() as time_tqdm:
+                for i in _range(total):
+                    a += i
+                    t.update(10)
 
         a = 0
         with relative_timer() as time_bench:
@@ -345,13 +345,13 @@ def test_manual_overhead_simplebar_hard():
     total = int(1e4)
 
     with closing(MockIO()) as our_file:
-        t = tqdm(total=total * 10, file=our_file, leave=True, miniters=1,
-                 mininterval=0, maxinterval=0)
-        a = 0
-        with relative_timer() as time_tqdm:
-            for i in _range(total):
-                a += i
-                t.update(10)
+        with tqdm(total=total * 10, file=our_file, leave=True, miniters=1,
+                  mininterval=0, maxinterval=0) as t:
+            a = 0
+            with relative_timer() as time_tqdm:
+                for i in _range(total):
+                    a += i
+                    t.update(10)
 
         simplebar_update = simple_progress(
             total=total * 10, file=our_file, leave=True, miniters=1,

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -221,7 +221,6 @@ class DisableOnWriteError(ObjectWrapper):
         """
         Quietly set `tqdm_instance.disable=True` if `func` raises `exc`.
         """
-        @wraps(func)
         def inner(*args, **kwargs):
             try:
                 return func(*args, **kwargs)


### PR DESCRIPTION
- fix exceptions when `file` is closed (fixes #1033)

This mirrors the behaviour of `logging.warning()`, which doesn't crash the process when disowned/`stderr` is closed.