### PR TITLE
Avoid telegram limit hit

### DIFF
--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -107,8 +107,8 @@ class tqdm_telegram(tqdm_auto):
             self.tgio = TelegramIO(
                 kwargs.pop('token', getenv('TQDM_TELEGRAM_TOKEN')),
                 kwargs.pop('chat_id', getenv('TQDM_TELEGRAM_CHAT_ID')))
-        super(tqdm_telegram, self).__init__(*args, **kwargs)
         self._last_display_operation_time = 0
+        super(tqdm_telegram, self).__init__(*args, **kwargs)
 
     def display(self, **kwargs):
         super(tqdm_telegram, self).display(**kwargs)

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -9,6 +9,7 @@ Usage:
 ![screenshot](https://img.tqdm.ml/screenshot-telegram.gif)
 """
 from __future__ import absolute_import
+from warnings import warn
 
 from os import getenv
 
@@ -42,6 +43,8 @@ class TelegramIO(MonoWorker):
         except Exception as e:
             tqdm_auto.write(str(e))
         else:
+            if res.json().get('error_code') == 429:
+                warn("Too Many Requests. See https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this")
             self.message_id = res.json()['result']['message_id']
 
     def write(self, s):
@@ -102,7 +105,7 @@ class tqdm_telegram(tqdm_auto):
             Minimum progress display update interval [default: 1.0] seconds.
             Override the default mininterval to Avoids "Too Many Requests" Error
             See https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
-
+            
         See `tqdm.auto.tqdm.__init__` for other parameters.
         """
         if not kwargs.get('disable'):


### PR DESCRIPTION
Using tqdm.contrib.telegram.tqdm with fast iteration results in "Too Many Requests" Error.

This issue is submitted in https://github.com/tqdm/tqdm/issues/1220.
