### PR TITLE
Fix formatting of '\n', '\0' in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -467,8 +467,8 @@ Extra CLI Options
 ~~~~~~~~~~~~~~~~~
 
 * delim  : chr, optional  
-    Delimiting character [default: '\n']. Use '\0' for null.
-    N.B.: on Windows systems, Python converts '\n' to '\r\n'.
+    Delimiting character [default: '\\n']. Use '\\0' for null.
+    N.B.: on Windows systems, Python converts '\\n' to '\\r\\n'.
 * buf_size  : int, optional  
     String buffer size in bytes [default: 256]
     used when ``delim`` is specified.


### PR DESCRIPTION
Another option is to use backicks