### PR TITLE
Estimated completion date/time in `bar_format`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -433,7 +433,7 @@ Parameters
     percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
     rate, rate_fmt, rate_noinv, rate_noinv_fmt,
     rate_inv, rate_inv_fmt, postfix, unit_divisor,
-    remaining, remaining_s.
+    remaining, remaining_s, eta.
     Note that a trailing ": " is automatically removed after {desc}
     if the latter is empty.
 * initial  : int or float, optional  

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1168,6 +1168,15 @@ def test_custom_format():
         assert "00:00 in total" in our_file.getvalue()
 
 
+def test_eta(capsys):
+    """Test eta bar_format"""
+    from datetime import datetime as dt
+    for _ in trange(2, leave=True, bar_format='{l_bar}{eta:%Y-%m-%d}'):
+        pass
+    _, err = capsys.readouterr()
+    assert "\r100%|{eta:%Y-%m-%d}\n".format(eta=dt.now()) in err
+
+
 def test_unpause():
     """Test unpause"""
     timer = DiscreteTimer()

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -454,7 +454,7 @@ class tqdm(Comparable):
         remaining = (total - n) / rate if rate and total else 0
         remaining_str = tqdm.format_interval(remaining) if rate else '?'
         if bar_format and 'eta_dt' in bar_format:
-            if remaining:
+            if remaining or total == n:
                 eta_dt = datetime.datetime.now() + \
                     datetime.timedelta(seconds=remaining)
             else:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -8,6 +8,8 @@ Usage:
 ...     ...
 """
 from __future__ import absolute_import, division
+import datetime
+
 # compatibility functions and utilities
 from .utils import _supports_unicode, _screen_shape_wrapper, _range, _unich, \
     _term_move_up, _unicode, WeakSet, _basestring, _OrderedDict, \
@@ -386,7 +388,7 @@ class tqdm(Comparable):
               percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
               rate, rate_fmt, rate_noinv, rate_noinv_fmt,
               rate_inv, rate_inv_fmt, postfix, unit_divisor,
-              remaining, remaining_s.
+              remaining, remaining_s, eta_dt.
             Note that a trailing ": " is automatically removed after {desc}
             if the latter is empty.
         postfix  : *, optional
@@ -451,6 +453,14 @@ class tqdm(Comparable):
 
         remaining = (total - n) / rate if rate and total else 0
         remaining_str = tqdm.format_interval(remaining) if rate else '?'
+        if bar_format and 'eta_dt' in bar_format:
+            if remaining:
+                eta_dt = datetime.datetime.now() + \
+                    datetime.timedelta(seconds=remaining)
+            else:
+                eta_dt = datetime.datetime.utcfromtimestamp(0)
+        else:
+            eta_dt = None
 
         # format the stats displayed to the left and right sides of the bar
         if prefix:
@@ -478,7 +488,7 @@ class tqdm(Comparable):
             colour=colour,
             # plus more useful definitions
             remaining=remaining_str, remaining_s=remaining,
-            l_bar=l_bar, r_bar=r_bar,
+            l_bar=l_bar, r_bar=r_bar, eta_dt=eta_dt,
             **extra_kwargs)
 
         # total is known: we can predict some stats
@@ -908,7 +918,7 @@ class tqdm(Comparable):
               percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
               rate, rate_fmt, rate_noinv, rate_noinv_fmt,
               rate_inv, rate_inv_fmt, postfix, unit_divisor,
-              remaining, remaining_s.
+              remaining, remaining_s, eta_dt.
             Note that a trailing ": " is automatically removed after {desc}
             if the latter is empty.
         initial  : int or float, optional

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -166,7 +166,7 @@ May impact performance.
 vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt, percentage,
 elapsed, elapsed_s, ncols, nrows, desc, unit, rate, rate_fmt,
 rate_noinv, rate_noinv_fmt, rate_inv, rate_inv_fmt, postfix,
-unit_divisor, remaining, remaining_s.
+unit_divisor, remaining, remaining_s, eta.
 Note that a trailing ": " is automatically removed after {desc} if the
 latter is empty.
 .RS


### PR DESCRIPTION
Closes #1051

Adds the possibility to display ETA date and time. Sample of basic usage of the feature:
```python3
from time import sleep
from random import randint

from tqdm import trange


for i in trange(20, bar_format='{l_bar}{bar}{r_bar} ({eta_dt})'):
    sleep(randint(1, 5) / 10)
```
<details>
<summary>How this looks</summary>

![2020-10-22 13-16-31](https://user-images.githubusercontent.com/23319866/96858547-11577d00-1469-11eb-8668-e581f81cfb2c.gif)

</details>

You can also customize the date format with the directives from the `datetime` build-in library (see [the official documentation](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior)):
```python3
from time import sleep
from random import randint

from tqdm import trange


for i in trange(20, bar_format='{l_bar}{bar}{r_bar} ({eta_dt:%Y.%m.%d, %H:%M})'):
    sleep(randint(1, 5) / 10)
```
<details>
<summary>How this looks</summary>

![2020-10-22 13-20-48](https://user-images.githubusercontent.com/23319866/96858910-8925a780-1469-11eb-8553-69879c6cce0c.gif)
</details>

## Notes
- Works for Python 2 just in the same way (in the samples above you should wrap `randint` in `float`, but no changes to `tqdm` calls are needed)
- When it's impossible to calculate ETA (i. e. first iteration or no `total` and length of an iterable is unavailable), `eta_dt` defaults to the epoch beginning datetime (to not break formatting directives usage)