### PR TITLE
fix Display wrong epoch on Keras resume training

### DIFF
--- a/tests/tests_keras.py
+++ b/tests/tests_keras.py
@@ -38,9 +38,7 @@ def test_keras(capsys):
                 desc="training",
                 data_size=len(x),
                 batch_size=batch_size,
-                verbose=0,
-            )],
-    )
+                verbose=0)])
     _, res = capsys.readouterr()
     assert "training: " in res
     assert "{epochs}/{epochs}".format(epochs=epochs) in res
@@ -59,9 +57,7 @@ def test_keras(capsys):
                 desc="training",
                 data_size=len(x),
                 batch_size=batch_size,
-                verbose=2,
-            )],
-    )
+                verbose=2)])
     _, res = capsys.readouterr()
     assert "training: " in res
     assert "{epochs}/{epochs}".format(epochs=epochs) in res
@@ -74,8 +70,7 @@ def test_keras(capsys):
         epochs=epochs,
         batch_size=batch_size,
         verbose=False,
-        callbacks=[TqdmCallback(desc="training", verbose=2)],
-    )
+        callbacks=[TqdmCallback(desc="training", verbose=2)])
     _, res = capsys.readouterr()
     assert "training: " in res
     assert "{epochs}/{epochs}".format(epochs=epochs) in res
@@ -90,12 +85,9 @@ def test_keras(capsys):
         epochs=epochs,
         batch_size=batch_size,
         verbose=False,
-        callbacks=[TqdmCallback(
-            desc="training",
-            verbose=2
-        )],
-    )
+        callbacks=[TqdmCallback(desc="training", verbose=0,
+                                miniters=1, mininterval=0, maxinterval=0)])
     _, res = capsys.readouterr()
     assert "training: " in res
+    assert "{epochs}/{epochs}".format(epochs=initial_epoch - 1) not in res
     assert "{epochs}/{epochs}".format(epochs=epochs) in res
-    assert "{batches}/{batches}".format(batches=batches) in res

--- a/tests/tests_keras.py
+++ b/tests/tests_keras.py
@@ -80,3 +80,22 @@ def test_keras(capsys):
     assert "training: " in res
     assert "{epochs}/{epochs}".format(epochs=epochs) in res
     assert "{batches}/{batches}".format(batches=batches) in res
+
+    # continue training (start from epoch != 0)
+    initial_epoch = 3
+    model.fit(
+        x,
+        x,
+        initial_epoch=initial_epoch,
+        epochs=epochs,
+        batch_size=batch_size,
+        verbose=False,
+        callbacks=[TqdmCallback(
+            desc="training",
+            verbose=2
+        )],
+    )
+    _, res = capsys.readouterr()
+    assert "training: " in res
+    assert "{epochs}/{epochs}".format(epochs=epochs) in res
+    assert "{batches}/{batches}".format(batches=batches) in res

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -69,10 +69,12 @@ class TqdmCallback(keras.callbacks.Callback):
     def on_train_begin(self, *_, **__):
         params = self.params.get
         auto_total = params('epochs', params('nb_epoch', None))
-        if auto_total is not None:
+        if auto_total is not None and auto_total != self.epoch_bar.total:
             self.epoch_bar.reset(total=auto_total)
 
-    def on_epoch_begin(self, *_, **__):
+    def on_epoch_begin(self, epoch, *_, **__):
+        if self.epoch_bar.n < epoch:
+            self.epoch_bar.update(epoch-self.epoch_bar.n)
         if self.verbose:
             params = self.params.get
             total = params('samples', params(

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -74,7 +74,8 @@ class TqdmCallback(keras.callbacks.Callback):
 
     def on_epoch_begin(self, epoch, *_, **__):
         if self.epoch_bar.n < epoch:
-            self.epoch_bar.update(epoch-self.epoch_bar.n)
+            ebar = self.epoch_bar
+            ebar.n = ebar.last_print_n = ebar.initial = epoch
         if self.verbose:
             params = self.params.get
             total = params('samples', params(


### PR DESCRIPTION
This fix `TqdmCallback` showing wrong information about epochs when resume training with `initial_epoch != 0`  as was reported on #1138 

The test has been provided but also the Colab example provided by @fabiocarrara  [here](https://colab.research.google.com/drive/1WMKllAs_edpU_kAV9klYk7q1lsP9DXwm?usp=sharing):