### PR TITLE
Save description if disabled

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1002,6 +1002,7 @@ class tqdm(Comparable):
             self.n = initial
             self.total = total
             self.leave = leave
+            self.desc = desc or ''
             return
 
         if kwargs:


### PR DESCRIPTION
I discovered this (potential?) issue while investigating https://github.com/iterative/dvc/issues/7896. Essentially, we're hitting this early return in non-interactive environments, which causes certain properties of the `tqdm` object not to be set. I'm not sure if the fix belongs here in tqdm, or if it does if `desc` is the only one we should be adding, but opening this PR to start the conversation :)