### PR TITLE
use wcwidth package to compute display length of text

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ python_requires=>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 install_requires=
     colorama; platform_system == 'Windows'
     importlib_resources; python_version < "3.7"
+    wcwidth
 tests_require=tox
 include_package_data=True
 packages=find:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -343,12 +343,13 @@ class tqdm(Comparable):
             fp.write(_unicode(s))
             fp_flush()
 
-        last_len = [0]
+        last_len = 0
 
         def print_status(s):
+            nonlocal last_len
             len_s = disp_len(s)
-            fp_write('\r' + s + (' ' * max(last_len[0] - len_s, 0)))
-            last_len[0] = len_s
+            fp_write('\r' + s + (' ' * max(last_len - len_s, 0)))
+            last_len = len_s
 
         return print_status
 


### PR DESCRIPTION
This updates the implementation of `util.disp_len` to use the `wcwidth` package, which is more reliable for "wide" Unicode characters.