### PR TITLE
Raise exception in iter() when trying to iterate over tqdm with no underlying iterator

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -13,7 +13,7 @@ from warnings import catch_warnings, simplefilter
 
 from pytest import importorskip, mark, raises, skip
 
-from tqdm import TqdmDeprecationWarning, TqdmWarning, tqdm, trange
+from tqdm import TqdmValueError, TqdmDeprecationWarning, TqdmWarning, tqdm, trange
 from tqdm.contrib import DummyTqdmFile
 from tqdm.std import EMA, Bar
 
@@ -2007,3 +2007,21 @@ def test_closed():
         for i in trange(9, file=our_file, miniters=1, mininterval=0):
             if i == 5:
                 our_file.close()
+
+
+def test_manual_mode_iter_raises():
+    with closing(StringIO()) as our_file:
+        # control check
+        t = tqdm([1, 2, 3], file=our_file)
+        iter(t)  # shouldn't raise
+        for _ in t:
+            pass
+
+        # raises when not wrapping an iterable ("manual mode")
+        with tqdm(file=our_file) as t:
+            with raises(TqdmValueError):
+                iter(t)
+
+            with raises(TqdmValueError):
+                for _ in t:
+                    pass

--- a/tqdm/__init__.py
+++ b/tqdm/__init__.py
@@ -5,12 +5,12 @@ from .gui import tqdm as tqdm_gui  # TODO: remove in v5.0.0
 from .gui import trange as tgrange  # TODO: remove in v5.0.0
 from .std import (
     TqdmDeprecationWarning, TqdmExperimentalWarning, TqdmKeyError, TqdmMonitorWarning,
-    TqdmTypeError, TqdmWarning, tqdm, trange)
+    TqdmTypeError, TqdmValueError, TqdmWarning, tqdm, trange)
 from .version import __version__
 
 __all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_pandas',
            'tqdm_notebook', 'tnrange', 'main', 'TMonitor',
-           'TqdmTypeError', 'TqdmKeyError',
+           'TqdmTypeError', 'TqdmKeyError', 'TqdmValueError',
            'TqdmWarning', 'TqdmDeprecationWarning',
            'TqdmExperimentalWarning',
            'TqdmMonitorWarning', 'TqdmSynchronisationWarning',

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -26,7 +26,7 @@ from .utils import (
 
 __author__ = "https://github.com/tqdm/tqdm#contributions"
 __all__ = ['tqdm', 'trange',
-           'TqdmTypeError', 'TqdmKeyError', 'TqdmWarning',
+           'TqdmTypeError', 'TqdmKeyError', 'TqdmValueError', 'TqdmWarning',
            'TqdmExperimentalWarning', 'TqdmDeprecationWarning',
            'TqdmMonitorWarning']
 
@@ -36,6 +36,10 @@ class TqdmTypeError(TypeError):
 
 
 class TqdmKeyError(KeyError):
+    pass
+
+
+class TqdmValueError(ValueError):
     pass
 
 
@@ -1156,7 +1160,13 @@ class tqdm(Comparable):
 
     def __iter__(self):
         """Backward-compatibility to use: for x in tqdm(iterable)"""
+        # check that we actually have an iterable
+        if self.iterable is None:
+            raise TqdmValueError(f"{self} isn't wrapping any iterable (manual mode)")
+        return self._iter()
 
+    def _iter(self):
+        """Internal hook for the actual implementation of __iter__."""
         # Inlining instance variables as locals (speed optimisation)
         iterable = self.iterable
 


### PR DESCRIPTION
Trying to iterate over a `tqdm` object in manual mode (i.e. that isn't wrapping around any iterable) will result in an error, as there is no underlying iterable to yield from.

This PR is to replace the slightly more cryptic "None object is not iterable" you get currently with a more explicit error. Also, by calling this as soon as iter() is called---and not when the iterator is first advanced---, this kind of mistake is caught earlier. (This is the reason I had to write a separate `_iter`, because the implementation was a generator and so calling `__iter__` wouldn't have immediately run the validation code.)

I added a `TqdmValueError` exception class, I wasn't sure what error to use.