### PR TITLE
Added tqdm.asyncio import

### DIFF
--- a/tqdm/__init__.py
+++ b/tqdm/__init__.py
@@ -1,3 +1,4 @@
+from . import asyncio  # noqa
 from ._monitor import TMonitor, TqdmSynchronisationWarning
 from ._tqdm_pandas import tqdm_pandas
 from .cli import main  # TODO: remove in v5.0.0
@@ -7,7 +8,6 @@ from .std import (
     TqdmDeprecationWarning, TqdmExperimentalWarning, TqdmKeyError, TqdmMonitorWarning,
     TqdmTypeError, TqdmWarning, tqdm, trange)
 from .version import __version__
-from . import asyncio
 
 __all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_pandas',
            'tqdm_notebook', 'tnrange', 'main', 'TMonitor',

--- a/tqdm/__init__.py
+++ b/tqdm/__init__.py
@@ -7,6 +7,7 @@ from .std import (
     TqdmDeprecationWarning, TqdmExperimentalWarning, TqdmKeyError, TqdmMonitorWarning,
     TqdmTypeError, TqdmWarning, tqdm, trange)
 from .version import __version__
+from . import asyncio
 
 __all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_pandas',
            'tqdm_notebook', 'tnrange', 'main', 'TMonitor',


### PR DESCRIPTION
When attempting to use the asyncio features of tqdm I realized that there was no imports for it, and that it could not be used.

I simply added the import statement to reference the file. I also added the `# noqa` since flake8 would warn of the unused import. I decided against adding it to `__all__` since that would likely override the standard library asyncio.