### PR TITLE
next release v4.62.1

### DIFF
--- a/tests/tests_contrib_logging.py
+++ b/tests/tests_contrib_logging.py
@@ -10,7 +10,7 @@ from io import StringIO
 import pytest
 
 from tqdm import tqdm
-from tqdm.contrib.logging import _get_first_found_console_logging_formatter
+from tqdm.contrib.logging import _get_first_found_console_logging_handler
 from tqdm.contrib.logging import _TqdmLoggingHandler as TqdmLoggingHandler
 from tqdm.contrib.logging import logging_redirect_tqdm, tqdm_logging_redirect
 
@@ -68,33 +68,25 @@ class TestTqdmLoggingHandler:
             logger.info('test')
 
 
-class TestGetFirstFoundConsoleLoggingFormatter:
+class TestGetFirstFoundConsoleLoggingHandler:
     def test_should_return_none_for_no_handlers(self):
-        assert _get_first_found_console_logging_formatter([]) is None
+        assert _get_first_found_console_logging_handler([]) is None
 
     def test_should_return_none_without_stream_handler(self):
         handler = logging.handlers.MemoryHandler(capacity=1)
-        handler.formatter = TEST_LOGGING_FORMATTER
-        assert _get_first_found_console_logging_formatter([handler]) is None
+        assert _get_first_found_console_logging_handler([handler]) is None
 
     def test_should_return_none_for_stream_handler_not_stdout_or_stderr(self):
         handler = logging.StreamHandler(StringIO())
-        handler.formatter = TEST_LOGGING_FORMATTER
-        assert _get_first_found_console_logging_formatter([handler]) is None
+        assert _get_first_found_console_logging_handler([handler]) is None
 
-    def test_should_return_stream_handler_formatter_if_stream_is_stdout(self):
+    def test_should_return_stream_handler_if_stream_is_stdout(self):
         handler = logging.StreamHandler(sys.stdout)
-        handler.formatter = TEST_LOGGING_FORMATTER
-        assert _get_first_found_console_logging_formatter(
-            [handler]
-        ) == TEST_LOGGING_FORMATTER
+        assert _get_first_found_console_logging_handler([handler]) == handler
 
-    def test_should_return_stream_handler_formatter_if_stream_is_stderr(self):
+    def test_should_return_stream_handler_if_stream_is_stderr(self):
         handler = logging.StreamHandler(sys.stderr)
-        handler.formatter = TEST_LOGGING_FORMATTER
-        assert _get_first_found_console_logging_formatter(
-            [handler]
-        ) == TEST_LOGGING_FORMATTER
+        assert _get_first_found_console_logging_handler([handler]) == handler
 
 
 class TestRedirectLoggingToTqdm:

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,8 @@ deps=
     matplotlib
     numpy
     pandas
-    keras: keras
+    py27-keras: keras<2.5
+    !py27-keras: keras
     py3{6,7,8,9}: rich
     tf: tensorflow!=2.5.0
 commands=

--- a/tqdm/contrib/__init__.py
+++ b/tqdm/contrib/__init__.py
@@ -6,9 +6,9 @@ Subpackages contain potentially unstable extensions.
 import sys
 from functools import wraps
 
-from tqdm import tqdm
-from tqdm.auto import tqdm as tqdm_auto
-from tqdm.utils import ObjectWrapper
+from ..auto import tqdm as tqdm_auto
+from ..std import tqdm
+from ..utils import ObjectWrapper
 
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['tenumerate', 'tzip', 'tmap']

--- a/tqdm/contrib/bells.py
+++ b/tqdm/contrib/bells.py
@@ -13,11 +13,11 @@ import warnings
 from os import getenv
 
 if getenv("TQDM_TELEGRAM_TOKEN") and getenv("TQDM_TELEGRAM_CHAT_ID"):
-    from tqdm.contrib.telegram import tqdm, trange
+    from .telegram import tqdm, trange
 elif getenv("TQDM_DISCORD_TOKEN") and getenv("TQDM_DISCORD_CHANNEL_ID"):
-    from tqdm.contrib.discord import tqdm, trange
+    from .discord import tqdm, trange
 else:
-    from tqdm.auto import tqdm, trange
+    from ..auto import tqdm, trange
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", category=FutureWarning)

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import
 
 from contextlib import contextmanager
 
-from tqdm import TqdmWarning
-from tqdm.auto import tqdm as tqdm_auto
+from ..auto import tqdm as tqdm_auto
+from ..std import TqdmWarning
 
 try:
     from operator import length_hint

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -18,9 +18,8 @@ try:
 except ImportError:
     raise ImportError("Please `pip install disco-py`")
 
-from tqdm.auto import tqdm as tqdm_auto
-from tqdm.utils import _range
-
+from ..auto import tqdm as tqdm_auto
+from ..utils import _range
 from .utils_worker import MonoWorker
 
 __author__ = {"github.com/": ["casperdcl"]}

--- a/tqdm/contrib/itertools.py
+++ b/tqdm/contrib/itertools.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import itertools
 
-from tqdm.auto import tqdm as tqdm_auto
+from ..auto import tqdm as tqdm_auto
 
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['product']

--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -26,7 +26,7 @@ class _TqdmLoggingHandler(logging.StreamHandler):
     def emit(self, record):
         try:
             msg = self.format(record)
-            self.tqdm_class.write(msg)
+            self.tqdm_class.write(msg, file=self.stream)
             self.flush()
         except (KeyboardInterrupt, SystemExit):
             raise
@@ -39,10 +39,10 @@ def _is_console_logging_handler(handler):
             and handler.stream in {sys.stdout, sys.stderr})
 
 
-def _get_first_found_console_logging_formatter(handlers):
+def _get_first_found_console_logging_handler(handlers):
     for handler in handlers:
         if _is_console_logging_handler(handler):
-            return handler.formatter
+            return handler
 
 
 @contextmanager
@@ -85,8 +85,10 @@ def logging_redirect_tqdm(
     try:
         for logger in loggers:
             tqdm_handler = _TqdmLoggingHandler(tqdm_class)
-            tqdm_handler.setFormatter(
-                _get_first_found_console_logging_formatter(logger.handlers))
+            orig_handler = _get_first_found_console_logging_handler(logger.handlers)
+            if orig_handler is not None:
+                tqdm_handler.setFormatter(orig_handler.formatter)
+                tqdm_handler.stream = orig_handler.stream
             logger.handlers = [
                 handler for handler in logger.handlers
                 if not _is_console_logging_handler(handler)] + [tqdm_handler]

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -14,9 +14,8 @@ from os import getenv
 
 from requests import Session
 
-from tqdm.auto import tqdm as tqdm_auto
-from tqdm.utils import _range
-
+from ..auto import tqdm as tqdm_auto
+from ..utils import _range
 from .utils_worker import MonoWorker
 
 __author__ = {"github.com/": ["casperdcl"]}

--- a/tqdm/contrib/utils_worker.py
+++ b/tqdm/contrib/utils_worker.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 
-from tqdm.auto import tqdm as tqdm_auto
+from ..auto import tqdm as tqdm_auto
 
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['MonoWorker']


### PR DESCRIPTION
- `contrib.logging`: inherit existing handler output stream (#1191)
- fix `PermissionError` by using `weakref` in `DisableOnWriteError` (#1207)
- fix `contrib.telegram` creation rate limit handling (#1223, #1221 <- #1220, #1076)
- misc tidy: relative imports

----

- closes #1191
- closes #1207
- fixes #1220
  - closes #1223
  - fixes #1076
  - replaces/closes #1221