### PR TITLE
Update logging.py to deal with comet_ml

### DIFF
--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -36,7 +36,7 @@ class _TqdmLoggingHandler(logging.StreamHandler):
 
 def _is_console_logging_handler(handler):
     return (isinstance(handler, logging.StreamHandler)
-            and handler.stream in {sys.stdout, sys.stderr})
+            and handler.stream.name in {'<stdout>', '<stderr>'})
 
 
 def _get_first_found_console_logging_handler(handlers):
@@ -88,7 +88,8 @@ def logging_redirect_tqdm(
             orig_handler = _get_first_found_console_logging_handler(logger.handlers)
             if orig_handler is not None:
                 tqdm_handler.setFormatter(orig_handler.formatter)
-                tqdm_handler.stream = orig_handler.stream
+                tqdm_handler.stream = sys.stderr if \
+                    orig_handler.stream.name == '<stderr>' else sys.stdout
             logger.handlers = [
                 handler for handler in logger.handlers
                 if not _is_console_logging_handler(handler)] + [tqdm_handler]

--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -35,8 +35,11 @@ class _TqdmLoggingHandler(logging.StreamHandler):
 
 
 def _is_console_logging_handler(handler):
-    return (isinstance(handler, logging.StreamHandler)
-            and handler.stream.name in {'<stdout>', '<stderr>'})
+    is_std_name = False
+    if hasattr(handler.stream, 'name'):
+        is_std_name = handler.stream.name in {'<stdout>', '<stderr>'}
+    return (isinstance(handler, logging.StreamHandler) and
+            (is_std_name or handler.stream in {sys.stdout, sys.stderr}))
 
 
 def _get_first_found_console_logging_handler(handlers):
@@ -88,8 +91,11 @@ def logging_redirect_tqdm(
             orig_handler = _get_first_found_console_logging_handler(logger.handlers)
             if orig_handler is not None:
                 tqdm_handler.setFormatter(orig_handler.formatter)
-                tqdm_handler.stream = sys.stderr if \
-                    orig_handler.stream.name == '<stderr>' else sys.stdout
+                try:
+                    tqdm_handler.stream = sys.stderr if \
+                        orig_handler.stream.name == '<stderr>' else sys.stdout
+                except AttributeError:
+                    tqdm_handler.stream = orig_handler.stream
             logger.handlers = [
                 handler for handler in logger.handlers
                 if not _is_console_logging_handler(handler)] + [tqdm_handler]


### PR DESCRIPTION
Hi,

When using comet in a project, the tqdm_logging_redirect fails (in duplicates messages). After searching, this comes from the
method tqdm.contrib.logging._is_console_logging_handler.

Without a comet environment, I get both sys.stderr and handler.stream as: `<_io.TextIOWrapper name='' mode='w' encoding='utf-8'>`.

However, with the comet environment, I get sys.stderr: `<comet_ml.console.Unbuffered object at 0x7fb7684e2af0>` but the handler.stream is still as before. 

Changing as proposed worked in my case, both when activating comet_ml or not. I hope this fix works in all cases.


Environment of test:
4.64.0 3.8.10 (default, Mar 15 2022, 12:22:08)
[GCC 9.4.0] linux