### PR TITLE
Fix for tqdm.rich module, reset() method is broken - Added missing argument task_id to self._prog.reset() call

### DIFF
--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -139,7 +139,7 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
         total  : int or float, optional. Total to use for the new bar.
         """
         if hasattr(self, '_prog'):
-            self._prog.reset(total=total)
+            self._prog.reset(task_id=self._task_id, total=total)
         super(tqdm_rich, self).reset(total=total)
 
 


### PR DESCRIPTION
There's seems to be a missing argument in the `reset` method definition for `tqdm.rich` module:
```python
    def reset(self, total=None):
        """
        Resets to 0 iterations for repeated use.

        Parameters
        ----------
        total  : int or float, optional. Total to use for the new bar.
        """
        if hasattr(self, '_prog'):
            self._prog.reset(total=total)
        super(tqdm_rich, self).reset(total=total)
```

I've created a fix for issue #1378 by adding the missing `task_id` parameter.
```python
self._prog.reset(task_id=self._task_id, total=total)
```

