### PR TITLE
add `unit_pre` and `unit_prefixes`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -407,15 +407,6 @@ Parameters
 * disable  : bool, optional  
     Whether to disable the entire progressbar wrapper
     [default: False]. If set to None, disable on non-TTY.
-* unit  : str, optional  
-    String that will be used to define the unit of each iteration
-    [default: it].
-* unit_scale  : bool or int or float, optional  
-    If 1 or True, the number of iterations will be reduced/scaled
-    automatically and a metric prefix following the
-    International System of Units standard will be added
-    (kilo, mega, etc.) [default: False]. If any other non-zero
-    number, will scale ``total`` and ``n``.
 * dynamic_ncols  : bool, optional  
     If set, constantly alters ``ncols`` and ``nrows`` to the
     environment (allowing for window resizes) [default: False].
@@ -447,8 +438,24 @@ Parameters
 * postfix  : dict or ``*``, optional  
     Specify additional stats to display at the end of the bar.
     Calls ``set_postfix(**postfix)`` if possible (dict).
+* unit  : str, optional  
+    String that will be used to define the unit of each iteration
+    [default: it].
+* unit_scale  : bool or int or float, optional  
+    If 1 or True, the number of iterations will be reduced/scaled
+    automatically and a metric prefix following the
+    International System of Units standard will be added
+    (kilo, mega, etc.) [default: False]. If any other non-zero
+    number, will scale ``total`` and ``n``.
 * unit_divisor  : float, optional  
     [default: 1000], ignored unless ``unit_scale`` is True.
+* unit_pre  : str, optional  
+    Pre-prefix [default: ''].
+* unit_prefixes  : list or str, optional  
+    Prefixes (default: [''] + list('kMGTPEZY')).
+    Use ``"IEEE1541"`` or ``"bytes"`` as a shortcut to override:
+    unit='B', unit_scale=True, unit_divisor=1024, unit_pre=' ',
+    unit_prefixes=[''] + [i + 'i' for i in 'KMGTPEZY'].
 * write_bytes  : bool, optional  
     If (default: None) and ``file`` is unspecified,
     bytes will be written in Python 2. If ``True`` will also write
@@ -474,7 +481,7 @@ Extra CLI Options
     used when ``delim`` is specified.
 * bytes  : bool, optional  
     If true, will count bytes, ignore ``delim``, and default
-    ``unit_scale`` to True, ``unit_divisor`` to 1024, and ``unit`` to 'B'.
+    ``unit_prefixes`` to ``"IEEE1541"``.
 * tee  : bool, optional  
     If true, passes ``stdin`` to both ``stderr`` and ``stdout``.
 * update  : bool, optional  

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,8 @@
 universal = 1
 
 [flake8]
-ignore = W503,W504,E722
-max_line_length = 80
+ignore = W503,W504,E203,E722
+max_line_length = 88
 exclude = .asv,.tox,.ipynb_checkpoints,build,dist,.git,__pycache__
 
 [tool:pytest]

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -127,7 +127,7 @@ CLI_EXTRA_DOC = r"""
             used when `delim` is specified.
         bytes  : bool, optional
             If true, will count bytes, ignore `delim`, and default
-            `unit_scale` to True, `unit_divisor` to 1024, and `unit` to 'B'.
+            `unit_prefixes` to `"IEEE1541"`.
         tee  : bool, optional
             If true, passes `stdin` to both `stderr` and `stdout`.
         update  : bool, optional
@@ -279,9 +279,7 @@ Options:
                         fp_write(x)
                     stdout_write(x)
         if delim_per_char:
-            tqdm_args.setdefault('unit', 'B')
-            tqdm_args.setdefault('unit_scale', True)
-            tqdm_args.setdefault('unit_divisor', 1024)
+            tqdm_args.setdefault('unit_prefixes', 'IEEE1541')
             log.debug(tqdm_args)
             with tqdm(**tqdm_args) as t:
                 posix_pipe(stdin, stdout, '', buf_size, t.update)

--- a/tqdm/completion.sh
+++ b/tqdm/completion.sh
@@ -5,14 +5,14 @@ _tqdm(){
   prv="${COMP_WORDS[COMP_CWORD - 1]}"
 
   case ${prv} in
-  --bar_format|--buf_size|--colour|--comppath|--delim|--desc|--initial|--lock_args|--manpath|--maxinterval|--mininterval|--miniters|--ncols|--nrows|--position|--postfix|--smoothing|--total|--unit|--unit_divisor)
+  --bar_format|--buf_size|--colour|--comppath|--delim|--desc|--initial|--lock_args|--manpath|--maxinterval|--mininterval|--miniters|--ncols|--nrows|--position|--postfix|--smoothing|--total|--unit|--unit_divisor|--unit_pre)
     # await user input
     ;;
   "--log")
     COMPREPLY=($(compgen -W       'CRITICAL FATAL ERROR WARN WARNING INFO DEBUG NOTSET' -- ${cur}))
     ;;
   *)
-    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --colour --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --null --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_scale --update --update_to --version --write_bytes -h -v' -- ${cur}))
+    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --colour --comppath --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --null --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_pre --unit_prefixes --unit_scale --update --update_to --version --write_bytes -h -v' -- ${cur}))
     ;;
   esac
 }

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -124,22 +124,6 @@ If set to None, disable on non\-TTY.
 .RS
 .RE
 .TP
-.B \-\-unit=\f[I]unit\f[]
-str, optional.
-String that will be used to define the unit of each iteration [default:
-it].
-.RS
-.RE
-.TP
-.B \-\-unit\-scale=\f[I]unit_scale\f[]
-bool or int or float, optional.
-If 1 or True, the number of iterations will be reduced/scaled
-automatically and a metric prefix following the International System of
-Units standard will be added (kilo, mega, etc.) [default: False].
-If any other non\-zero number, will scale \f[C]total\f[] and \f[C]n\f[].
-.RS
-.RE
-.TP
 .B \-\-dynamic\-ncols
 bool, optional.
 If set, constantly alters \f[C]ncols\f[] and \f[C]nrows\f[] to the
@@ -196,9 +180,41 @@ Calls \f[C]set_postfix(**postfix)\f[] if possible (dict).
 .RS
 .RE
 .TP
+.B \-\-unit=\f[I]unit\f[]
+str, optional.
+String that will be used to define the unit of each iteration [default:
+it].
+.RS
+.RE
+.TP
+.B \-\-unit\-scale=\f[I]unit_scale\f[]
+bool or int or float, optional.
+If 1 or True, the number of iterations will be reduced/scaled
+automatically and a metric prefix following the International System of
+Units standard will be added (kilo, mega, etc.) [default: False].
+If any other non\-zero number, will scale \f[C]total\f[] and \f[C]n\f[].
+.RS
+.RE
+.TP
 .B \-\-unit\-divisor=\f[I]unit_divisor\f[]
 float, optional.
 [default: 1000], ignored unless \f[C]unit_scale\f[] is True.
+.RS
+.RE
+.TP
+.B \-\-unit\-pre=\f[I]unit_pre\f[]
+str, optional.
+Pre\-prefix [default: \[aq]\[aq]].
+.RS
+.RE
+.TP
+.B \-\-unit\-prefixes=\f[I]unit_prefixes\f[]
+list or str, optional.
+Prefixes (default: [\[aq]\[aq]] + list(\[aq]kMGTPEZY\[aq])).
+Use \f[C]"IEEE1541"\f[] or \f[C]"bytes"\f[] as a shortcut to override:
+unit=\[aq]B\[aq], unit_scale=True, unit_divisor=1024, unit_pre=\[aq]
+\[aq], unit_prefixes=[\[aq]\[aq]] + [i + \[aq]i\[aq] for i in
+\[aq]KMGTPEZY\[aq]].
 .RS
 .RE
 .TP
@@ -253,8 +269,7 @@ specified.
 .B \-\-bytes
 bool, optional.
 If true, will count bytes, ignore \f[C]delim\f[], and default
-\f[C]unit_scale\f[] to True, \f[C]unit_divisor\f[] to 1024, and
-\f[C]unit\f[] to \[aq]B\[aq].
+\f[C]unit_prefixes\f[] to \f[C]"IEEE1541"\f[].
 .RS
 .RE
 .TP


### PR DESCRIPTION
- add `unit_pre` (#825)
  + [ ] maybe make `' '` rather than `''` default?
- add `unit_prefixes`
  + add `unit_prefixes="bytes"` or `"IEEE1541"` or iterable (#953, #952)
- [ ] add tests

Explicit #952 fix:

```python
from tqdm.auto import tqdm as tqdm_auto
from functools import partial

tqdm = partial(tqdm_auto, unit_prefixes=[" B"] + [i + "iB" for i in "KMGTPEZY"],
               unit_divisor=1024, unit_scale=True, unit="", unit_pre=" ")
```

----

- fixes #825
- fixes #953
- fixes #952