### PR TITLE
Use new API for Windows: colorama.just_fix_windows_console()

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ classifiers=
 setup_requires=setuptools>=42; setuptools_scm[toml]>=3.4
 python_requires=>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 install_requires=
-    colorama; platform_system == 'Windows'
+    colorama >= 0.4.6; platform_system == 'Windows'
     importlib_resources; python_version < "3.7"
 tests_require=tox
 include_package_data=True

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -42,10 +42,7 @@ try:
 except ImportError:
     colorama = None
 else:
-    try:
-        colorama.init(strip=False)
-    except TypeError:
-        colorama.init()
+    colorama.just_fix_windows_console()
 
 
 class FormatReplace(object):


### PR DESCRIPTION
tqdm uses colorama to enable proper ANSI support on Windows. Traditionally, it's done this by calling `colorama.init`. But this API is pretty awkward: it tries to do too much (e.g. guessing whether you have ANSI support and if not then installing sys.stdout/stderr filters that remove all ANSI codes from output -- even if the system actually does support ANSI!), and it isn't idempotent, so if multiple libraries all call `colorama.init` then you can get brokenness (in particular, it can trigger the situation where colorama thinks ANSI is unavailable, when it actually is!).

To solve this, colorama 0.4.6 added a new API,
`colorama.just_fix_windows_console`:
https://github.com/tartley/colorama/pull/352

The advantage of this is that it does what it says: it just fixes the Windows console, without any strange side-effects, and it's safe to call multiple times. The colorama maintainers are
recommending that everyone switch to it.