### PR TITLE
Use dummy logger to provide hierarchal control of "disable" feature.

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division
 
 import os
 import sys
+import logging
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta
@@ -30,6 +31,10 @@ __all__ = ['tqdm', 'trange',
            'TqdmTypeError', 'TqdmKeyError', 'TqdmWarning',
            'TqdmExperimentalWarning', 'TqdmDeprecationWarning',
            'TqdmMonitorWarning']
+
+DISABLE_THRESHOLD = 20  # disabled for log level above this
+_log = logging.getLogger('tqdm')
+_log.setLevel(DISABLE_THRESHOLD)  # default enabled
 
 
 class TqdmTypeError(TypeError):
@@ -982,8 +987,10 @@ class tqdm(Comparable):
 
         file = DisableOnWriteError(file, tqdm_instance=self)
 
+        log = _log.getChild(desc) if desc else _log
         if disable == 'default':
-            disable = os.environ.get('TQDM_DISABLE', False)
+            disable = os.environ.get('TQDM_DISABLE',
+                                     not log.isEnabledFor(DISABLE_THRESHOLD))
 
         if disable is None and hasattr(file, "isatty") and not file.isatty():
             disable = True

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -9,6 +9,7 @@ Usage:
 """
 from __future__ import absolute_import, division
 
+import os
 import sys
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
@@ -845,7 +846,7 @@ class tqdm(Comparable):
 
     def __init__(self, iterable=None, desc=None, total=None, leave=True, file=None,
                  ncols=None, mininterval=0.1, maxinterval=10.0, miniters=None,
-                 ascii=None, disable=False, unit='it', unit_scale=False,
+                 ascii=None, disable='default', unit='it', unit_scale=False,
                  dynamic_ncols=False, smoothing=0.3, bar_format=None, initial=0,
                  position=None, postfix=None, unit_divisor=1000, write_bytes=None,
                  lock_args=None, nrows=None, colour=None, delay=0, gui=False,
@@ -900,7 +901,7 @@ class tqdm(Comparable):
             the meter. The fallback is to use ASCII characters " 123456789#".
         disable  : bool, optional
             Whether to disable the entire progressbar wrapper
-            [default: False]. If set to None, disable on non-TTY.
+            [default: os.environ.get('TQDM_DISABLE', False)]. If set to None, disable on non-TTY.
         unit  : str, optional
             String that will be used to define the unit of each iteration
             [default: it].
@@ -980,6 +981,9 @@ class tqdm(Comparable):
                 file, encoding=getattr(file, 'encoding', None) or 'utf-8')
 
         file = DisableOnWriteError(file, tqdm_instance=self)
+
+        if disable == 'default':
+            disable = os.environ.get('TQDM_DISABLE', False)
 
         if disable is None and hasattr(file, "isatty") and not file.isatty():
             disable = True


### PR DESCRIPTION
This builds off of #950 and adds the ability to control the disabled state of tqdm objects by setting the level of the associated dummy logger.

Dummy loggers are named `'tqdm' + '.' + desc`.
For example, given tqdm instances located anywhere:
- `tqdm(..., desc=None)`
- `tqdm(..., desc='a')`
- `tqdm(..., desc='a.b')`
- `tqdm(..., desc='a.c')`

all instances can be disabled with `logging.getLogger('tqdm').setLevel(30)`. The last three instances only can be disabled with `logging.getLogger('tqdm.a').setLevel(30)`. Or individual instances only can be disabled with `logging.getLogger('tqdm.a.b').setLevel(30)`.

Disabled states are set to True if the associated logger's effective level is >20, False otherwise.