### PR TITLE
docs: update the simplified `make alltests` instructions to include reference to installing coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ that each distribution has an alias to call the Python interpreter:
 
 Alternatively, use `pytest` to run the tests just for the current Python version:
 
-- install `pytest` and `flake8`
+- install `pytest`, `coverage`, `pytest-cov` and `flake8`
 - run the following command:
 
 ```


### PR DESCRIPTION
The "Alternative unit tests with pytest" instructions in CONTRIBUTING.md no longer work after switching from [nose -> pytest](https://github.com/tqdm/tqdm/pull/1052). You need to also install `coverage` and `pytest-cov` in order to run `make alltests`

```
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]                                                                                           
pytest: error: unrecognized arguments: --cov=tqdm --cov-fail-under=80                                                                                      
```