### PR TITLE
Improve documentation of `ascii` argument

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -897,7 +897,10 @@ class tqdm(Comparable):
             (network, skipping items, etc) you should set miniters=1.
         ascii  : bool or str, optional
             If unspecified or False, use unicode (smooth blocks) to fill
-            the meter. The fallback is to use ASCII characters " 123456789#".
+            the meter, with blank whitespace padding. If specified, adopt
+            given characters to fill the meter, using the first given
+            character to  fill the  whitespace padding. If True, use ASCII
+            characters " 123456789#".
         disable  : bool, optional
             Whether to disable the entire progressbar wrapper
             [default: False]. If set to None, disable on non-TTY.


### PR DESCRIPTION
I only discover this by try and error.
I think it should be more clear in the documentation to new users.

Not give `ascii`:
```python
from tqdm import tqdm
for i in tqdm(range(5)):
    ...
```

![image](https://user-images.githubusercontent.com/57204023/192104187-b076dc6e-d31c-4a7f-8cbd-daa54e5280ef.png)

Give `ascii`:
```python
from tqdm import tqdm
for i in tqdm(range(5),ascii='-█'):
    ...
```

![image](https://user-images.githubusercontent.com/57204023/192104219-418c0ee4-dcb3-4ba8-bf74-f04e60d1f2de.png)
