### PR TITLE
Make TqdmLoggingHandler a public class and adapt documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1347,6 +1347,22 @@ Helper methods are available in ``tqdm.contrib.logging``. For example:
                     LOG.info("console logging redirected to `tqdm.write()`")
         # logging restored
 
+Alternatively you can replace your ``StreamHandler`` with the ``TqdmLoggingHandler()``. In this case make sure to not overwrite the ``emit()`` function.
+
+.. code:: python
+
+    import logging
+    from tqdm import trange
+    from tqdm.contrib.logging import TqdmLoggingHandler
+
+    LOG = logging.getLogger(__name__)
+
+    if __name__ == '__main__':
+        logging.basicConfig(level=logging.INFO, handlers=[TqdmLoggingHandler()])
+        for i in trange(9):
+            if i == 4:
+                LOG.info("console logging redirected to `tqdm.write()`")
+
 Monitoring thread, intervals and miniters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -1334,6 +1334,7 @@ Helper methods are available in ``tqdm.contrib.logging``. For example:
 .. code:: python
 
     import logging
+    import time
     from tqdm import trange
     from tqdm.contrib.logging import logging_redirect_tqdm
 
@@ -1343,7 +1344,8 @@ Helper methods are available in ``tqdm.contrib.logging``. For example:
         logging.basicConfig(level=logging.INFO)
         with logging_redirect_tqdm():
             for i in trange(9):
-                if i == 4:
+                time.sleep(0.5)
+                if i % 2:
                     LOG.info("console logging redirected to `tqdm.write()`")
         # logging restored
 
@@ -1352,6 +1354,7 @@ Alternatively you can replace your ``StreamHandler`` with the ``TqdmLoggingHandl
 .. code:: python
 
     import logging
+    import time
     from tqdm import trange
     from tqdm.contrib.logging import TqdmLoggingHandler
 
@@ -1360,7 +1363,8 @@ Alternatively you can replace your ``StreamHandler`` with the ``TqdmLoggingHandl
     if __name__ == '__main__':
         logging.basicConfig(level=logging.INFO, handlers=[TqdmLoggingHandler()])
         for i in trange(9):
-            if i == 4:
+            time.sleep(0.5)
+            if i % 2:
                 LOG.info("console logging redirected to `tqdm.write()`")
 
 Monitoring thread, intervals and miniters

--- a/tests/tests_contrib_logging.py
+++ b/tests/tests_contrib_logging.py
@@ -10,9 +10,9 @@ from io import StringIO
 import pytest
 
 from tqdm import tqdm
-from tqdm.contrib.logging import _get_first_found_console_logging_handler
-from tqdm.contrib.logging import _TqdmLoggingHandler as TqdmLoggingHandler
-from tqdm.contrib.logging import logging_redirect_tqdm, tqdm_logging_redirect
+from tqdm.contrib.logging import (
+    TqdmLoggingHandler, _get_first_found_console_logging_handler, logging_redirect_tqdm,
+    tqdm_logging_redirect)
 
 from .tests_tqdm import importorskip
 

--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -15,15 +15,17 @@ except ImportError:
 from ..std import tqdm as std_tqdm
 
 
-class _TqdmLoggingHandler(logging.StreamHandler):
+class TqdmLoggingHandler(logging.StreamHandler):
+    """Logging StreamHandler drop-in replacement for logging inside progress bars."""
     def __init__(
         self,
         tqdm_class=std_tqdm  # type: Type[std_tqdm]
     ):
-        super(_TqdmLoggingHandler, self).__init__()
+        super(TqdmLoggingHandler, self).__init__()
         self.tqdm_class = tqdm_class
 
     def emit(self, record):
+        """Write a log message *above* the progress bar, without breaking it."""
         try:
             msg = self.format(record)
             self.tqdm_class.write(msg, file=self.stream)
@@ -84,7 +86,7 @@ def logging_redirect_tqdm(
     original_handlers_list = [logger.handlers for logger in loggers]
     try:
         for logger in loggers:
-            tqdm_handler = _TqdmLoggingHandler(tqdm_class)
+            tqdm_handler = TqdmLoggingHandler(tqdm_class)
             orig_handler = _get_first_found_console_logging_handler(logger.handlers)
             if orig_handler is not None:
                 tqdm_handler.setFormatter(orig_handler.formatter)


### PR DESCRIPTION
This PR makes the TqdmLoggingHandler a public class to mark it as importable by users. This is more convenient then using `with logging_redirect_tqdm():` for every logging location inside a pbar in larger projects.

It also adds this functionality to the documentation and (hopefully) the minimum required docstring.

In addition it extends the logging example by a 'sleep' timer to make it more "experienceable" when executing.

Disclaimer: While I have verified that this approach works for me I am no expert in the tqdm/logging/stream world, so feel free to point out any missed side-effects.