### PR TITLE
chore(tests): add Python 3.11 in CI run/tox/trove classifier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
         include:
         - os: macos
           python: 2.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ classifiers=
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation
     Programming Language :: Python :: Implementation :: IronPython
     Programming Language :: Python :: Implementation :: PyPy

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # deprecation warning: py{27,py2,34,35,36}
-envlist=py{27,34,35,36,37,38,39,310,py2,py3}{,-tf}{,-keras}, perf, setup.py
+envlist=py{27,34,35,36,37,38,39,310,311,py2,py3}{,-tf}{,-keras}, perf, setup.py
 isolated_build=True
 
 [gh-actions]
@@ -17,6 +17,7 @@ python=
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
     pypy-2.7: pypy2
     pypy-3.7: pypy3
 [gh-actions:env]
@@ -29,9 +30,9 @@ deps=
     py3{4,5,6}: pytest<7
     pytest-cov
     pytest-timeout
-    py3{7,8,9,10}: pytest-asyncio
-    py3{6,7,8,9,10}: ipywidgets
-    py3{7,8,9,10}: git+https://github.com/casperdcl/nbval.git@master#egg=nbval
+    py3{7,8,9,10,11}: pytest-asyncio
+    py3{6,7,8,9,10,11}: ipywidgets
+    py3{7,8,9,10,11}: git+https://github.com/casperdcl/nbval.git@master#egg=nbval
     coverage
     coveralls
     codecov
@@ -54,11 +55,11 @@ deps=
     py27-keras: keras<2.5
     py35-keras: keras<2.7
     py27-tf: protobuf<3.18
-    py3{6,7,8,9,10}: rich
+    py3{6,7,8,9,10,11}: rich
 commands=
     py3{4,5,6}: pytest --cov=tqdm --cov-report=xml --cov-report=term -k "not perf" -o addopts= -v --tb=short -rxs -W=error --durations=0 --durations-min=0.1
-    py3{7,8,9,10}: pytest --cov=tqdm --cov-report= tests_notebook.ipynb --nbval --nbval-current-env -W=ignore --nbval-sanitize-with=setup.cfg
-    py3{7,8,9,10}: pytest --cov=tqdm --cov-report=xml --cov-report=term --cov-append -k "not perf"
+    py3{7,8,9,10,11}: pytest --cov=tqdm --cov-report= tests_notebook.ipynb --nbval --nbval-current-env -W=ignore --nbval-sanitize-with=setup.cfg
+    py3{7,8,9,10,11}: pytest --cov=tqdm --cov-report=xml --cov-report=term --cov-append -k "not perf"
     {[core]commands}
 allowlist_externals=codacy
 


### PR DESCRIPTION
## Description

This PR adds Python 3.11 in CI run/tox/trove classifier