### PR TITLE
Allow `TqdmCallback` to run without an explicit `set_params`

### DIFF
--- a/tests/tests_keras.py
+++ b/tests/tests_keras.py
@@ -91,3 +91,33 @@ def test_keras(capsys):
     assert "training: " in res
     assert "{epochs}/{epochs}".format(epochs=initial_epoch - 1) not in res
     assert "{epochs}/{epochs}".format(epochs=epochs) in res
+
+    # 1D autoencoder
+    dtype = np.float32
+    model = K.models.Sequential([
+        K.layers.InputLayer((1, 1), dtype=dtype), K.layers.Conv1D(1, 1)])
+    model.compile("adam", "mse")
+    x = np.random.rand(100, 1, 1).astype(dtype)
+    batch_size = 10
+    batches = len(x) / batch_size
+    epochs = 5
+
+    # just epoch (no batch) progress
+    model.fit(
+        x,
+        x,
+        epochs=epochs,
+        batch_size=batch_size,
+        verbose=False,
+        # check if TqdmCallback can be wrapped in a tf.keras.callbacks.CallbackList object
+        callbacks=K.callbacks.CallbackList(
+            callbacks=[TqdmCallback(
+                epochs,
+                desc="training",
+                data_size=len(x),
+                batch_size=batch_size,
+                verbose=0)]))
+    _, res = capsys.readouterr()
+    assert "training: " in res
+    assert "{epochs}/{epochs}".format(epochs=epochs) in res
+    assert "{batches}/{batches}".format(batches=batches) not in res

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -50,6 +50,7 @@ class TqdmCallback(keras.callbacks.Callback):
         tqdm_kwargs  : optional
             Any other arguments used for all bars.
         """
+        self.params = {} # in case `set_params` is not called
         if tqdm_kwargs:
             tqdm_class = partial(tqdm_class, **tqdm_kwargs)
         self.tqdm_class = tqdm_class


### PR DESCRIPTION
Fixes #1423 by setting `params` to an empty dictionary initially