### PR TITLE
notebook: support delay display & other kwargs

### DIFF
--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division
 from .auto import tqdm as tqdm_auto
 from copy import copy
+from functools import partial
 try:
     import keras
 except ImportError as e:
@@ -44,12 +45,12 @@ class TqdmCallback(keras.callbacks.Callback):
         tqdm_class : optional
             `tqdm` class to use for bars [default: `tqdm.auto.tqdm`].
         tqdm_kwargs  : optional
-            Any other arguments used for initial bars.
-            Instead, for passing arguments to all bars, create a custom
-            `tqdm_class`.
+            Any other arguments used for all bars.
         """
+        if tqdm_kwargs:
+            tqdm_class = partial(tqdm_class, **tqdm_kwargs)
         self.tqdm_class = tqdm_class
-        self.epoch_bar = tqdm_class(total=epochs, unit='epoch', **tqdm_kwargs)
+        self.epoch_bar = tqdm_class(total=epochs, unit='epoch')
         self.on_epoch_end = self.bar2callback(self.epoch_bar)
         if data_size and batch_size:
             self.batches = batches = (data_size + batch_size - 1) // batch_size
@@ -58,7 +59,7 @@ class TqdmCallback(keras.callbacks.Callback):
         self.verbose = verbose
         if verbose == 1:
             self.batch_bar = tqdm_class(total=batches, unit='batch',
-                                        leave=False, **tqdm_kwargs)
+                                        leave=False)
             self.on_batch_end = self.bar2callback(
                 self.batch_bar,
                 pop=['batch', 'size'],

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -92,6 +92,17 @@ class TqdmCallback(keras.callbacks.Callback):
             self.batch_bar.close()
         self.epoch_bar.close()
 
+    def display(self):
+        """displays in the current cell in Notebooks"""
+        container = getattr(self.epoch_bar, 'container', None)
+        if container is None:
+            return
+        from .notebook import display
+        display(container)
+        batch_bar = getattr(self, 'batch_bar', None)
+        if batch_bar is not None:
+            display(batch_bar.container)
+
     @staticmethod
     def _implements_train_batch_hooks():
         return True

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -28,7 +28,7 @@ class TqdmCallback(keras.callbacks.Callback):
         return callback
 
     def __init__(self, epochs=None, data_size=None, batch_size=None, verbose=1,
-                 tqdm_class=tqdm_auto):
+                 tqdm_class=tqdm_auto, **tqdm_kwargs):
         """
         Parameters
         ----------
@@ -43,9 +43,13 @@ class TqdmCallback(keras.callbacks.Callback):
             are given.
         tqdm_class : optional
             `tqdm` class to use for bars [default: `tqdm.auto.tqdm`].
+        tqdm_kwargs  : optional
+            Any other arguments used for initial bars.
+            Instead, for passing arguments to all bars, create a custom
+            `tqdm_class`.
         """
         self.tqdm_class = tqdm_class
-        self.epoch_bar = tqdm_class(total=epochs, unit='epoch')
+        self.epoch_bar = tqdm_class(total=epochs, unit='epoch', **tqdm_kwargs)
         self.on_epoch_end = self.bar2callback(self.epoch_bar)
         if data_size and batch_size:
             self.batches = batches = (data_size + batch_size - 1) // batch_size
@@ -54,7 +58,7 @@ class TqdmCallback(keras.callbacks.Callback):
         self.verbose = verbose
         if verbose == 1:
             self.batch_bar = tqdm_class(total=batches, unit='batch',
-                                        leave=False)
+                                        leave=False, **tqdm_kwargs)
             self.on_batch_end = self.bar2callback(
                 self.batch_bar,
                 pop=['batch', 'size'],

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -124,7 +124,6 @@ class tqdm_notebook(std_tqdm):
             container.layout.width = ncols
             container.layout.display = 'inline-flex'
             container.layout.flex_flow = 'row wrap'
-        display(container)
 
         return container
 
@@ -195,6 +194,14 @@ class tqdm_notebook(std_tqdm):
             self.container.children[-2].style.bar_color = bar_color
 
     def __init__(self, *args, **kwargs):
+        """
+        Supports the usual `tqdm.tqdm` parameters as well as those listed below.
+
+        Parameters
+        ----------
+        display  : Whether to call `display(self.container)` immediately
+            [default: True].
+        """
         kwargs = kwargs.copy()
         # Setup default output
         file_kwarg = kwargs.get('file', sys.stderr)
@@ -209,6 +216,7 @@ class tqdm_notebook(std_tqdm):
         # convert disable = None to False
         kwargs['disable'] = bool(kwargs.get('disable', False))
         colour = kwargs.pop('colour', None)
+        display_here = kwargs.pop('display', True)
         super(tqdm_notebook, self).__init__(*args, **kwargs)
         if self.disable or not kwargs['gui']:
             self.sp = lambda *_, **__: None
@@ -222,6 +230,8 @@ class tqdm_notebook(std_tqdm):
         total = self.total * unit_scale if self.total else self.total
         self.container = self.status_printer(
             self.fp, total, self.desc, self.ncols)
+        if display_here:
+            display(self.container)
         self.sp = self.display
         self.colour = colour
 


### PR DESCRIPTION
- allow delaying `display()` to a different notebook cell (#909)

```python
from tqdm.notebook import trange
t = trange(int(1e7), display=False)
```
```python
display(t.container)
for _ in t:
    pass
```

- same for `tqdm.keras`

```python
from tqdm.keras import TqdmCallback
...
tqdm_callback = TqdmCallback(..., display=False)
```
```python
tqdm_callback.display()
model.fit(..., verbose=False, callbacks=[tqdm_callback])
```

- support `keras` bar arguments (#1065)

# screenshots

![image](https://user-images.githubusercontent.com/10780059/97096123-9906dc80-165f-11eb-8a62-860ebbb16e4e.png)

![image](https://user-images.githubusercontent.com/10780059/97096415-e7b67580-1663-11eb-8e93-e5a0bbceba37.png)

----

- fixes #909
- fixes #1065
