### PR TITLE
Fix bug where the thread monitor checks miniter instead of mininterval

### DIFF
--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -74,7 +74,7 @@ class TMonitor(Thread):
                     # Only if mininterval > 1 (else iterations are just slow)
                     # and last refresh exceeded maxinterval
                     if (
-                        instance.miniters > 1
+                        instance.mininterval > 1
                         and (cur_t - instance.last_print_t) >= instance.maxinterval
                     ):
                         # force bypassing miniters on next iteration


### PR DESCRIPTION
The comment above the condition of the monitoring thread that makes it
refresh the progress bar, states that the refreshing should happen only
if the mininterval of the instance is greater than 1 second, but instead
the miniter of the interval is checked.

Additionally, since we force set the miniter to 1 to bypass the user set
value, this condition could be true at most once, which caused the
monitoring thread to not refresh the progress bar according to
maxinterval.