### PR TITLE
Fix: `logging_redirect_tqdm` now respects the log level

### DIFF
--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -89,6 +89,7 @@ def logging_redirect_tqdm(
             if orig_handler is not None:
                 tqdm_handler.setFormatter(orig_handler.formatter)
                 tqdm_handler.stream = orig_handler.stream
+                tqdm_handler.level = orig_handler.level
             logger.handlers = [
                 handler for handler in logger.handlers
                 if not _is_console_logging_handler(handler)] + [tqdm_handler]


### PR DESCRIPTION
Fixes: #1272

The fix was already mentioned in the issue. Since the author didn't create a PR and I have this problem too, I created this PR hoping it will be fixed soon.