### PR TITLE
Ensure that data files are installed even when dist-info is regenerated

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include tqdm/tqdm.1
+include tqdm/completion.sh


### PR DESCRIPTION
Similarly to https://github.com/pypa/auditwheel/issues/321
I was struggling when we package this in Fedora.
The fact is that we re-generate the dist-info with
`prepare_metadata_for_build_wheel` hook and when the files are
not mentioned here, they are omitted.