### PR TITLE
Fix scaling issue tqdm notebook

### DIFF
--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -159,7 +159,8 @@ class tqdm_notebook(std_tqdm):
             msg = self.format_meter(**d)
 
         ltext, pbar, rtext = self.container.children
-        pbar.value = self.n
+        unit_scale = 1 if self.unit_scale is True else self.unit_scale or 1
+        pbar.value = self.n * unit_scale
 
         if msg:
             # html escape special characters (like '&')


### PR DESCRIPTION
Fixes #1399 
Fix to make sure the progress bar is scaled according to `unit_scale` by multiplying `n` with `unit_scale`.