### PR TITLE
Use weakref on tqdm instance in DisableOnWriteError

### DIFF
--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -4,9 +4,9 @@ General helpers required for `tqdm.std`.
 import os
 import re
 import sys
-import weakref
 from functools import wraps
 from warnings import warn
+from weakref import proxy
 
 # py2/3 compat
 try:
@@ -138,22 +138,25 @@ class DisableOnWriteError(ObjectWrapper):
         """
         Quietly set `tqdm_instance.miniters=inf` if `func` raises `errno=5`.
         """
-        tqdm_instance_ref = weakref.ref(tqdm_instance)
+        tqdm_instance = proxy(tqdm_instance)
 
         def inner(*args, **kwargs):
-            tqdm_instance = tqdm_instance_ref()
             try:
                 return func(*args, **kwargs)
             except OSError as e:
                 if e.errno != 5:
                     raise
-                if tqdm_instance is not None:
+                try:
                     tqdm_instance.miniters = float('inf')
+                except ReferenceError:
+                    pass
             except ValueError as e:
                 if 'closed' not in str(e):
                     raise
-                if tqdm_instance is not None:
+                try:
                     tqdm_instance.miniters = float('inf')
+                except ReferenceError:
+                    pass
         return inner
 
     def __init__(self, wrapped, tqdm_instance):


### PR DESCRIPTION
This PR fixes a PermissionError on Windows when deleting objects caused by the reference cycle in `DisableOnWriteError`. The solution is to wrap the tqdm instance in `weakref.ref` in `DisableOnWriteError.disable_on_exception` to break the cycle.