### PR TITLE
Fix: set_description() getting an error when desc is non str.

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1399,11 +1399,11 @@ class tqdm(Comparable):
 
         Parameters
         ----------
-        desc  : str, optional
+        desc  : any, optional
         refresh  : bool, optional
             Forces refresh [default: True].
         """
-        self.desc = desc + ': ' if desc else ''
+        self.desc = str(desc) + ': ' if desc else ''
         if refresh:
             self.refresh()
 


### PR DESCRIPTION
When using set_description(), if you set desc as int, or any other non str type object, TypeError: unsupported operand type(s) for +: 'int' and 'str' would occure. This fix would automatically cast the object to str.