### PR TITLE
Set tqdm.disable from os.environ

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -406,6 +406,8 @@ Parameters
     the meter. The fallback is to use ASCII characters " 123456789#".
 * disable  : bool, optional  
     Whether to disable the entire progressbar wrapper
+    Setting os.environ['TQDM_DISABLE'] = 1 will disable the entire
+    progressbar wrapper. It overwrites this flag.
     [default: False]. If set to None, disable on non-TTY.
 * unit  : str, optional  
     String that will be used to define the unit of each iteration

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -882,6 +882,40 @@ def test_disable():
         assert our_file.getvalue() == ''
 
 
+def test_disable_environ(monkeypatch):
+    """ Test that disable can be done with environment variable"""
+
+    # Sets a os.environ flag during this test. This should silence the logging
+    monkeypatch.setenv('TQDM_DISABLE', '1')
+
+    with closing(StringIO()) as our_file:
+        instance = tqdm(_range(3), file=our_file)
+        assert instance.disable is True
+
+        for _ in instance:
+            pass
+
+        assert our_file.getvalue() == ''
+
+    with closing(StringIO()) as our_file:
+        instance = tqdm(_range(3), file=our_file, disable=False)
+        assert instance.disable is True
+
+        for _ in instance:
+            pass
+
+        assert our_file.getvalue() == ''
+
+    with closing(StringIO()) as our_file:
+        instance = tqdm(_range(3), file=our_file, disable=True)
+        assert instance.disable is True
+
+        for _ in instance:
+            pass
+
+        assert our_file.getvalue() == ''
+
+
 def test_infinite_total():
     """Test treatment of infinite total"""
     with closing(StringIO()) as our_file:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -21,6 +21,7 @@ from numbers import Number
 from time import time
 from warnings import warn
 import sys
+import os
 
 __author__ = "https://github.com/tqdm/tqdm#contributions"
 __all__ = ['tqdm', 'trange',
@@ -886,7 +887,9 @@ class tqdm(Comparable):
             If unspecified or False, use unicode (smooth blocks) to fill
             the meter. The fallback is to use ASCII characters " 123456789#".
         disable  : bool, optional
-            Whether to disable the entire progressbar wrapper
+            Whether to disable the entire progressbar wrapper.
+            Setting os.environ['TQDM_DISABLE'] = 1 will disable the entire
+            progressbar wrapper. It overwrites this flag.
             [default: False]. If set to None, disable on non-TTY.
         unit  : str, optional
             String that will be used to define the unit of each iteration
@@ -965,6 +968,9 @@ class tqdm(Comparable):
                 file, encoding=getattr(file, 'encoding', None) or 'utf-8')
 
         file = DisableOnWriteError(file, tqdm_instance=self)
+
+        if 'TQDM_DISABLE' in os.environ:
+            disable = True
 
         if disable is None and hasattr(file, "isatty") and not file.isatty():
             disable = True


### PR DESCRIPTION
This PR is a updated version of #950 that also adds in tests and updates the documentation for the `disable` parameter, and it updates the branch to be able to merge again as the other PR is stale since before the summer.

The following is taken from #950 

```
Allow setting the tqdm.disable option from the environment variables.
The default value of False is unchanged, as is the expected behavior with None.

Resolves issues laid out it #619 #614 #612. Similar to the request in #370.
```

We evaluated the following suggestion that was posted earlier and decided it was not good enough as a general solution as it would both require us to update all usages of tqdm in our code, and we would have to remove it when/if this PR would be added in and all developers coding new code that uses tqdm would have to remember/know that they need to add in that fix in order to get the centralized disable feature.

```python
from tqdm import tqdm
import os

for x in tqdm(..., disable=os.environ.get("DISABLE_TQDM", False)):
    ...
```

- [X] I have marked all applicable categories:
    + [ ] exception-raising bug
    + [ ] visual output bug
    + [ ] documentation request (i.e. "X is missing from the documentation." If instead I want to ask "how to use X?" I understand [StackOverflow#tqdm] is more appropriate)
    + [X] new feature request
- [X] I have visited the [source website], and in particular
  read the [known issues]
- [X] I have searched through the [issue tracker] for duplicates
- [ ] I have mentioned version numbers, operating system and

## environment, where applicable:
```
>>> import tqdm, sys
>>> print(tqdm.__version__, sys.version, sys.platform)
4.51.0-git.UNKNOWN 3.7.5 (default, Nov  7 2019, 10:50:52) 
[GCC 8.3.0] linux
```

## Usecase example

A simple use-case for this option is that we are running a big set of code where we have both support to run the exact same code as a cli tool from a users computer and in a hosted environment inside celery. And when we run it in celery, we do not want our logs to be polluted with tdqm loggin output. This option would make it super easy to disable all tdqm logging as we have it in a lot of places in our code and we would just configure our production servers with ansible/terraform to have this environment variable and we are all set and can controll our logging from a central point.

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=
[StackOverflow#tqdm]: https://stackoverflow.com/questions/tagged/tqdm
