### PR TITLE
notebook: support `delay`

### DIFF
--- a/tests_notebook.ipynb
+++ b/tests_notebook.ipynb
@@ -16,6 +16,7 @@
    "outputs": [],
    "source": [
     "from functools import partial\n",
+    "from time import sleep\n",
     "\n",
     "from tqdm.notebook import tqdm_notebook\n",
     "from tqdm.notebook import tnrange\n",
@@ -36,7 +37,7 @@
      "text": [
       "Help on function display in module tqdm.notebook:\n",
       "\n",
-      "display(self, msg=None, pos=None, close=False, bar_style=None)\n",
+      "display(self, msg=None, pos=None, close=False, bar_style=None, check_delay=True)\n",
       "    Use `self.sp` to display `msg` in the specified `pos`.\n",
       "    \n",
       "    Consider overloading this function when inheriting to use e.g.:\n",
@@ -449,6 +450,44 @@
     "    t.update()\n",
     "    print(t)\n",
     "    assert t.colour == 'yellow'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_TEST_NAME: delay no trigger\n",
+    "with tqdm_notebook(total=1, delay=10) as t:\n",
+    "    t.update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fe102eedbb4f437783fbd0cff32f6613",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "100%|##########| 1/1 [00:00<00:00,  7.68it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# NBVAL_TEST_NAME: delay trigger\n",
+    "with tqdm_notebook(total=1, delay=0.1) as t:\n",
+    "    sleep(0.1)\n",
+    "    t.update()"
    ]
   }
  ],

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -258,6 +258,8 @@ class tqdm_notebook(std_tqdm):
         # since this could be a shared bar which the user will `reset()`
 
     def update(self, n=1):
+        if self.disable:
+            return
         if not self.displayed and self.delay > 0:
             display(self.container)
             self.displayed = True

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -234,8 +234,10 @@ class tqdm_notebook(std_tqdm):
         total = self.total * unit_scale if self.total else self.total
         self.container = self.status_printer(self.fp, total, self.desc, self.ncols)
         self.container.pbar = self
-        if display_here:
+        self.displayed = False
+        if display_here and self.delay <= 0:
             display(self.container)
+            self.displayed = True
         self.disp = self.display
         self.colour = colour
 
@@ -256,6 +258,9 @@ class tqdm_notebook(std_tqdm):
         # since this could be a shared bar which the user will `reset()`
 
     def update(self, n=1):
+        if not self.displayed and self.delay > 0:
+            display(self.container)
+            self.displayed = True
         try:
             return super(tqdm_notebook, self).update(n=n)
         # NB: except ... [ as ...] breaks IPython async KeyboardInterrupt


### PR DESCRIPTION
If you specify a delay in a jupyter notebook, the bar will always display regardless.

This PR will also delay the `display` command until the first update, unless display=True.