### PR TITLE
tqdm_telegram - add Zero Width Non-Joiner

### DIFF
--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -130,7 +130,7 @@ class tqdm_telegram(tqdm_auto):
             fmt['bar_format'] = fmt['bar_format'].replace(
                 '<bar/>', '{bar:10u}').replace('{bar}', '{bar:10u}')
         else:
-            fmt['bar_format'] = '{l_bar}{bar:10u}{r_bar}'
+            fmt['bar_format'] = '\u200c{l_bar}{bar:10u}{r_bar}'
         self.tgio.write(self.format_meter(**fmt))
 
     def clear(self, *args, **kwargs):


### PR DESCRIPTION
Adding a special character for proper right alignment.

Before:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/454655/210629647-5ba6d01e-da9a-44bb-86ec-d044d8f04520.png">

After:
<img width="637" alt="image" src="https://user-images.githubusercontent.com/454655/210629608-dd4705e9-493a-4d57-8e54-7480a61beefe.png">
