### PR TITLE
Gracefully handle empty COLUMNS/LINES env vars on Linux.

### DIFF
--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -285,7 +285,7 @@ def _screen_shape_linux(fp):  # pragma: no cover
         except Exception:
             try:
                 return [int(os.environ[i]) - 1 for i in ("COLUMNS", "LINES")]
-            except KeyError:
+            except (KeyError, ValueError):
                 return None, None
 
 


### PR DESCRIPTION
This is related to https://github.com/conda/conda/issues/10673 where tqdm is used internally and a user reported an error with the `_screen_shape_linux` function.