### PR TITLE
Use standard tqdm if import ipywidgets fails in notebook

### DIFF
--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -15,6 +15,7 @@ try:
         raise ImportError("console")
     if 'VSCODE_PID' in os.environ:  # pragma: no cover
         raise ImportError("vscode")
+    import ipywidgets
 except Exception:
     from .std import tqdm, trange
 else:  # pragma: no cover

--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -15,7 +15,7 @@ try:
         raise ImportError("console")
     if 'VSCODE_PID' in os.environ:  # pragma: no cover
         raise ImportError("vscode")
-    import ipywidgets
+    import ipywidgets  # noqa: F401
 except Exception:
     from .std import tqdm, trange
 else:  # pragma: no cover


### PR DESCRIPTION
Using `tqdm` imported from `tqdm.auto` in jupyter notebook will fail if `ipywidgets` is not available.
The current behaviour means that a user with a minimum install of jupyter notebook will not be able to use packages that "naively" utilize `tqdm.auto` but do not rely on `ipywidgets`.

This PR lets `tqdm.auto` revert to using the standard tqdm progress bar if the HTML one is unavailable. 

Fixes #1082, #1072.

Test by creating an environment without ipywidgets (ie. `conda create -n test notebook` and calling the code below:

```python
from tqdm.auto import tqdm as tqdm_auto
for i in tqdm_auto(range(10)):
    pass
```

I ran into this issue coming from using the Dask tqdm Callback: #1217.