### PR TITLE
`asyncio.gather` API consistency with stdlib

### DIFF
--- a/tests/py37_asyncio.py
+++ b/tests/py37_asyncio.py
@@ -122,7 +122,7 @@ async def double(i):
 @mark.asyncio
 async def test_gather(capsys):
     """Test asyncio gather"""
-    res = await gather(list(map(double, range(30))))
+    res = await gather(*map(double, range(30)))
     _, err = capsys.readouterr()
     assert '30/30' in err
     assert res == list(range(0, 30 * 2, 2))

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -68,7 +68,7 @@ class tqdm_asyncio(std_tqdm):
                        total=total, **tqdm_kwargs)
 
     @classmethod
-    async def gather(cls, fs, *, loop=None, timeout=None, total=None, **tqdm_kwargs):
+    async def gather(cls, *fs, loop=None, timeout=None, total=None, **tqdm_kwargs):
         """
         Wrapper for `asyncio.gather`.
         """


### PR DESCRIPTION
Intended as a drop-in replacement of the stdlib `asyncio.gather()`, it would be much reasonable if the function interface is consistent with that of `asyncio.gather()` as well.

It also ensures that our interface doesn't violate the least-surprising principle. It would have been surprising and frustrating for a user to wanting to use `tqdm_asyncio.gather()` as a drop-in replacement to the stdlib `asyncio.gather()` but ending up being bitten by the trivial inconsistency.