### PR TITLE
Flush after writing (fixes #958)

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -613,6 +613,7 @@ class tqdm(Comparable):
             # Write the message
             fp.write(s)
             fp.write(end)
+            fp.flush()
 
     @classmethod
     @contextmanager


### PR DESCRIPTION
On Windows 10 using the MINGW mintty terminal emulator, the output of `tqdm.write()` does not appear during the loop, but all at once after the loop has finished.

Flushing the stream after writing to it fixes this issue.