### PR TITLE
iterable comparison

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.3.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1382,32 +1382,54 @@ def test_deprecated_gui():
             assert hasattr(t, "sp")
 
 
-def test_cmp():
+def test_cmp(capsys):
     """Test comparison functions"""
-    with closing(StringIO()) as our_file:
-        t0 = tqdm(total=10, file=our_file)
-        t1 = tqdm(total=10, file=our_file)
-        t2 = tqdm(total=10, file=our_file)
+    t0 = tqdm(total=10)
+    t1 = tqdm(total=10)
+    t2 = tqdm(total=10)
 
-        assert t0 < t1
-        assert t2 >= t0
-        assert t0 <= t2
+    assert t0 < t1
+    assert t2 >= t0
+    assert t0 <= t2
 
-        t3 = tqdm(total=10, file=our_file)
-        t4 = tqdm(total=10, file=our_file)
-        t5 = tqdm(total=10, file=our_file)
-        t5.close()
-        t6 = tqdm(total=10, file=our_file)
+    t3 = tqdm(total=10)
+    t4 = tqdm(total=10)
+    t5 = tqdm(total=10)
+    t5.close()
+    t6 = tqdm(total=10)
 
-        assert t3 != t4
-        assert t3 > t2
-        assert t5 == t6
-        t6.close()
-        t4.close()
-        t3.close()
-        t2.close()
-        t1.close()
-        t0.close()
+    assert t3 != t4
+    assert t3 > t2
+    assert t5 == t6
+    t6.close()
+    t4.close()
+    t3.close()
+    t2.close()
+    t1.close()
+    t0.close()
+    out, err = capsys.readouterr()
+    assert not out
+    assert " 0/10 " in err
+
+
+# https://docs.python.org/3/tutorial/datastructures.html#comparing-sequences-and-other-types
+@mark.parametrize('left,right', [
+    ((1, 2, 3), (1, 2, 4)),
+    ([1, 2, 3], [1, 2, 4]),
+    ('ABC', 'C'),
+    ('C', 'Pascal'),
+    ('Pascal', 'Python'),
+    ((1, 2, 3, 4), (1, 2, 4)),
+    ((1, 2), (1, 2, -1)),
+    ((1, 2, ('aa', 'ab')), (1, 2, ('abc', 'a'), 4))])
+def test_cmp_iterables(capsys, left, right):
+    """Test iterable comparison"""
+    assert (left < right) == (tqdm(left) < right)
+    assert (left == right) == (tqdm(left) == right)
+    assert (left > right) == (tqdm(left) > right)
+    out, err = capsys.readouterr()
+    assert not out
+    assert "/{0:d} ".format(len(left)) in err
 
 
 def test_repr():

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -64,15 +64,44 @@ class FormatReplace(object):
 
 
 class Comparable(object):
-    """Assumes child has self._comparable attr/@property"""
+    """
+    Compares `self._comparable` & `other._comparable` (fallback `self.iterable` & `other`)
+    """
     def __lt__(self, other):
-        return self._comparable < other._comparable
+        if hasattr(other, '_comparable'):
+            return self._comparable < other._comparable
+        if not isinstance(self.iterable, other.__class__):
+            raise TypeError(("'<' not supported between instances of"
+                             " {i.__class__.__name__!r} and {j.__class__.__name__!r}").format(
+                            i=self.iterable, j=other))
+        for i, j in zip(self, other):
+            if i != j:
+                return i < j
+        return len(self) < len(other)
 
     def __le__(self, other):
-        return (self < other) or (self == other)
+        if hasattr(other, '_comparable'):
+            return self._comparable <= other._comparable
+        if not isinstance(self.iterable, other.__class__):
+            raise TypeError(("'<=' not supported between instances of"
+                             " {i.__class__.__name__!r} and {j.__class__.__name__!r}").format(
+                            i=self.iterable, j=other))
+        for i, j in zip(self, other):
+            if i != j:
+                return i <= j
+        return len(self) <= len(other)
 
     def __eq__(self, other):
-        return self._comparable == other._comparable
+        if hasattr(other, '_comparable'):
+            return self._comparable == other._comparable
+        if not isinstance(self.iterable, other.__class__):
+            raise TypeError(("'==' not supported between instances of"
+                             " {i.__class__.__name__!r} and {j.__class__.__name__!r}").format(
+                            i=self.iterable, j=other))
+        for i, j in zip(self, other):
+            if i != j:
+                return False
+        return len(self) == len(other)
 
     def __ne__(self, other):
         return not self == other


### PR DESCRIPTION
- allow `tqdm(iterable0) <=> iterable1`
- update tests
- bump pre-commit hooks

---

- fixes #1288