### PR TITLE
Hacktoberfest: Publish release on PyPI

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -48,3 +48,23 @@ jobs:
         git checkout -
         make deploy
         popd
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: build and publish
+      env:
+        TWINE_REPOSITORY: pypi
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
I think you upload the releases to PyPI manually, but it's inconvenient. Especially since you already have a workflow to publish documentation after the release.

I added you a release publication from the github action. To make it work, you just need to set `PYPI_USERNAME ` and `PYPI_PASSWORD ` in the repository secrets :).