### PR TITLE
Inherit the log level from the console logger

### DIFF
--- a/tests/tests_contrib_logging.py
+++ b/tests/tests_contrib_logging.py
@@ -116,6 +116,15 @@ class TestRedirectLoggingToTqdm:
         with logging_redirect_tqdm(loggers=[logger]):
             assert logger.handlers[0].formatter == formatter
 
+    def test_should_inherit_console_logger_level(self):
+        logger = logging.Logger('test')
+        level = logging.INFO
+        console_handler = logging.StreamHandler(sys.stderr)
+        console_handler.setLevel(level)
+        logger.handlers = [console_handler]
+        with logging_redirect_tqdm(loggers=[logger]):
+            assert logger.handlers[0].level == level
+
     def test_should_not_remove_stream_handlers_not_for_stdout_or_stderr(self):
         logger = logging.Logger('test')
         stream_handler = logging.StreamHandler(StringIO())

--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -88,6 +88,7 @@ def logging_redirect_tqdm(
             orig_handler = _get_first_found_console_logging_handler(logger.handlers)
             if orig_handler is not None:
                 tqdm_handler.setFormatter(orig_handler.formatter)
+                tqdm_handler.setLevel(orig_handler.level)
                 tqdm_handler.stream = orig_handler.stream
             logger.handlers = [
                 handler for handler in logger.handlers


### PR DESCRIPTION
At the moment `logging_redirect_tqdm` does not inherit the log level from the console logger. This pull request fixes the problem. Fixes #1272.