### PR TITLE
Multiple bars display fix

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1303,8 +1303,8 @@ class tqdm(Comparable):
             if leave:
                 # stats for overall rate (no weighted average)
                 self._ema_dt = lambda: None
-                self.display(pos=0)
-                fp_write('\n')
+                self.display()
+                fp_write('\r')
             else:
                 # clear previous display
                 if self.display(msg='', pos=pos) and not pos:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -574,6 +574,19 @@ class tqdm(Comparable):
                          " (monitor_interval = 0) due to:\n" + str(e),
                          TqdmMonitorWarning, stacklevel=2)
                     cls.monitor_interval = 0
+
+            # Create simultaneous bars counters field
+            if not hasattr(cls, '_simultaneous_bars_counters'):
+                # To make multiple bars display correctly but also let
+                # user program safely print something after all the
+                # `tqdm` bars are closed, we only print terminate
+                # lines after the very last bar occupying the file
+                # closes.
+                # The following dictionary's keys are files, values
+                # are numbers of bars in the corresponding file we
+                # want to skip with `'\n'`s when the last bar closes
+                cls._simultaneous_bars_counters = {}
+
         return instance
 
     @classmethod
@@ -593,25 +606,26 @@ class tqdm(Comparable):
         order is not maintained but screen flicker/blank space is minimised.
         (tqdm<=4.44.1 moved ALL subsequent unfixed bars up.)
         """
-        with cls._lock:
-            try:
-                cls._instances.remove(instance)
-            except KeyError:
-                # if not instance.gui:  # pragma: no cover
-                #     raise
-                pass  # py2: maybe magically removed already
-            # else:
-            if not instance.gui:
-                last = (instance.nrows or 20) - 1
-                # find unfixed (`pos >= 0`) overflow (`pos >= nrows - 1`)
-                instances = list(filter(
-                    lambda i: hasattr(i, "pos") and last <= i.pos,
-                    cls._instances))
-                # set first found to current `pos`
-                if instances:
-                    inst = min(instances, key=lambda i: i.pos)
-                    inst.clear(nolock=True)
-                    inst.pos = abs(instance.pos)
+        # The lock is acquired by the caller of the method
+
+        try:
+            cls._instances.remove(instance)
+        except KeyError:
+            # if not instance.gui:  # pragma: no cover
+            #     raise
+            pass  # py2: maybe magically removed already
+        # else:
+        if not instance.gui:
+            last = (instance.nrows or 20) - 1
+            # find unfixed (`pos >= 0`) overflow (`pos >= nrows - 1`)
+            instances = list(filter(
+                lambda i: hasattr(i, "pos") and last <= i.pos,
+                cls._instances))
+            # set first found to current `pos`
+            if instances:
+                inst = min(instances, key=lambda i: i.pos)
+                inst.clear(nolock=True)
+                inst.pos = abs(instance.pos)
 
     @classmethod
     def write(cls, s, file=None, end="\n", nolock=False):
@@ -875,8 +889,8 @@ class tqdm(Comparable):
             If `None`, will leave only if `position` is `0`.
         file  : `io.TextIOWrapper` or `io.StringIO`, optional
             Specifies where to output the progress messages
-            (default: sys.stderr). Uses `file.write(str)` and `file.flush()`
-            methods.  For encoding, see `write_bytes`.
+            (default: sys.stderr). Uses `file.write(str)`, `file.flush()`
+            and `hash(file)`. For encoding, see `write_bytes`.
         ncols  : int, optional
             The width of the entire output message. If specified,
             dynamically resizes the progressbar to stay within this bound.
@@ -1107,6 +1121,12 @@ class tqdm(Comparable):
             else:  # mark fixed positions as negative
                 self.pos = -position
 
+        if leave and not disable:
+            with self._lock:
+                self._simultaneous_bars_counters[file] = \
+                    max(abs(self.pos) + 1,
+                        self._simultaneous_bars_counters.get(file, 0))
+
         if not gui:
             # Initialize the screen printer
             self.sp = self.status_printer(self.fp)
@@ -1274,9 +1294,7 @@ class tqdm(Comparable):
         # Prevent multiple closures
         self.disable = True
 
-        # decrement instance pos and remove from internal set
         pos = abs(self.pos)
-        self._decr_instances(self)
 
         if self.last_print_t < self.start_t + self.delay:
             # haven't ever displayed; nothing to clear
@@ -1300,6 +1318,9 @@ class tqdm(Comparable):
         leave = pos == 0 if self.leave is None else self.leave
 
         with self._lock:
+            # decrement instance pos and remove from internal set
+            self._decr_instances(self)
+
             if leave:
                 # stats for overall rate (no weighted average)
                 self._ema_dt = lambda: None
@@ -1307,8 +1328,24 @@ class tqdm(Comparable):
                 fp_write('\r')
             else:
                 # clear previous display
-                if self.display(msg='', pos=pos) and not pos:
+                if self.display(msg='', pos=pos):
                     fp_write('\r')
+
+            # No matter if current bar's traces should be left or not,
+            # if it's the last bar, it should print write terminators
+            if self.fp in self._simultaneous_bars_counters.keys():
+                for instance in self._instances:
+                    # If this is not the last bar, do nothing
+                    if instance.fp == self.fp:
+                        break
+                else:
+                    # Terminate lines to make further writes to the file
+                    # possible
+                    fp_write('\n' *
+                             self._simultaneous_bars_counters[self.fp])
+                    # Reset counter for current file (because the
+                    # previous bars are skipped already)
+                    del self._simultaneous_bars_counters[self.fp]
 
     def clear(self, nolock=False):
         """Clear current bar display."""

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -865,8 +865,8 @@ class tqdm(Comparable):
                  ascii=None, disable=False, unit='it', unit_scale=False,
                  dynamic_ncols=False, smoothing=0.3, bar_format=None, initial=0,
                  position=None, postfix=None, unit_divisor=1000, write_bytes=None,
-                 lock_args=None, nrows=None, colour=None, delay=0, gui=False,
-                 **kwargs):
+                 lock_args=None, nrows=None, colour=None, delay=0,
+                 terminate_lines=True, gui=False, **kwargs):
         """
         Parameters
         ----------
@@ -975,6 +975,17 @@ class tqdm(Comparable):
             Bar colour (e.g. 'green', '#00ff00').
         delay  : float, optional
             Don't display until [default: 0] seconds have elapsed.
+        terminate_lines  : bool, optional
+            Whether to print empty lines after the bars when all of them
+            are finished.
+
+            At the moment when the current bar gets finished: if there
+            are other bars left, the value is ignored; otherwise:
+            if [default: True], there'll be empty lines printed such
+            that the cursor is put below all the left bars, so that
+            you can print something below, if `False`, the cursor is
+            put back where it was before the group of bars has started,
+            so that you can overwrite them.
         gui  : bool, optional
             WARNING: internal parameter - do not use.
             Use tqdm.gui.tqdm(...) instead. If set, will attempt to use
@@ -1102,6 +1113,7 @@ class tqdm(Comparable):
         self.bar_format = bar_format
         self.postfix = None
         self.colour = colour
+        self.terminate_lines = terminate_lines
         self._time = time
         if postfix:
             try:
@@ -1339,13 +1351,14 @@ class tqdm(Comparable):
                     if instance.fp == self.fp:
                         break
                 else:
-                    # Terminate lines to make further writes to the file
-                    # possible
-                    fp_write('\n' *
-                             self._simultaneous_bars_counters[self.fp])
-                    # Reset counter for current file (because the
-                    # previous bars are skipped already)
-                    del self._simultaneous_bars_counters[self.fp]
+                    if self.terminate_lines:
+                        # Terminate lines to make further writes to the
+                        # file possible
+                        fp_write('\n' *
+                                 self._simultaneous_bars_counters[self.fp])
+                        # Reset counter for current file (because the
+                        # previous bars are skipped already)
+                        del self._simultaneous_bars_counters[self.fp]
 
     def clear(self, nolock=False):
         """Clear current bar display."""

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -171,6 +171,9 @@ class DisableOnWriteError(ObjectWrapper):
     def __eq__(self, other):
         return self._wrapped == getattr(other, '_wrapped', other)
 
+    def __hash__(self):
+        return hash(self._wrapped)
+
 
 class CallbackIOWrapper(ObjectWrapper):
     def __init__(self, callback, stream, method="read"):


### PR DESCRIPTION
# About
Fixes several issues with bars positioning when using multiple bars. Resolves #1000 and probably some other similar issues.

# Other solutions
I know there already exists a PR fixing the problem (#1001), but I don't like it for a few reasons, including:
-  it simply doesn't work for me (however, I didn't do my best to make it. I'll probably try it later and tell about my results on its page)
-  it introduces negative positions, which I don't find intuitive, and (if I'm not mistaken) requires the library users to change their code to make it work correctly

# Changed and unchanged behaviour
Here there are samples I was running to compare the modified `tqdm` with the original one. All the samples were run on Python with `sys.platform == 'linux'`, `sys.version == '3.8.5 (default, Jul 28 2020, 12:59:40) \n[GCC 9.3.0]'`. The "before" screenshots are run on `tqdm` installed from `master`, the "after" screenshots are run on `tqdm` installed from the current branch (`bars_position_fix`).
<details>
<summary>Trivial</summary>

(Just to verify I haven't broken the very basics)
```Python3
from time import sleep

from tqdm import trange


for _ in trange(10):
    sleep(0.1)

for _ in trange(10, leave=False):
    sleep(0.1)
```
## Before
![2020-10-21 22-10-45](https://user-images.githubusercontent.com/23319866/96771890-fe05cc80-13ea-11eb-9c05-ac6ec38f97f3.gif)
## After
![2020-10-21 22-22-17](https://user-images.githubusercontent.com/23319866/96773158-ce57c400-13ec-11eb-90f3-e3a647dd8c4c.gif)
</details>
<details>
<summary>Nested loops</summary>

```python3
from time import sleep

from tqdm import trange


for _ in trange(10):
    for _ in trange(10):
        sleep(0.1)
```
## Before
![2020-10-21 22-11-29](https://user-images.githubusercontent.com/23319866/96771895-ff36f980-13ea-11eb-8a28-eec095630d57.gif)
## After
![2020-10-21 22-22-44](https://user-images.githubusercontent.com/23319866/96773162-cef05a80-13ec-11eb-975b-bdcbcd5bb39f.gif)
</details>
<details>
<summary>Multithreaded with `position`</summary>

Please, pay attention to the order of the bars (numbers in the beginnings of the lines): in the version before the PR bars change their order. Sometimes (when using enough many bars or running them long enough) a similar sample can also produce empty lines or duplicate bars (if you want, I can try to dig into it and provide such a sample)
```python3
from time import sleep
from threading import Thread

from tqdm import trange


def progresser(n):
    interval = 0.001 / (n + 2)
    total = 1000
    text = "#{}, est. {:<04.2}s".format(n, interval * total)
    for _ in trange(total, desc=text, position=n):
        sleep(interval)


if __name__ == '__main__':
    list(map(lambda x: Thread(target=progresser, args=(x,)).start(), range(9)))
```
## Before
![2020-10-21 22-12-25](https://user-images.githubusercontent.com/23319866/96771899-00682680-13eb-11eb-8908-78e293117301.gif)
## After
![2020-10-21 22-23-16](https://user-images.githubusercontent.com/23319866/96773166-cf88f100-13ec-11eb-9114-2fbb8d9eec24.gif)
</details>
<details>
<summary>One-threaded with `position` and `leave=False`</summary>

```python3
from time import sleep

from tqdm import trange


def progresser(n):
    interval = 0.001 / (n + 2)
    total = 1000
    text = "#{}, est. {:<04.2}s".format(n, interval * total)
    for _ in trange(total, desc=text, position=n, leave=False):
        sleep(interval)


if __name__ == '__main__':
    list(map(progresser, range(9)))
```
## Before
![2020-10-21 22-13-06](https://user-images.githubusercontent.com/23319866/96771900-0100bd00-13eb-11eb-8933-7f93022a6afa.gif)
## After
![2020-10-21 22-23-35](https://user-images.githubusercontent.com/23319866/96773167-d0218780-13ec-11eb-8e1d-dba7e536f1a6.gif)
</details>
<details>
<summary>One-threaded with `position`</summary>

This is the only case (I can think of) where you have to change code to make it produce a perfect output (if not changing it, the produced output is still better, than the output before the PR, as for me). However, I don't think this is a serious issue, because I think, this case is extremely special: there is no need to use bars with `position` if the application is one-threaded. In theory, there is one more situation where this case may come (when you use a multi-threaded application, but for some reason, a subset of the bars you want to use both starts and closes before other bars are created).

```python3
from time import sleep

from tqdm import trange


def progresser(n):
    interval = 0.001 / (n + 2)
    total = 1000
    text = "#{}, est. {:<04.2}s".format(n, interval * total)
    for _ in trange(total, desc=text, position=n):
        sleep(interval)


if __name__ == '__main__':
    list(map(progresser, range(9)))
```
## Before
![2020-10-21 22-13-34](https://user-images.githubusercontent.com/23319866/96771901-01995380-13eb-11eb-83f3-088046fe0d98.gif)
## After
![2020-10-21 22-24-39](https://user-images.githubusercontent.com/23319866/96773169-d0218780-13ec-11eb-8d24-e143d0498fdc.gif)

Updated sample:
```python3
from time import sleep

from tqdm import trange


def progresser(n):
    interval = 0.001 / (n + 2)
    total = 1000
    text = "#{}, est. {:<04.2}s".format(n, interval * total)
    for _ in trange(total, desc=text, position=n, terminate_lines=False):
        sleep(interval)


if __name__ == '__main__':
    list(map(progresser, range(9)))
    print('\n' * 9, end='')
```
## After edit
![2020-10-21 22-27-51](https://user-images.githubusercontent.com/23319866/96773174-d0ba1e00-13ec-11eb-919f-ae7c2d98d9d9.gif)
</details>

# Tests
I have very little experience with tests (both in python and generally). My PR has obviously changed `tqdm` outputs in some cases, so I think some tests will fail and I'll need help from maintainers (@casperdcl?) to understand, where I should change something back and where tests should be updated instead