### PR TITLE
zsh completion script for tqdm

### DIFF
--- a/scripts/zsh_completion.in
+++ b/scripts/zsh_completion.in
@@ -1,0 +1,7 @@
+#compdef {{programs}}
+# https://github.com/zsh-users/zsh/blob/master/Etc/completion-style-guide
+
+_arguments -s -S \
+  '(- *)'{-h,--help}'[Print this help and exit.]' \
+  '(- *)'{-v,--version}'[Print version and exit.]' \
+  {{flags}}

--- a/scripts/zsh_completion.py
+++ b/scripts/zsh_completion.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+import os
+import sys
+from os.path import dirname as dirn
+from typing import Final
+
+path = dirn(dirn((os.path.abspath(__file__))))
+sys.path.insert(0, path)
+import tqdm  # noqa: E402
+from tqdm.cli import CLI_EXTRA_DOC, RE_OPTS  # noqa: E402
+
+d = tqdm.__init__.__doc__ + CLI_EXTRA_DOC  # type: ignore
+opt_types = dict(RE_OPTS.findall(d))
+split = RE_OPTS.split(d)
+opt_types_desc = zip(split[1::3], split[2::3], split[3::3])
+
+PACKAGE: Final = "tqdm"if sys.argv[1:2] == [] else sys.argv[1]
+BINNAME: Final = PACKAGE.replace("_", "-")
+BINNAMES: Final = [BINNAME]
+ZSH_COMPLETION_FILE: Final = (
+    "_" + BINNAME if sys.argv[2:3] == [] else sys.argv[2]
+)
+ZSH_COMPLETION_TEMPLATE: Final = os.path.join(
+    dirn(os.path.abspath(__file__)), "zsh_completion.in"
+)
+
+flags = []
+for o, t, d in opt_types_desc:
+    optionstr = "--" + o
+    helpstr = (
+        " ".join(list(map(str.strip, d.splitlines()[1:])))
+        .replace("]", "\\]")
+        .replace("'", "'\\''")
+    )
+    helpstr = "[" + helpstr + "]"
+
+    if t == "bool":
+        metavar = ""
+    else:
+        metavar = t
+    if metavar != "":
+        # use lowcase conventionally
+        metavar = metavar.lower().replace(":", "\\:")
+
+    if metavar == "":
+        completion = ""
+    elif o == "log":
+        completion = "(CRITICAL FATAL ERROR WARN WARNING INFO DEBUG NOTSET)"
+    elif o in ["manpath", "comppath"]:
+        completion = "_dirs"
+    else:
+        completion = ""
+
+    if metavar != "":
+        metavar = ":" + metavar
+    if completion != "":
+        completion = ":" + completion
+
+    flag = "{0}'{1}{2}{3}'".format(optionstr, helpstr, metavar, completion)
+    flags += [flag]
+
+with open(ZSH_COMPLETION_TEMPLATE) as f:
+    template = f.read()
+
+template = template.replace("{{programs}}", " ".join(BINNAMES))
+template = template.replace("{{flags}}", " \\\n  ".join(flags))
+
+with (
+    open(ZSH_COMPLETION_FILE, "w")
+    if ZSH_COMPLETION_FILE != "-"
+    else sys.stdout
+) as f:
+    f.write(template)


### PR DESCRIPTION
---
name: Pull Request
about: Use this template for proposing change(s)
---

- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [x] visual output fix
    + [x] documentation modification
    + [x] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=

How to use:

```sh
scripts/zsh_completion.py
sudo mv _tqdm /usr/share/zsh/site-functions
```

Result:

```shell
❯ tqdm --<Tab>
option
--buf_size    String buffer size in bytes [default: 256] used when `delim` is specified.
--bytes       If true, will count bytes, ignore `delim`, and default `unit_scale` to True, `unit_divisor` to 1024, and `unit` to 'B'.
--comppath    Directory in which to place tqdm completion.
--delim       Delimiting character [default: 'n']. Use '0' for null. N.B.: on Windows systems, Python converts 'n' to 'rn'.
--help        Print this help and exit.
--log         CRITICAL|FATAL|ERROR|WARN(ING)|[default: 'INFO']|DEBUG|NOTSET.
--manpath     Directory in which to install tqdm man pages.
--name        TODO: find out why this is needed.
--null        If true, will discard input (no stdout).
--tee         If true, passes `stdin` to both `stderr` and `stdout`.
--update      If true, will treat input as newly elapsed iterations, i.e. numbers to pass to `update()`. Note that this is slow (~2e5 it/s) since every input must be decoded as a number.
--update_to   If true, will treat input as total elapsed iterations, i.e. numbers to assign to `self.n`. Note that this is slow (~2e5 it/s) since every input must be decoded as a number.
--version     Print version and exit.
❯ tqdm --manpath <Tab>
directory
benchmarks/  examples/    images/      scripts/     tests/       tqdm/
```