### PR TITLE
next release v4.54.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,7 +35,8 @@ jobs:
         python-version: '3.x'
     - uses: reviewdog/action-setup@v1
     - run: pip install -U flake8
-    - name: flake8
+    - if: github.event_name != 'schedule'
+      name: flake8
       run: |
         set -o pipefail
         flake8 -j8 --count --statistics . | \
@@ -57,9 +58,8 @@ jobs:
       run: |
         pip install -U wheel
         pip install -U virtualenv asv
+        git checkout master && git checkout -
         asv machine --machine github-actions --yes
-        git fetch --tags
-        git fetch origin master:master
     - name: Restore previous results
       uses: actions/cache@v2
       with:
@@ -85,6 +85,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
@@ -92,9 +94,8 @@ jobs:
       run: |
         pip install -U wheel
         pip install -U virtualenv asv
+        git checkout master && git checkout -
         asv machine --machine github-actions --yes
-        git fetch --tags
-        git fetch origin master:master
     - name: Restore previous results
       uses: actions/cache@v2
       with:

--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -1,10 +1,9 @@
 name: Comment Bot
 on:
   issue_comment:
-    types: [created, edited]
+    types: [created]
   pull_request_review_comment:
-    types: [created, edited]
-
+    types: [created]
 jobs:
   tag:  # /tag <tagname> <commit>
     if: startsWith(github.event.comment.body, '/tag ')
@@ -21,7 +20,6 @@ jobs:
           post = (context.eventName == "issue_comment"
             ? github.reactions.createForIssueComment
             : github.reactions.createForPullRequestReviewComment)
-
           if (!["admin", "write"].includes(perm.data.permission)){
             post({
               owner: context.repo.owner, repo: context.repo.repo,
@@ -50,7 +48,3 @@ jobs:
           post({
             owner: context.repo.owner, repo: context.repo.repo,
             comment_id: context.payload.comment.id, content: "rocket"})
-  always:
-    runs-on: ubuntu-latest
-    steps:
-    - run: echo prevent failure when other jobs are skipped

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -919,9 +919,7 @@ For further customisation,
 (e.g. GUIs such as notebook or plotting packages). In the latter case:
 
 1. ``def __init__()`` to call ``super().__init__(..., gui=True)`` to disable
-   terminal ``status_printer`` creation. Otherwise (if terminal is required),
-   ``def __new__()`` to call ``cls.get_new()`` (see below) to ensure correct
-   nested positioning.
+   terminal ``status_printer`` creation.
 2. Redefine: ``close()``, ``clear()``, ``display()``.
 
 Consider overloading ``display()`` to use e.g.
@@ -934,23 +932,6 @@ above recommendation:
 - `tqdm/gui.py <https://github.com/tqdm/tqdm/blob/master/tqdm/gui.py>`__
 - `tqdm/contrib/telegram.py <https://github.com/tqdm/tqdm/blob/master/tqdm/contrib/telegram.py>`__
 - `tqdm/contrib/discord.py <https://github.com/tqdm/tqdm/blob/master/tqdm/contrib/discord.py>`__
-
-Note that multiple different ``tqdm`` subclasses which all write to the terminal
-(``gui=False``) can cause positioning issues when used simultaneously (in nested
-mode). To fix this, custom subclasses which expect to write to the terminal
-should define a ``__new__()`` method as follows:
-
-.. code:: python
-
-    from tqdm import tqdm as std_tqdm
-
-    class TqdmExt(std_tqdm):
-        def __new__(cls, *args, **kwargs):
-            return cls.get_new(super(TqdmExt, cls), std_tqdm, *args, **kwargs)
-
-This approach is used ``tqdm.asyncio`` and ``tqdm.contrib.telegram/discord``.
-However it is not necessary for ``tqdm.notebook/gui`` since they don't use the
-terminal.
 
 Dynamic Monitor/Meter
 ~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -1136,9 +1136,7 @@ For further customisation,
 (e.g. GUIs such as notebook or plotting packages). In the latter case:
 
 1. ``def __init__()`` to call ``super().__init__(..., gui=True)`` to disable
-   terminal ``status_printer`` creation. Otherwise (if terminal is required),
-   ``def __new__()`` to call ``cls.get_new()`` (see below) to ensure correct
-   nested positioning.
+   terminal ``status_printer`` creation.
 2. Redefine: ``close()``, ``clear()``, ``display()``.
 
 Consider overloading ``display()`` to use e.g.
@@ -1151,23 +1149,6 @@ above recommendation:
 - `tqdm/gui.py <https://github.com/tqdm/tqdm/blob/master/tqdm/gui.py>`__
 - `tqdm/contrib/telegram.py <https://github.com/tqdm/tqdm/blob/master/tqdm/contrib/telegram.py>`__
 - `tqdm/contrib/discord.py <https://github.com/tqdm/tqdm/blob/master/tqdm/contrib/discord.py>`__
-
-Note that multiple different ``tqdm`` subclasses which all write to the terminal
-(``gui=False``) can cause positioning issues when used simultaneously (in nested
-mode). To fix this, custom subclasses which expect to write to the terminal
-should define a ``__new__()`` method as follows:
-
-.. code:: python
-
-    from tqdm import tqdm as std_tqdm
-
-    class TqdmExt(std_tqdm):
-        def __new__(cls, *args, **kwargs):
-            return cls.get_new(super(TqdmExt, cls), std_tqdm, *args, **kwargs)
-
-This approach is used ``tqdm.asyncio`` and ``tqdm.contrib.telegram/discord``.
-However it is not necessary for ``tqdm.notebook/gui`` since they don't use the
-terminal.
 
 Dynamic Monitor/Meter
 ~~~~~~~~~~~~~~~~~~~~~

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -62,9 +62,6 @@ class tqdm_asyncio(std_tqdm):
         yield from cls(asyncio.as_completed(fs, loop=loop, timeout=timeout),
                        total=total, **tqdm_kwargs)
 
-    def __new__(cls, *args, **kwargs):
-        return cls.get_new(super(tqdm_asyncio, cls), std_tqdm, *args, **kwargs)
-
 
 def tarange(*args, **kwargs):
     """

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -102,9 +102,6 @@ class tqdm_discord(tqdm_auto):
             fmt['bar_format'] = '{l_bar}{bar:10u}{r_bar}'
         self.dio.write(self.format_meter(**fmt))
 
-    def __new__(cls, *args, **kwargs):
-        return cls.get_new(super(tqdm_discord, cls), tqdm_auto, *args, **kwargs)
-
 
 def tdrange(*args, **kwargs):
     """

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -106,10 +106,6 @@ class tqdm_telegram(tqdm_auto):
             fmt['bar_format'] = '{l_bar}{bar:10u}{r_bar}'
         self.tgio.write(self.format_meter(**fmt))
 
-    def __new__(cls, *args, **kwargs):
-        return cls.get_new(
-            super(tqdm_telegram, cls), tqdm_auto, *args, **kwargs)
-
 
 def ttgrange(*args, **kwargs):
     """


### PR DESCRIPTION
- get rid of `get_new` (#1084, #509)
- minor CI framework optimisations

----

- fixes #1084, fixes #509, partially reverts & improves on #1075