### PR TITLE
Adding an asyncio.gather() replacement for tqdm

### DIFF
--- a/tests/py37_asyncio.py
+++ b/tests/py37_asyncio.py
@@ -10,6 +10,7 @@ from .tests_tqdm import StringIO, closing, mark
 tqdm = partial(tqdm_asyncio, miniters=0, mininterval=0)
 trange = partial(tarange, miniters=0, mininterval=0)
 as_completed = partial(tqdm_asyncio.as_completed, miniters=0, mininterval=0)
+gather = partial(tqdm_asyncio.gather, miniters=0, mininterval=0)
 
 
 def count(start=0, step=1):
@@ -104,6 +105,25 @@ async def test_as_completed(capsys, tol):
         skew = time() - t
         for i in as_completed([asyncio.sleep(0.01 * i) for i in range(30, 0, -1)]):
             await i
+        t = time() - t - 2 * skew
+        try:
+            assert 0.3 * (1 - tol) < t < 0.3 * (1 + tol), t
+            _, err = capsys.readouterr()
+            assert '30/30' in err
+        except AssertionError:
+            if retry == 2:
+                raise
+
+
+@mark.slow
+@mark.asyncio
+@mark.parametrize("tol", [0.2 if platform.startswith("darwin") else 0.1])
+async def test_gather(capsys, tol):
+    """Test asyncio gather"""
+    for retry in range(3):
+        t = time()
+        skew = time() - t
+        await gather([asyncio.sleep(0.01 * i) for i in range(30, 0, -1)])
         t = time() - t - 2 * skew
         try:
             assert 0.3 * (1 - tol) < t < 0.3 * (1 + tol), t

--- a/tests/py37_asyncio.py
+++ b/tests/py37_asyncio.py
@@ -115,20 +115,14 @@ async def test_as_completed(capsys, tol):
                 raise
 
 
-@mark.slow
+async def double(i):
+    return i * 2
+
+
 @mark.asyncio
-@mark.parametrize("tol", [0.2 if platform.startswith("darwin") else 0.1])
-async def test_gather(capsys, tol):
+async def test_gather(capsys):
     """Test asyncio gather"""
-    for retry in range(3):
-        t = time()
-        skew = time() - t
-        await gather([asyncio.sleep(0.01 * i) for i in range(30, 0, -1)])
-        t = time() - t - 2 * skew
-        try:
-            assert 0.3 * (1 - tol) < t < 0.3 * (1 + tol), t
-            _, err = capsys.readouterr()
-            assert '30/30' in err
-        except AssertionError:
-            if retry == 2:
-                raise
+    res = await gather(list(map(double, range(30))))
+    _, err = capsys.readouterr()
+    assert '30/30' in err
+    assert res == list(range(0, 30 * 2, 2))

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -8,7 +8,7 @@ Usage:
 ...     ...
 """
 import asyncio
-from typing import Awaitable, TypeVar, List
+from typing import Awaitable, List, TypeVar
 
 from .std import tqdm as std_tqdm
 
@@ -89,7 +89,11 @@ class tqdm_asyncio(std_tqdm):
 
         numbered_results = [
             await f for f in cls.as_completed(
-                numbered_awaitables, total=total, loop=loop, timeout=timeout, **tqdm_kwargs
+                numbered_awaitables,
+                total=total,
+                loop=loop,
+                timeout=timeout,
+                **tqdm_kwargs
             )
         ]
 

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -17,7 +17,7 @@ __all__ = ['tqdm_asyncio', 'tarange', 'tqdm', 'trange']
 
 class tqdm_asyncio(std_tqdm):
     """
-    Asynchronous-friendly version of tqdm (Python 3.5+).
+    Asynchronous-friendly version of tqdm (Python 3.6+).
     """
     def __init__(self, iterable=None, *args, **kwargs):
         super(tqdm_asyncio, self).__init__(iterable, *args, **kwargs)

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -67,7 +67,7 @@ class tqdm_asyncio(std_tqdm):
                        total=total, **tqdm_kwargs)
 
     @classmethod
-    def gather(
+    async def gather(
             cls,
             fs: List[Awaitable[T]],
             *,

--- a/tqdm/auto.py
+++ b/tqdm/auto.py
@@ -4,7 +4,7 @@ Enables multiple commonly used features.
 Method resolution order:
 
 - `tqdm.autonotebook` without import warnings
-- `tqdm.asyncio` on Python3.5+
+- `tqdm.asyncio` on Python3.6+
 - `tqdm.std` base class
 
 Usage:
@@ -22,10 +22,10 @@ with warnings.catch_warnings():
     from .autonotebook import tqdm as notebook_tqdm
     from .autonotebook import trange as notebook_trange
 
-if sys.version_info[:2] < (3, 5):
+if sys.version_info[:2] < (3, 6):
     tqdm = notebook_tqdm
     trange = notebook_trange
-else:  # Python3.5+
+else:  # Python3.6+
     from .asyncio import tqdm as asyncio_tqdm
     from .std import tqdm as std_tqdm
 


### PR DESCRIPTION
tqdm's as_completed() is helpful, but does mean results are not in the same order as inputs, which can be frustrating.

I've tried writing a wrapper which emulates the behaviour of asyncio.gather, though I'm not sure whether this conforms to the ideas of the project. (I'm not sure the `typing` import will be well appreciated, at the very least)