### PR TITLE
Fix process leak

### DIFF
--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -10,6 +10,9 @@ Usage:
 import asyncio
 from sys import version_info
 
+from copy import copy
+from multiprocessing import active_children
+
 from .std import tqdm as std_tqdm
 
 __author__ = {"github.com/": ["casperdcl"]}
@@ -24,6 +27,8 @@ class tqdm_asyncio(std_tqdm):
         super(tqdm_asyncio, self).__init__(iterable, *args, **kwargs)
         self.iterable_awaitable = False
         if iterable is not None:
+            curr_processes = active_children()
+            iterable = copy(iterable)
             if hasattr(iterable, "__anext__"):
                 self.iterable_next = iterable.__anext__
                 self.iterable_awaitable = True
@@ -32,6 +37,13 @@ class tqdm_asyncio(std_tqdm):
             else:
                 self.iterable_iterator = iter(iterable)
                 self.iterable_next = self.iterable_iterator.__next__
+            new_processes = active_children()
+            # get only freshly spawned processes
+            processes_on_termination = [x for x in new_processes if x not in curr_processes]
+            # if we don't need anything from them, we can terminate immediately
+            # (Maybe it can cause some problems, but this solution is better than processes filling up memory)
+            for child in processes_on_termination:
+                child.terminate()
 
     def __aiter__(self):
         return self

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -15,7 +15,6 @@ from numbers import Number
 from time import time
 from warnings import warn
 from weakref import WeakSet
-from multiprocessing import active_children
 
 from ._monitor import TMonitor
 from .utils import (

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -15,6 +15,7 @@ from numbers import Number
 from time import time
 from warnings import warn
 from weakref import WeakSet
+from multiprocessing import active_children
 
 from ._monitor import TMonitor
 from .utils import (
@@ -1274,6 +1275,10 @@ class tqdm(Comparable):
         if self.last_print_t < self.start_t + self.delay:
             # haven't ever displayed; nothing to clear
             return
+
+        # terminate all possibly spawned processes from iterating object
+        for child in active_children():
+            child.terminate()
 
         # GUI mode
         if getattr(self, 'sp', None) is None:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1276,10 +1276,6 @@ class tqdm(Comparable):
             # haven't ever displayed; nothing to clear
             return
 
-        # terminate all possibly spawned processes from iterating object
-        for child in active_children():
-            child.terminate()
-
         # GUI mode
         if getattr(self, 'sp', None) is None:
             return


### PR DESCRIPTION
Possible fix for #1467. 

Problem was that tqdm.auto.tqdm creates tqdm class which inherits from autonotebook AND asyncio. Asyncio has situation, where processes can be spawned uncontrollable. 

Getting iter() and/or __next__ from iterable each time spawned copy of DataLoader workers, that were not handled. They can be easelly terminated right after creation.