### PR TITLE
Add new SI prefixes

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -319,11 +319,12 @@ def test_si_format():
     assert '1.00P ' in format_meter(1, 999999999999999, 1, unit_scale=True)
     assert '1.00E ' in format_meter(1, 999999999999999999, 1, unit_scale=True)
     assert '1.00Z ' in format_meter(1, 999999999999999999999, 1, unit_scale=True)
-    assert '1.0Y ' in format_meter(1, 999999999999999999999999, 1, unit_scale=True)
-    assert '10.0Y ' in format_meter(1, 9999999999999999999999999, 1, unit_scale=True)
-    assert '100.0Y ' in format_meter(1, 99999999999999999999999999, 1, unit_scale=True)
-    assert '1000.0Y ' in format_meter(1, 999999999999999999999999999, 1,
-                                      unit_scale=True)
+    assert '1.00Y ' in format_meter(1, 999999999999999999999999, 1, unit_scale=True)
+    assert '1.00R ' in format_meter(1, 999999999999999999999999999, 1, unit_scale=True)
+    assert '1.0Q ' in format_meter(1, 999999999999999999999999999999, 1, unit_scale=True)
+    assert '10.0Q ' in format_meter(1, 9999999999999999999999999999999, 1, unit_scale=True)
+    assert '100.0Q ' in format_meter(1, 99999999999999999999999999999999, 1, unit_scale=True)
+    assert '1000.0Q ' in format_meter(1, 999999999999999999999999999999999, 1, unit_scale=True)
 
 
 def test_bar_formatspec():

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -275,7 +275,7 @@ class tqdm(Comparable):
         out  : str
             Number with Order of Magnitude SI unit postfix.
         """
-        for unit in ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z']:
+        for unit in ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R']:
             if abs(num) < 999.5:
                 if abs(num) < 99.95:
                     if abs(num) < 9.995:
@@ -283,7 +283,7 @@ class tqdm(Comparable):
                     return '{0:2.1f}'.format(num) + unit + suffix
                 return '{0:3.0f}'.format(num) + unit + suffix
             num /= divisor
-        return '{0:3.1f}Y'.format(num) + suffix
+        return '{0:3.1f}Q'.format(num) + suffix
 
     @staticmethod
     def format_interval(t):


### PR DESCRIPTION
Add new SI prefixes for numeric formatting in progress bar.

In November 2022 the International Bureau of Weights and Measures introduced two new SI prefixes for 10^27 (_ronna_) and 10^30 (_quetta_).  While they are not likely to be used in common parlance anytime soon, it doesn't hurt to future-proof.

See:
- https://www.bipm.org/en/cgpm-2022/resolution-3
- https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes