### PR TITLE
next release v4.63.2

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -757,7 +757,7 @@ custom callback take advantage of this, simply use the return value of
 
     class TqdmExt(std_tqdm):
         def update(self, n=1):
-            displayed = super(TqdmExt, self).update(n):
+            displayed = super(TqdmExt, self).update(n)
             if displayed:
                 external_callback(**self.format_dict)
             return displayed

--- a/README.rst
+++ b/README.rst
@@ -976,7 +976,7 @@ custom callback take advantage of this, simply use the return value of
 
     class TqdmExt(std_tqdm):
         def update(self, n=1):
-            displayed = super(TqdmExt, self).update(n):
+            displayed = super(TqdmExt, self).update(n)
             if displayed:
                 external_callback(**self.format_dict)
             return displayed

--- a/environment.yml
+++ b/environment.yml
@@ -36,10 +36,10 @@ dependencies:
 - wheel              # `setup.py bdist_wheel`
 # `cd docs && pymake`
 - mkdocs-material
-- pydoc-markdown >=3.3.0
+- pydoc-markdown >=4.6.0
 - pygments
 - pymdown-extensions
 - pip:
   - py-make >=0.1.0  # `setup.py make/pymake`
   - mkdocs-minify-plugin                                   # `cd docs && pymake`
-  - git+git://github.com/tqdm/jsmin@python3-only#egg=jsmin # `cd docs && pymake`
+  - git+https://github.com/tqdm/jsmin@python3-only#egg=jsmin # `cd docs && pymake`

--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -6,7 +6,6 @@ Usage:
 >>> for i in trange(10):
 ...     ...
 """
-import os
 import sys
 from warnings import warn
 
@@ -14,8 +13,6 @@ try:
     get_ipython = sys.modules['IPython'].get_ipython
     if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover
         raise ImportError("console")
-    if 'VSCODE_PID' in os.environ:  # pragma: no cover
-        raise ImportError("vscode")
     from .notebook import WARN_NOIPYW, IProgress
     if IProgress is None:
         from .std import TqdmWarning

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -84,12 +84,15 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
         ----------
         progress  : tuple, optional
             arguments for `rich.progress.Progress()`.
+        options  : dict, optional
+            keyword arguments for `rich.progress.Progress()`.
         """
         kwargs = kwargs.copy()
         kwargs['gui'] = True
         # convert disable = None to False
         kwargs['disable'] = bool(kwargs.get('disable', False))
         progress = kwargs.pop('progress', None)
+        options = kwargs.pop('options', {}).copy()
         super(tqdm_rich, self).__init__(*args, **kwargs)
 
         if self.disable:
@@ -108,7 +111,8 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
                 ",", RateColumn(unit=d['unit'], unit_scale=d['unit_scale'],
                                 unit_divisor=d['unit_divisor']), "]"
             )
-        self._prog = Progress(*progress, transient=not self.leave)
+        options.setdefault('transient', not self.leave)
+        self._prog = Progress(*progress, **options)
         self._prog.__enter__()
         self._task_id = self._prog.add_task(self.desc or "", **d)
 

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -672,7 +672,7 @@ class tqdm(Comparable):
             | groupby.(generic.)SeriesGroupBy
             ).progress_apply
 
-        A new instance will be create every time `progress_apply` is called,
+        A new instance will be created every time `progress_apply` is called,
         and each instance will automatically `close()` upon completion.
 
         Parameters


### PR DESCRIPTION
- `rich`: expose `options` kwargs (#1282)
- `autonotebook`: re-enable VSCode (#1309)
- build: fix dev deps URL
- docs: fix typos (#1301, #1299)


---

- replaces/closes #1282
- closes #1309
- closes #1301
- closes #1299