### PR TITLE
next release v4.51.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 branch = True
+include = tqdm/*
 omit =
-    tqdm/tests/*
     tqdm/contrib/bells.py
     tqdm/contrib/discord.py
     tqdm/contrib/telegram.py

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@ demo.yml @casperdcl @martinzugnoni
 codecov.yml @lrq3000
 setup.py @casperdcl @lrq3000
 tqdm/_tqdm_notebook.py @lrq3000 @casperdcl
-tqdm/tests/tests_pandas.py @casperdcl @chengs
+tests/tests_pandas.py @casperdcl @chengs

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,9 @@ tqdm_*_amd64.snap
 # Unit test / coverage reports
 .tox/
 .coverage
-__pycache__
-nosetests.xml
+.coverage.*
+__pycache__/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
   - name: pypy2.7
     python: pypy2.7-7.3.1
     env: TOXENV=pypy
-  - name: pypy3.5
+  - name: pypy3.6
     python: pypy3.6-7.3.1
     env: TOXENV=pypy3
   - stage: development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,11 +100,11 @@ you can use `MiniConda` to install a minimal setup. You must also make sure
 that each distribution has an alias to call the Python interpreter:
 `python27` for Python 2.7's interpreter, `python32` for Python 3.2's, etc.
 
-### Alternative unit tests with Nose
+### Alternative unit tests with pytest
 
-Alternatively, use `nose` to run the tests just for the current Python version:
+Alternatively, use `pytest` to run the tests just for the current Python version:
 
-- install `nose` and `flake8`
+- install `pytest` and `flake8`
 - run the following command:
 
 ```

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,7 +11,7 @@ include tox.ini
 recursive-include tqdm/contrib *.py
 
 # Test suite
-recursive-include tqdm/tests *.py
+recursive-include tests *.py
 include requirements-dev.txt
 
 # Examples/Documentation

--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,9 @@ distclean:
 	@+make clean
 pre-commit:
 	# quick sanity checks
-	@make testsetup
+	@make --no-print-directory testsetup
 	flake8 -j 8 --count --statistics tqdm/ tests/ examples/
-	pytest -q -k "basic_overhead or not (perf or keras or pandas or monitoring)"
+	pytest -qq -k "basic_overhead or not (perf or keras or pandas or monitoring)"
 prebuildclean:
 	@+python -c "import shutil; shutil.rmtree('build', True)"
 	@+python -c "import shutil; shutil.rmtree('dist', True)"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 	all
 	flake8
 	test
-	testnose
+	pytest
 	testsetup
 	testcoverage
 	testperf
@@ -50,8 +50,8 @@ test:
 	TOX_SKIP_ENV=perf tox --skip-missing-interpreters -p all
 	tox -e perf
 
-testnose:
-	nosetests -d -v tqdm
+pytest:
+	pytest
 
 testsetup:
 	@make README.rst
@@ -62,14 +62,14 @@ testsetup:
 
 testcoverage:
 	@make coverclean
-	nosetests -d -v tqdm --ignore-files="tests_perf\.py" --with-coverage --cover-package=tqdm --cover-erase --cover-min-percentage=80
+	pytest -k "not tests_perf" --cov=tqdm --cov-fail-under=80
 
 testperf:
 	# do not use coverage (which is extremely slow)
-	nosetests -d -v tqdm/tests/tests_perf.py
+	pytest -k tests_perf
 
 testtimer:
-	nosetests -d -v tqdm --with-timer
+	pytest --durations=10
 
 # another performance test, to check evolution across commits
 testasv:
@@ -120,23 +120,24 @@ distclean:
 pre-commit:
 	# quick sanity checks
 	@make testsetup
-	flake8 -j 8 --count --statistics tqdm/ examples/
-	nosetests -d tqdm --ignore-files="tests_(perf|keras)\.py" -e "pandas|monitoring"
-	nosetests -d tqdm/tests/tests_perf.py -m basic_overhead
+	flake8 -j 8 --count --statistics tqdm/ tests/ examples/
+	pytest -q -k "basic_overhead or not (perf or keras or pandas or monitoring)"
 prebuildclean:
 	@+python -c "import shutil; shutil.rmtree('build', True)"
 	@+python -c "import shutil; shutil.rmtree('dist', True)"
 	@+python -c "import shutil; shutil.rmtree('tqdm.egg-info', True)"
 coverclean:
 	@+python -c "import os; os.remove('.coverage') if os.path.exists('.coverage') else None"
+	@+python -c "import os, glob; [os.remove(i) for i in glob.glob('.coverage.*')]"
+	@+python -c "import shutil; shutil.rmtree('tests/__pycache__', True)"
 	@+python -c "import shutil; shutil.rmtree('tqdm/__pycache__', True)"
 	@+python -c "import shutil; shutil.rmtree('tqdm/contrib/__pycache__', True)"
-	@+python -c "import shutil; shutil.rmtree('tqdm/tests/__pycache__', True)"
+	@+python -c "import shutil; shutil.rmtree('tqdm/examples/__pycache__', True)"
 clean:
 	@+python -c "import os, glob; [os.remove(i) for i in glob.glob('*.py[co]')]"
+	@+python -c "import os, glob; [os.remove(i) for i in glob.glob('tests/*.py[co]')]"
 	@+python -c "import os, glob; [os.remove(i) for i in glob.glob('tqdm/*.py[co]')]"
 	@+python -c "import os, glob; [os.remove(i) for i in glob.glob('tqdm/contrib/*.py[co]')]"
-	@+python -c "import os, glob; [os.remove(i) for i in glob.glob('tqdm/tests/*.py[co]')]"
 	@+python -c "import os, glob; [os.remove(i) for i in glob.glob('tqdm/examples/*.py[co]')]"
 toxclean:
 	@+python -c "import shutil; shutil.rmtree('.tox', True)"

--- a/README.rst
+++ b/README.rst
@@ -433,7 +433,7 @@ Parameters
     percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
     rate, rate_fmt, rate_noinv, rate_noinv_fmt,
     rate_inv, rate_inv_fmt, postfix, unit_divisor,
-    remaining, remaining_s.
+    remaining, remaining_s, eta.
     Note that a trailing ": " is automatically removed after {desc}
     if the latter is empty.
 * initial  : int or float, optional  

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,9 @@ universal = 1
 ignore = W503,W504,E722
 max_line_length = 80
 exclude = .asv,.tox,.ipynb_checkpoints,build,dist,.git,__pycache__
+
+[tool:pytest]
+python_files = tests_*.py
+testpaths = tests
+addopts = -v --tb=short
+usefixtures = pretest_posttest

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,6 @@ setup(
     ],
     keywords='progressbar progressmeter progress bar meter'
              ' rate eta console terminal time',
-    test_suite='nose.collector',
-    tests_require=['nose', 'flake8', 'coverage'],
+    test_suite='pytest',
+    tests_require=['pytest', 'flake8', 'coverage'],
 )

--- a/tests/py37_asyncio.py
+++ b/tests/py37_asyncio.py
@@ -1,9 +1,10 @@
-import asyncio
 from functools import partial, wraps
 from time import time
+import asyncio
 
-from tests_tqdm import with_setup, pretest, posttest, StringIO, closing
 from tqdm.asyncio import tqdm_asyncio, tarange
+from .tests_tqdm import pretest_posttest  # NOQA, pylint: disable=unused-import
+from .tests_tqdm import StringIO, closing
 
 tqdm = partial(tqdm_asyncio, miniters=0, mininterval=0)
 trange = partial(tarange, miniters=0, mininterval=0)
@@ -11,7 +12,6 @@ as_completed = partial(tqdm_asyncio.as_completed, miniters=0, mininterval=0)
 
 
 def with_setup_sync(func):
-    @with_setup(pretest, posttest)
     @wraps(func)
     def inner():
         return asyncio.run(func())

--- a/tests/tests_asyncio.py
+++ b/tests/tests_asyncio.py
@@ -1,0 +1,11 @@
+"""Tests `tqdm.asyncio` on `python>=3.7`."""
+import sys
+
+if sys.version_info[:2] > (3, 6):
+    from .py37_asyncio import *  # NOQA, pylint: disable=wildcard-import
+else:
+    import pytest
+    try:
+        pytest.skip("async not supported", allow_module_level=True)
+    except TypeError:
+        pass

--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -2,9 +2,10 @@
 Tests for `tqdm.contrib.concurrent`.
 """
 from warnings import catch_warnings
+
 from tqdm.contrib.concurrent import thread_map, process_map
-from tests_tqdm import with_setup, pretest, posttest, SkipTest, StringIO, \
-    closing
+from .tests_tqdm import pretest_posttest  # NOQA, pylint: disable=unused-import
+from .tests_tqdm import importorskip, skip, StringIO, closing
 
 
 def incr(x):
@@ -12,7 +13,6 @@ def incr(x):
     return x + 1
 
 
-@with_setup(pretest, posttest)
 def test_thread_map():
     """Test contrib.concurrent.thread_map"""
     with closing(StringIO()) as our_file:
@@ -20,12 +20,11 @@ def test_thread_map():
         b = [i + 1 for i in a]
         try:
             assert thread_map(lambda x: x + 1, a, file=our_file) == b
-        except ImportError:
-            raise SkipTest
+        except ImportError as err:
+            skip(str(err))
         assert thread_map(incr, a, file=our_file) == b
 
 
-@with_setup(pretest, posttest)
 def test_process_map():
     """Test contrib.concurrent.process_map"""
     with closing(StringIO()) as our_file:
@@ -33,16 +32,13 @@ def test_process_map():
         b = [i + 1 for i in a]
         try:
             assert process_map(incr, a, file=our_file) == b
-        except ImportError:
-            raise SkipTest
+        except ImportError as err:
+            skip(str(err))
 
 
 def test_chunksize_warning():
     """Test contrib.concurrent.process_map chunksize warnings"""
-    try:
-        from unittest.mock import patch
-    except ImportError:
-        raise SkipTest
+    patch = importorskip("unittest.mock").patch
 
     for iterables, should_warn in [
         ([], False),

--- a/tests/tests_contrib.py
+++ b/tests/tests_contrib.py
@@ -2,9 +2,10 @@
 Tests for `tqdm.contrib`.
 """
 import sys
+
 from tqdm.contrib import tenumerate, tzip, tmap
-from tests_tqdm import with_setup, pretest, posttest, SkipTest, StringIO, \
-    closing
+from .tests_tqdm import pretest_posttest  # NOQA, pylint: disable=unused-import
+from .tests_tqdm import importorskip, StringIO, closing
 
 
 def incr(x):
@@ -12,7 +13,6 @@ def incr(x):
     return x + 1
 
 
-@with_setup(pretest, posttest)
 def test_enumerate():
     """Test contrib.tenumerate"""
     with closing(StringIO()) as our_file:
@@ -27,19 +27,14 @@ def test_enumerate():
         assert "100%" in our_file.getvalue()
 
 
-@with_setup(pretest, posttest)
 def test_enumerate_numpy():
     """Test contrib.tenumerate(numpy.ndarray)"""
-    try:
-        import numpy as np
-    except ImportError:
-        raise SkipTest
+    np = importorskip("numpy")
     with closing(StringIO()) as our_file:
         a = np.random.random((42, 1337))
         assert list(tenumerate(a, file=our_file)) == list(np.ndenumerate(a))
 
 
-@with_setup(pretest, posttest)
 def test_zip():
     """Test contrib.tzip"""
     with closing(StringIO()) as our_file:
@@ -53,7 +48,6 @@ def test_zip():
             assert list(gen) == list(zip(a, b))
 
 
-@with_setup(pretest, posttest)
 def test_map():
     """Test contrib.tmap"""
     with closing(StringIO()) as our_file:

--- a/tests/tests_itertools.py
+++ b/tests/tests_itertools.py
@@ -1,9 +1,11 @@
 """
 Tests for `tqdm.contrib.itertools`.
 """
-from tqdm.contrib.itertools import product
-from tests_tqdm import with_setup, pretest, posttest, StringIO, closing
 import itertools
+
+from tqdm.contrib.itertools import product
+from .tests_tqdm import pretest_posttest  # NOQA, pylint: disable=unused-import
+from .tests_tqdm import StringIO, closing
 
 
 class NoLenIter(object):
@@ -15,7 +17,6 @@ class NoLenIter(object):
             yield i
 
 
-@with_setup(pretest, posttest)
 def test_product():
     """Test contrib.itertools.product"""
     with closing(StringIO()) as our_file:

--- a/tests/tests_keras.py
+++ b/tests/tests_keras.py
@@ -1,21 +1,18 @@
 from __future__ import division
+
 from tqdm import tqdm
-from tests_tqdm import with_setup, pretest, posttest, SkipTest, StringIO, \
-    closing
+from .tests_tqdm import pretest_posttest  # NOQA, pylint: disable=unused-import
+from .tests_tqdm import importorskip, StringIO, closing
 
 
-@with_setup(pretest, posttest)
 def test_keras():
     """Test tqdm.keras.TqdmCallback"""
+    TqdmCallback = importorskip("tqdm.keras").TqdmCallback
+    np = importorskip("numpy")
     try:
-        from tqdm.keras import TqdmCallback
-        import numpy as np
-        try:
-            import keras as K
-        except ImportError:
-            from tensorflow import keras as K
+        import keras as K
     except ImportError:
-        raise SkipTest
+        K = importorskip("tensorflow.keras")
 
     # 1D autoencoder
     dtype = np.float32

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -1,14 +1,15 @@
-import sys
-import subprocess
+"""Test CLI usage."""
+from io import open as io_open
 from os import path
 from shutil import rmtree
 from tempfile import mkdtemp
+import sys
+import subprocess
+
 from tqdm.cli import main, TqdmKeyError, TqdmTypeError
 from tqdm.utils import IS_WIN
-from io import open as io_open
-
-from tests_tqdm import with_setup, pretest, posttest, _range, closing, \
-    UnicodeIO, StringIO, SkipTest
+from .tests_tqdm import pretest_posttest  # NOQA, pylint: disable=unused-import
+from .tests_tqdm import skip, _range, closing, UnicodeIO, StringIO, BytesIO
 
 
 def _sh(*cmd, **kwargs):
@@ -27,7 +28,6 @@ class Null(object):
 NULL = Null()
 
 
-@with_setup(pretest, posttest)
 def test_pipes():
     """Test command line pipes"""
     ls_out = _sh('ls').replace('\r\n', '\n')
@@ -43,22 +43,22 @@ def test_pipes():
 
 
 # WARNING: this should be the last test as it messes with sys.stdin, argv
-@with_setup(pretest, posttest)
 def test_main():
     """Test misc CLI options"""
     _SYS = sys.stdin, sys.argv
+    _STDOUT = sys.stdout
     N = 123
 
     # test direct import
-    sys.stdin = map(str, _range(N))
+    sys.stdin = [str(i).encode() for i in _range(N)]
     sys.argv = ['', '--desc', 'Test CLI import',
                 '--ascii', 'True', '--unit_scale', 'True']
     import tqdm.__main__  # NOQA
     sys.stderr.write("Test misc CLI options ... ")
 
     # test --delim
-    IN_DATA = '\0'.join(map(str, _range(N)))
-    with closing(StringIO()) as sys.stdin:
+    IN_DATA = '\0'.join(map(str, _range(N))).encode()
+    with closing(BytesIO()) as sys.stdin:
         sys.argv = ['', '--desc', 'Test CLI delim',
                     '--ascii', 'True', '--delim', r'\0', '--buf_size', '64']
         sys.stdin.write(IN_DATA)
@@ -69,8 +69,8 @@ def test_main():
             assert str(N) + "it" in fp.getvalue()
 
     # test --bytes
-    IN_DATA = IN_DATA.replace('\0', '\n')
-    with closing(StringIO()) as sys.stdin:
+    IN_DATA = IN_DATA.replace(b'\0', b'\n')
+    with closing(BytesIO()) as sys.stdin:
         sys.stdin.write(IN_DATA)
         sys.stdin.seek(0)
         sys.argv = ['', '--ascii', '--bytes=True', '--unit_scale', 'False']
@@ -79,30 +79,32 @@ def test_main():
             assert str(len(IN_DATA)) in fp.getvalue()
 
     # test --log
-    sys.stdin = map(str, _range(N))
+    sys.stdin = [str(i).encode() for i in _range(N)]
     # with closing(UnicodeIO()) as fp:
     main(argv=['--log', 'DEBUG'], fp=NULL)
     # assert "DEBUG:" in sys.stdout.getvalue()
 
-    # test --tee
-    with closing(StringIO()) as sys.stdin:
-        sys.stdin.write(IN_DATA)
-
-        sys.stdin.seek(0)
-        with closing(UnicodeIO()) as fp:
-            main(argv=['--mininterval', '0', '--miniters', '1'], fp=fp)
-            res = len(fp.getvalue())
-            # assert len(fp.getvalue()) < len(sys.stdout.getvalue())
-
-        sys.stdin.seek(0)
-        with closing(UnicodeIO()) as fp:
-            main(argv=['--tee', '--mininterval', '0', '--miniters', '1'], fp=fp)
-            # spaces to clear intermediate lines could increase length
-            assert len(fp.getvalue()) >= res + len(IN_DATA)
-
-    # test --null
-    _STDOUT = sys.stdout
     try:
+        # test --tee
+        IN_DATA = IN_DATA.decode()
+        with closing(StringIO()) as sys.stdout:
+            with closing(StringIO()) as sys.stdin:
+                sys.stdin.write(IN_DATA)
+
+                sys.stdin.seek(0)
+                with closing(UnicodeIO()) as fp:
+                    main(argv=['--mininterval', '0', '--miniters', '1'], fp=fp)
+                    res = len(fp.getvalue())
+                    # assert len(fp.getvalue()) < len(sys.stdout.getvalue())
+
+                sys.stdin.seek(0)
+                with closing(UnicodeIO()) as fp:
+                    main(argv=['--tee', '--mininterval', '0',
+                               '--miniters', '1'], fp=fp)
+                    # spaces to clear intermediate lines could increase length
+                    assert len(fp.getvalue()) >= res + len(IN_DATA)
+
+        # test --null
         with closing(StringIO()) as sys.stdout:
             with closing(StringIO()) as sys.stdin:
                 sys.stdin.write(IN_DATA)
@@ -119,14 +121,12 @@ def test_main():
                 with closing(UnicodeIO()) as fp:
                     main(argv=[], fp=fp)
                     assert sys.stdout.getvalue()
-    except:
-        sys.stdout = _STDOUT
-        raise
-    else:
+    finally:
         sys.stdout = _STDOUT
 
     # test integer --update
-    with closing(StringIO()) as sys.stdin:
+    IN_DATA = IN_DATA.encode()
+    with closing(BytesIO()) as sys.stdin:
         sys.stdin.write(IN_DATA)
 
         sys.stdin.seek(0)
@@ -136,8 +136,8 @@ def test_main():
             assert str(N // 2 * N) + "it" in res  # arithmetic sum formula
 
     # test integer --update --delim
-    with closing(StringIO()) as sys.stdin:
-        sys.stdin.write(IN_DATA.replace('\n', 'D'))
+    with closing(BytesIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA.replace(b'\n', b'D'))
 
         sys.stdin.seek(0)
         with closing(UnicodeIO()) as fp:
@@ -146,7 +146,7 @@ def test_main():
             assert str(N // 2 * N) + "it" in res  # arithmetic sum formula
 
     # test integer --update_to
-    with closing(StringIO()) as sys.stdin:
+    with closing(BytesIO()) as sys.stdin:
         sys.stdin.write(IN_DATA)
 
         sys.stdin.seek(0)
@@ -157,8 +157,8 @@ def test_main():
             assert str(N) + "it" not in res
 
     # test integer --update_to --delim
-    with closing(StringIO()) as sys.stdin:
-        sys.stdin.write(IN_DATA.replace('\n', 'D'))
+    with closing(BytesIO()) as sys.stdin:
+        sys.stdin.write(IN_DATA.replace(b'\n', b'D'))
 
         sys.stdin.seek(0)
         with closing(UnicodeIO()) as fp:
@@ -168,8 +168,8 @@ def test_main():
             assert str(N) + "it" not in res
 
     # test float --update_to
-    IN_DATA = '\n'.join((str(i / 2.0) for i in _range(N)))
-    with closing(StringIO()) as sys.stdin:
+    IN_DATA = '\n'.join((str(i / 2.0) for i in _range(N))).encode()
+    with closing(BytesIO()) as sys.stdin:
         sys.stdin.write(IN_DATA)
 
         sys.stdin.seek(0)
@@ -186,7 +186,7 @@ def test_main():
 def test_manpath():
     """Test CLI --manpath"""
     if IS_WIN:
-        raise SkipTest
+        skip("no manpages on windows")
     tmp = mkdtemp()
     man = path.join(tmp, "tqdm.1")
     assert not path.exists(man)
@@ -203,7 +203,7 @@ def test_manpath():
 def test_comppath():
     """Test CLI --comppath"""
     if IS_WIN:
-        raise SkipTest
+        skip("no manpages on windows")
     tmp = mkdtemp()
     man = path.join(tmp, "tqdm_completion.sh")
     assert not path.exists(man)

--- a/tests/tests_notebook.py
+++ b/tests/tests_notebook.py
@@ -1,8 +1,7 @@
 from tqdm.notebook import tqdm as tqdm_notebook
-from tests_tqdm import with_setup, pretest, posttest
+from .tests_tqdm import pretest_posttest  # NOQA, pylint: disable=unused-import
 
 
-@with_setup(pretest, posttest)
 def test_notebook_disabled_description():
     """Test that set_description works for disabled tqdm_notebook"""
     with tqdm_notebook(1, disable=True) as t:

--- a/tests/tests_pandas.py
+++ b/tests/tests_pandas.py
@@ -1,17 +1,15 @@
 from tqdm import tqdm
-from tests_tqdm import with_setup, pretest, posttest, SkipTest, \
-    StringIO, closing
+from .tests_tqdm import pretest_posttest  # NOQA, pylint: disable=unused-import
+from .tests_tqdm import importorskip, skip, StringIO, closing
+
+random = importorskip("numpy.random")
+rand = random.rand
+randint = random.randint
+pd = importorskip("pandas")
 
 
-@with_setup(pretest, posttest)
 def test_pandas_setup():
     """Test tqdm.pandas()"""
-    try:
-        from numpy.random import randint
-        import pandas as pd
-    except ImportError:
-        raise SkipTest
-
     with closing(StringIO()) as our_file:
         tqdm.pandas(file=our_file, leave=True, ascii=True, total=123)
         series = pd.Series(randint(0, 50, (100,)))
@@ -20,15 +18,8 @@ def test_pandas_setup():
         assert '100/123' in res
 
 
-@with_setup(pretest, posttest)
 def test_pandas_rolling_expanding():
     """Test pandas.(Series|DataFrame).(rolling|expanding)"""
-    try:
-        from numpy.random import randint
-        import pandas as pd
-    except ImportError:
-        raise SkipTest
-
     with closing(StringIO()) as our_file:
         tqdm.pandas(file=our_file, leave=True, ascii=True)
 
@@ -51,15 +42,8 @@ def test_pandas_rolling_expanding():
                         exres + " at least twice.", our_file.read()))
 
 
-@with_setup(pretest, posttest)
 def test_pandas_series():
     """Test pandas.Series.progress_apply and .progress_map"""
-    try:
-        from numpy.random import randint
-        import pandas as pd
-    except ImportError:
-        raise SkipTest
-
     with closing(StringIO()) as our_file:
         tqdm.pandas(file=our_file, leave=True, ascii=True)
 
@@ -82,15 +66,8 @@ def test_pandas_series():
                         exres + " at least twice.", our_file.read()))
 
 
-@with_setup(pretest, posttest)
 def test_pandas_data_frame():
     """Test pandas.DataFrame.progress_apply and .progress_applymap"""
-    try:
-        from numpy.random import randint
-        import pandas as pd
-    except ImportError:
-        raise SkipTest
-
     with closing(StringIO()) as our_file:
         tqdm.pandas(file=our_file, leave=True, ascii=True)
         df = pd.DataFrame(randint(0, 50, (100, 200)))
@@ -131,15 +108,8 @@ def test_pandas_data_frame():
                         exres + " at least once.", our_file.read()))
 
 
-@with_setup(pretest, posttest)
 def test_pandas_groupby_apply():
     """Test pandas.DataFrame.groupby(...).progress_apply"""
-    try:
-        from numpy.random import randint, rand
-        import pandas as pd
-    except ImportError:
-        raise SkipTest
-
     with closing(StringIO()) as our_file:
         tqdm.pandas(file=our_file, leave=False, ascii=True)
 
@@ -192,15 +162,8 @@ def test_pandas_groupby_apply():
                         exres + " at least once.", our_file.read()))
 
 
-@with_setup(pretest, posttest)
 def test_pandas_leave():
     """Test pandas with `leave=True`"""
-    try:
-        from numpy.random import randint
-        import pandas as pd
-    except ImportError:
-        raise SkipTest
-
     with closing(StringIO()) as our_file:
         df = pd.DataFrame(randint(0, 100, (1000, 6)))
         tqdm.pandas(file=our_file, leave=True, ascii=True)
@@ -215,16 +178,13 @@ def test_pandas_leave():
                 "\nExpected:\n{0}\nIn:{1}\n".format(exres, our_file.read()))
 
 
-@with_setup(pretest, posttest)
 def test_pandas_apply_args_deprecation():
     """Test warning info in
     `pandas.Dataframe(Series).progress_apply(func, *args)`"""
     try:
-        from numpy.random import randint
         from tqdm import tqdm_pandas
-        import pandas as pd
-    except ImportError:
-        raise SkipTest
+    except ImportError as err:
+        skip(str(err))
 
     with closing(StringIO()) as our_file:
         tqdm_pandas(tqdm(file=our_file, leave=False, ascii=True, ncols=20))
@@ -237,15 +197,12 @@ def test_pandas_apply_args_deprecation():
             "keyword arguments instead")])
 
 
-@with_setup(pretest, posttest)
 def test_pandas_deprecation():
     """Test bar object instance as argument deprecation"""
     try:
-        from numpy.random import randint
         from tqdm import tqdm_pandas
-        import pandas as pd
-    except ImportError:
-        raise SkipTest
+    except ImportError as err:
+        skip(str(err))
 
     with closing(StringIO()) as our_file:
         tqdm_pandas(tqdm(file=our_file, leave=False, ascii=True, ncols=20))

--- a/tests/tests_perf.py
+++ b/tests/tests_perf.py
@@ -11,10 +11,9 @@ except ImportError:
 import sys
 
 from tqdm import tqdm, trange
-from tests_tqdm import with_setup, pretest, posttest, StringIO, closing, \
-    _range, patch_lock
-
-from nose.plugins.skip import SkipTest
+from .tests_tqdm import pretest_posttest  # NOQA, pylint: disable=unused-import
+from .tests_tqdm import importorskip, skip, StringIO, closing, _range, \
+    patch_lock
 
 
 def cpu_sleep(t):
@@ -41,7 +40,7 @@ def checkCpuTime(sleeptime=0.2):
     if abs(t1) < 0.0001 and t1 < t2 / 10:
         checkCpuTime.passed = True
         return True
-    raise SkipTest
+    skip("cpu time not reliable on this machine")
 
 
 checkCpuTime.passed = False
@@ -74,8 +73,6 @@ def retry_on_except(n=6, check_cpu_time=True):
                     if check_cpu_time:
                         checkCpuTime()
                     func(*args, **kwargs)
-                except SkipTest:
-                    raise
                 except Exception:
                     if i >= n:
                         raise
@@ -170,7 +167,6 @@ def assert_performance(thresh, name_left, time_left, name_right, time_right):
                 ratio=time_left / time_right, thresh=thresh))
 
 
-@with_setup(pretest, posttest)
 @retry_on_except()
 def test_iter_basic_overhead():
     """Test overhead of iteration based tqdm"""
@@ -194,7 +190,6 @@ def test_iter_basic_overhead():
     assert_performance(3, 'trange', time_tqdm(), 'range', time_bench())
 
 
-@with_setup(pretest, posttest)
 @retry_on_except()
 def test_manual_basic_overhead():
     """Test overhead of manual tqdm"""
@@ -230,15 +225,11 @@ def worker(total, blocking=True):
     return incr_bar
 
 
-@with_setup(pretest, posttest)
 @retry_on_except()
 @patch_lock(thread=True)
 def test_lock_args():
     """Test overhead of nonblocking threads"""
-    try:
-        from concurrent.futures import ThreadPoolExecutor
-    except ImportError:
-        raise SkipTest
+    ThreadPoolExecutor = importorskip('concurrent.futures').ThreadPoolExecutor
 
     total = 16
     subtotal = 10000
@@ -258,7 +249,6 @@ def test_lock_args():
     assert_performance(0.5, 'noblock', time_noblock(), 'tqdm', time_tqdm())
 
 
-@with_setup(pretest, posttest)
 @retry_on_except()
 def test_iter_overhead_hard():
     """Test overhead of iteration based tqdm (hard)"""
@@ -283,7 +273,6 @@ def test_iter_overhead_hard():
     assert_performance(130, 'trange', time_tqdm(), 'range', time_bench())
 
 
-@with_setup(pretest, posttest)
 @retry_on_except()
 def test_manual_overhead_hard():
     """Test overhead of manual tqdm (hard)"""
@@ -308,7 +297,6 @@ def test_manual_overhead_hard():
     assert_performance(130, 'tqdm', time_tqdm(), 'range', time_bench())
 
 
-@with_setup(pretest, posttest)
 @retry_on_except()
 def test_iter_overhead_simplebar_hard():
     """Test overhead of iteration based tqdm vs simple progress bar (hard)"""
@@ -335,7 +323,6 @@ def test_iter_overhead_simplebar_hard():
         10, 'trange', time_tqdm(), 'simple_progress', time_bench())
 
 
-@with_setup(pretest, posttest)
 @retry_on_except()
 def test_manual_overhead_simplebar_hard():
     """Test overhead of manual tqdm vs simple progress bar (hard)"""

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1168,6 +1168,15 @@ def test_custom_format():
         assert "00:00 in total" in our_file.getvalue()
 
 
+def test_eta(capsys):
+    """Test eta bar_format"""
+    from datetime import datetime as dt
+    for _ in trange(2, leave=True, bar_format='{l_bar}{eta:%Y-%m-%d}'):
+        pass
+    _, err = capsys.readouterr()
+    assert "\r100%|{eta:%Y-%m-%d}\n".format(eta=dt.now()) in err
+
+
 def test_unpause():
     """Test unpause"""
     timer = DiscreteTimer()

--- a/tests/tests_version.py
+++ b/tests/tests_version.py
@@ -1,5 +1,7 @@
 import re
 
+from .tests_tqdm import pretest_posttest  # NOQA, pylint: disable=unused-import
+
 
 def test_version():
     """Test version string"""

--- a/tox.ini
+++ b/tox.ini
@@ -9,13 +9,13 @@ envlist = py{26,27,33,34,35,36,37,38,py,py3}, tf-no-keras, perf, flake8, setup.p
 
 [coverage]
 deps =
-    nose
+    pytest
+    pytest-cov
     coverage
     coveralls
 commands =
-    nosetests -d -v --with-coverage --cover-package=tqdm --ignore-files="tests_perf\.py" tqdm/
+    pytest --cov=tqdm --cov-report=xml --cov-report=term -k "not tests_perf"
     - coveralls
-    - coverage xml
     - curl -OL https://coverage.codacy.com/get.sh
     - bash get.sh report -r coverage.xml
 allowlist_externals =
@@ -25,13 +25,11 @@ allowlist_externals =
 [extra]
 deps =
     {[coverage]deps}
-    nose-timer
     codecov
 commands =
-    nosetests -d -v --with-coverage --with-timer --cover-package=tqdm --ignore-files="tests_perf\.py" tqdm/
+    pytest --durations=10 --cov=tqdm --cov-report=xml --cov-report=term -k "not tests_perf"
     - coveralls
     codecov
-    - coverage xml
     - curl -OL https://coverage.codacy.com/get.sh
     - bash get.sh report -r coverage.xml
 allowlist_externals = {[coverage]allowlist_externals}
@@ -51,9 +49,9 @@ allowlist_externals = {[extra]allowlist_externals}
 # no cython/numpy/pandas for py{py,py3,26,33,34}
 
 [testenv:py26]
-# no codecov and timer for py26
 deps =
-    nose
+    pytest
+    pytest-cov
     coverage
     coveralls==1.2.0
     codecov
@@ -81,14 +79,13 @@ deps =
     {[extra]deps}
     tensorflow
 commands =
-    nosetests -d -v --with-timer tqdm/tests/tests_keras.py
+    pytest --durations=10 -k tests_keras
 
 [testenv:perf]
 deps =
-    nose
-    nose-timer
+    pytest
 commands =
-    nosetests -d -v --with-timer tqdm/tests/tests_perf.py
+    pytest --durations=0 -k tests_perf
 
 [testenv:flake8]
 deps = flake8

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -302,10 +302,10 @@ Options:
                 with tqdm(**tqdm_args) as t:
                     if update:
                         def callback(i):
-                            t.update(numeric(i))
+                            t.update(numeric(i.decode()))
                     else:  # update_to
                         def callback(i):
-                            t.update(numeric(i) - t.n)
+                            t.update(numeric(i.decode()) - t.n)
                     for i in stdin:
                         stdout.write(i)
                         callback(i)
@@ -318,10 +318,10 @@ Options:
                 callback_len = False
                 if update:
                     def callback(i):
-                        t.update(numeric(i))
+                        t.update(numeric(i.decode()))
                 elif update_to:
                     def callback(i):
-                        t.update(numeric(i) - t.n)
+                        t.update(numeric(i.decode()) - t.n)
                 else:
                     callback = t.update
                     callback_len = True

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -16,6 +16,7 @@ from .utils import _supports_unicode, _screen_shape_wrapper, _range, _unich, \
 from ._monitor import TMonitor
 # native libraries
 from contextlib import contextmanager
+from datetime import datetime, timedelta
 from numbers import Number
 from time import time
 from warnings import warn
@@ -386,7 +387,7 @@ class tqdm(Comparable):
               percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
               rate, rate_fmt, rate_noinv, rate_noinv_fmt,
               rate_inv, rate_inv_fmt, postfix, unit_divisor,
-              remaining, remaining_s.
+              remaining, remaining_s, eta.
             Note that a trailing ": " is automatically removed after {desc}
             if the latter is empty.
         postfix  : *, optional
@@ -451,6 +452,11 @@ class tqdm(Comparable):
 
         remaining = (total - n) / rate if rate and total else 0
         remaining_str = tqdm.format_interval(remaining) if rate else '?'
+        try:
+            eta_dt = datetime.now() + timedelta(seconds=remaining) \
+                if rate and total else datetime.utcfromtimestamp(0)
+        except OverflowError:
+            eta_dt = datetime.max
 
         # format the stats displayed to the left and right sides of the bar
         if prefix:
@@ -478,7 +484,7 @@ class tqdm(Comparable):
             colour=colour,
             # plus more useful definitions
             remaining=remaining_str, remaining_s=remaining,
-            l_bar=l_bar, r_bar=r_bar,
+            l_bar=l_bar, r_bar=r_bar, eta=eta_dt,
             **extra_kwargs)
 
         # total is known: we can predict some stats
@@ -908,7 +914,7 @@ class tqdm(Comparable):
               percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
               rate, rate_fmt, rate_noinv, rate_noinv_fmt,
               rate_inv, rate_inv_fmt, postfix, unit_divisor,
-              remaining, remaining_s.
+              remaining, remaining_s, eta.
             Note that a trailing ": " is automatically removed after {desc}
             if the latter is empty.
         initial  : int or float, optional

--- a/tqdm/tests/tests_asyncio.py
+++ b/tqdm/tests/tests_asyncio.py
@@ -1,7 +1,0 @@
-import sys
-
-if sys.version_info[:2] > (3, 6):
-    from py37_asyncio import *  # NOQA
-else:
-    from tests_tqdm import SkipTest
-    raise SkipTest

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -166,7 +166,7 @@ May impact performance.
 vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt, percentage,
 elapsed, elapsed_s, ncols, nrows, desc, unit, rate, rate_fmt,
 rate_noinv, rate_noinv_fmt, rate_inv, rate_inv_fmt, postfix,
-unit_divisor, remaining, remaining_s.
+unit_divisor, remaining, remaining_s, eta.
 Note that a trailing ": " is automatically removed after {desc} if the
 latter is empty.
 .RS


### PR DESCRIPTION
- add `{eta}` datetime `bar_format` argument (#1055 <- #1051)
  + e.g. `bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt} [{rate_fmt} ETA:{eta:%y-%m-%d %H:%M}{postfix}]'`
- [ ] allow delaying `display()` to a different notebook cell (#1059 <- #909)
  + add `notebook` argument `display=True` (use `False` with `display(tqdm_object.container)`)
  + add `keras.TqdmCallback` support for initial arguments (use `display=False` with `tqdm_callback_object.display()`)
  + [ ] add documentation
- fix py3 CLI `--update` & `--update_to`
- replace `nosetests` with `pytest` (#1052, #1045)
- add & update tests

----

- closes #1055, fixes #1051
- closes #1059, fixes #909
- closes #1052, closes #1045