### PR TITLE
docs: fix custom callback example typo

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -757,7 +757,7 @@ custom callback take advantage of this, simply use the return value of
 
     class TqdmExt(std_tqdm):
         def update(self, n=1):
-            displayed = super(TqdmExt, self).update(n):
+            displayed = super(TqdmExt, self).update(n)
             if displayed:
                 external_callback(**self.format_dict)
             return displayed

--- a/README.rst
+++ b/README.rst
@@ -976,7 +976,7 @@ custom callback take advantage of this, simply use the return value of
 
     class TqdmExt(std_tqdm):
         def update(self, n=1):
-            displayed = super(TqdmExt, self).update(n):
+            displayed = super(TqdmExt, self).update(n)
             if displayed:
                 external_callback(**self.format_dict)
             return displayed


### PR DESCRIPTION
Small typo fix in custom callback code example.

Thanks for this amazing library, btw!
