### PR TITLE
Fix typo

### DIFF
--- a/tests/tests_contrib_logging.py
+++ b/tests/tests_contrib_logging.py
@@ -124,7 +124,7 @@ class TestRedirectLoggingToTqdm:
         with logging_redirect_tqdm(loggers=[logger]):
             assert logger.handlers[0].formatter == formatter
 
-    def test_should_not_remove_stream_handlers_not_fot_stdout_or_stderr(self):
+    def test_should_not_remove_stream_handlers_not_for_stdout_or_stderr(self):
         logger = logging.Logger('test')
         stream_handler = logging.StreamHandler(StringIO())
         logger.addHandler(stream_handler)


### PR DESCRIPTION
- Fix typo in `contrib.logging` tests