### PR TITLE
Fix: Add display() call to close() in rich module

### DIFF
--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -116,6 +116,7 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
     def close(self):
         if self.disable:
             return
+        self.display()  # print 100%, vis #1306
         super().close()
         self._prog.__exit__(None, None, None)
 


### PR DESCRIPTION
See how I've come to this conclusion. This note and notes before it:
- https://github.com/tqdm/tqdm/issues/1306#issuecomment-1322762835

Testcase:

```py
from tqdm.rich import trange, tqdm
for i in trange(10):
    print(f"i={i}")
print("finished")
```

This snippet, when run, must reach 100%. without the patch it doesn't even get past 0.

The `display()` calls in std.close are never reached because the "gui mode check" exits the function:
- https://github.com/tqdm/tqdm/blob/6791e8c5b3d6c30bdd2060c346996bfb5a6f10d1/tqdm/std.py#L1295-L1297