### PR TITLE
Keep logging level when using tqdm logger redirect

### DIFF
--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -87,6 +87,7 @@ def logging_redirect_tqdm(
             if orig_handler is not None:
                 tqdm_handler.setFormatter(orig_handler.formatter)
                 tqdm_handler.stream = orig_handler.stream
+                tqdm_handler.level = orig_handler.level
             logger.handlers = [
                 handler for handler in logger.handlers
                 if not _is_console_logging_handler(handler)] + [tqdm_handler]


### PR DESCRIPTION
This fixes an issue with the logging redirect. When using it, it removes the level of the associated logger that it is superseding, resulting in any verbosity setting being ignored from that point on. This is just a simple fix to carry over the logging level to the new logger object.