### PR TITLE
fix wrong slack channel id type in docs

### DIFF
--- a/tqdm/contrib/slack.py
+++ b/tqdm/contrib/slack.py
@@ -74,7 +74,7 @@ class tqdm_slack(tqdm_auto):
         ----------
         token  : str, required. Slack token
             [default: ${TQDM_SLACK_TOKEN}].
-        channel  : int, required. Slack channel
+        channel  : str, required. Slack channel
             [default: ${TQDM_SLACK_CHANNEL}].
         mininterval  : float, optional.
           Minimum of [default: 1.5] to avoid rate limit.


### PR DESCRIPTION
For some reason it was int, while it's actually a string