### PR TITLE
Ensure that stderr/stdout has flush attr before calling it

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -336,10 +336,8 @@ class tqdm(Comparable):
         fp = file
         fp_flush = getattr(fp, 'flush', lambda: None)  # pragma: no cover
         if fp in (sys.stderr, sys.stdout):
-            if hasattr(sys.stderr, 'flush'):
-                sys.stderr.flush()
-            if hasattr(sys.stdout, 'flush'):
-                sys.stdout.flush()
+            getattr(sys.stderr, 'flush', lambda: None)()
+            getattr(sys.stdout, 'flush', lambda: None)()
 
         def fp_write(s):
             fp.write(_unicode(s))
@@ -1457,7 +1455,7 @@ class tqdm(Comparable):
     def moveto(self, n):
         # TODO: private method
         self.fp.write(_unicode('\n' * n + _term_move_up() * -n))
-        self.fp.flush()
+        getattr(self.fp, 'flush', lambda: None)()
 
     @property
     def format_dict(self):

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -336,8 +336,10 @@ class tqdm(Comparable):
         fp = file
         fp_flush = getattr(fp, 'flush', lambda: None)  # pragma: no cover
         if fp in (sys.stderr, sys.stdout):
-            sys.stderr.flush()
-            sys.stdout.flush()
+            if hasattr(sys.stderr, 'flush'):
+                sys.stderr.flush()
+            if hasattr(sys.stdout, 'flush'):
+                sys.stdout.flush()
 
         def fp_write(s):
             fp.write(_unicode(s))


### PR DESCRIPTION
The recent commit 63f427b0b8be2102bcc8251d7548e0f51b81f00e (which was evidently in response to #1177) is leading to errors in some cases.  It turns out that `sys.stdout` and `sys.stderr` can be `None` in some cases, as mentioned in the note at the bottom of [this section](https://docs.python.org/3.9/library/sys.html#sys.__stdin__) in the python docs.  (This is news to me, and the cases I've encountered this in are not like what the docs suggest.)  When they are `None` [an error occurs inside `tqdm`](https://github.com/sxs-collaboration/sxs/runs/3588413424?check_suite_focus=true#step:7:67) because obviously `None.flush()` does not exist.

This PR just checks that `stderr` and `stdout` actually have a `flush` attribute before using that attribute.  Note that we can't just reuse `fp_flush` because the point of #1177 was that *both* `stdout` and `stderr` need to be flushed.

---

For reference, I've encountered the bug on two systems:

1. Ubuntu 20.04.3 LTS with Python 3.9.6 and tqdm 4.62.2 (via github actions, for which the traceback is [here](https://github.com/sxs-collaboration/sxs/runs/3588413424?check_suite_focus=true#step:7:67))
2. Debian 4.19.160-2 with Python 3.7.3.  This is through [a bug report on an unrelated repo](/moble/sxs_notebooks/issues/1), so I can't actually check the tqdm version, but I'll bet it's >=4.61.2.

