### PR TITLE
Fix initial render in `wrapattr` with `bytes=True`

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1525,11 +1525,13 @@ class tqdm(Comparable):
         ...         if not chunk:
         ...             break
         """
+        if bytes:
+            tqdm_kwargs.update(
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024
+            )
         with cls(total=total, **tqdm_kwargs) as t:
-            if bytes:
-                t.unit = "B"
-                t.unit_scale = True
-                t.unit_divisor = 1024
             yield CallbackIOWrapper(t.update, stream, method)
 
 


### PR DESCRIPTION
Simple change to fix the initial render of bars created with `wrapattr` with `bytes=True`.

Because the unit and scale were added after creation, the bar would need at least one update before they would actually apply. Simply setting them before creation fixes the issue.