### PR TITLE
contrib.concurrent: fix iterable length handling

### DIFF
--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -38,7 +38,9 @@ def test_process_map():
 
 @mark.parametrize("iterables,should_warn", [([], False), (['x'], False), ([()], False),
                                             (['x', ()], False), (['x' * 1001], True),
-                                            (['x' * 100, ('x',) * 1001], True)])
+                                            (['x' * 100, ('x',) * 1001], False),
+                                            (['x' * 1001, ('x',) * 100], False),
+                                            (['x' * 1001, ('x',) * 1001], True)])
 def test_chunksize_warning(iterables, should_warn):
     """Test contrib.concurrent.process_map chunksize warnings"""
     patch = importorskip('unittest.mock').patch

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -39,7 +39,8 @@ def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
     """
     kwargs = tqdm_kwargs.copy()
     if "total" not in kwargs:
-        kwargs["total"] = length_hint(iterables[0])
+        shortest_iterable_len = min(map(length_hint, iterables))
+        kwargs["total"] = shortest_iterable_len
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
     max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))
     chunksize = kwargs.pop("chunksize", 1)
@@ -100,12 +101,12 @@ def process_map(fn, *iterables, **tqdm_kwargs):
     if iterables and "chunksize" not in tqdm_kwargs:
         # default `chunksize=1` has poor performance for large iterables
         # (most time spent dispatching items to workers).
-        longest_iterable_len = max(map(length_hint, iterables))
-        if longest_iterable_len > 1000:
+        shortest_iterable_len = min(map(length_hint, iterables))
+        if shortest_iterable_len > 1000:
             from warnings import warn
             warn("Iterable length %d > 1000 but `chunksize` is not set."
                  " This may seriously degrade multiprocess performance."
-                 " Set `chunksize=1` or more." % longest_iterable_len,
+                 " Set `chunksize=1` or more." % shortest_iterable_len,
                  TqdmWarning, stacklevel=2)
     if "lock_name" not in tqdm_kwargs:
         tqdm_kwargs = tqdm_kwargs.copy()

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -26,6 +26,16 @@ def ensure_lock(tqdm_class, lock_name=""):
         tqdm_class.set_lock(old_lock)
 
 
+def _shortest_iterable_length(iterables):
+    # Negative default for iterables that have no length (e.g. itertools.repeat)
+    iterable_lengths = [length_hint(iterable, -1) for iterable in iterables]
+    # Remove the negative values
+    iterable_lengths = filter(lambda length: length >= 0, iterable_lengths)
+    # Take the shortest of the finite iterables
+    shortest_iterable_len = min(iterable_lengths)
+    return shortest_iterable_len
+
+
 def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
     """
     Implementation of `thread_map` and `process_map`.
@@ -39,8 +49,7 @@ def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
     """
     kwargs = tqdm_kwargs.copy()
     if "total" not in kwargs:
-        shortest_iterable_len = min(map(length_hint, iterables))
-        kwargs["total"] = shortest_iterable_len
+        kwargs["total"] = _shortest_iterable_length(iterables)
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
     max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))
     chunksize = kwargs.pop("chunksize", 1)
@@ -101,7 +110,7 @@ def process_map(fn, *iterables, **tqdm_kwargs):
     if iterables and "chunksize" not in tqdm_kwargs:
         # default `chunksize=1` has poor performance for large iterables
         # (most time spent dispatching items to workers).
-        shortest_iterable_len = min(map(length_hint, iterables))
+        shortest_iterable_len = _shortest_iterable_length(iterables)
         if shortest_iterable_len > 1000:
             from warnings import warn
             warn("Iterable length %d > 1000 but `chunksize` is not set."

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -26,14 +26,9 @@ def ensure_lock(tqdm_class, lock_name=""):
         tqdm_class.set_lock(old_lock)
 
 
-def _shortest_iterable_length(iterables):
-    # Negative default for iterables that have no length (e.g. itertools.repeat)
-    iterable_lengths = [length_hint(iterable, -1) for iterable in iterables]
-    # Remove the negative values
-    iterable_lengths = filter(lambda length: length >= 0, iterable_lengths)
-    # Take the shortest of the finite iterables
-    shortest_iterable_len = min(iterable_lengths)
-    return shortest_iterable_len
+def _min_map_len(iterables):
+    """min(map(length_hint, iterables))"""
+    return min(n for it in iterables if (n := length_hint(it, -1)) >= 0)
 
 
 def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
@@ -49,7 +44,7 @@ def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
     """
     kwargs = tqdm_kwargs.copy()
     if "total" not in kwargs:
-        kwargs["total"] = _shortest_iterable_length(iterables)
+        kwargs["total"] = _min_map_len(iterables)
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
     max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))
     chunksize = kwargs.pop("chunksize", 1)
@@ -110,7 +105,7 @@ def process_map(fn, *iterables, **tqdm_kwargs):
     if iterables and "chunksize" not in tqdm_kwargs:
         # default `chunksize=1` has poor performance for large iterables
         # (most time spent dispatching items to workers).
-        shortest_iterable_len = _shortest_iterable_length(iterables)
+        shortest_iterable_len = _min_map_len(iterables)
         if shortest_iterable_len > 1000:
             from warnings import warn
             warn("Iterable length %d > 1000 but `chunksize` is not set."


### PR DESCRIPTION
`contrib.concurrent` has functions for running `map`-like functions in parallel with a progress bar. This PR makes three fixes to how the lengths of the iterables are detected.

If the function provided to `process_map` or `thread_map` accepts `N` arguments, these map functions accept `N` iterables, with each iterable providing values for one argument. The map function keeps calling the provided function until reaching the end of the shortest iterable.

`process_map` raises a warning if a long iterable has been provided but a `chunksize` has not been set. It was looking at the length of the longest iterable, but it should look at the shortest length, as that's what sets the number of iterations.

Prior behavior:
```python
In [7]: from tqdm.contrib.concurrent import process_map
   ...: from time import sleep
   ...: from random import random
   ...: def f(*args):
   ...:     sleep(random() * 3)
   ...: process_map(f, range(2000), range(2))
<ipython-input-7-cc99b55bb53a>:6: TqdmWarning: Iterable length 2000 > 1000 but `chunksize` is not set. This may seriously degrade multiprocess performance. Set `chunksize=1` or more.
  process_map(f, range(2000), range(2))
  0%|                                          | 2/2000 [00:01<26:27,  1.26it/s]
Out[7]: [None, None]
```
Note the warning about a length-2000 iterable, despite only running two iterations. With this PR, the warning is not raised in this instance.

Note also that the progress bar shows an expected total of 2000 iterations, despite ending after 2. This is because `_executor_map` was only looking at the first iterable to set the expected total. This PR changes this behavior to use the length of the shortest iterable.

New behavior:
```python
In [1]: from tqdm.contrib.concurrent import process_map
   ...: from time import sleep
   ...: from random import random
   ...: def f(*args):
   ...:     sleep(random() * 3)
   ...: process_map(f, range(2000), range(2))
100%|█████████████████████████████████████████████| 2/2 [00:02<00:00,  1.23s/it]
Out[1]: [None, None]
```

This PR also improves how these map functions handle iterables with no length. (One pattern would be having one variable and one fixed argument, and calling `process_map(my_function, range(10), itertools.repeat(fixed_value))`.) Because of the default length of zero returned by `operator.length_hint` (and with this PR's emphasis on the *shortest* length), no-length iterables caused the expected total to be 0. The second commit in this PR ignores those lengths when calculating the expected total.

Before:
```python
In [20]: from tqdm.contrib.concurrent import process_map
    ...: from time import sleep
    ...: from random import random
   ...: from itertools import repeat
    ...: def f(*args):
    ...:     sleep(random() * 3)
    ...: process_map(f, range(2000), range(2), repeat(1))
2it [00:02,  1.11s/it]
Out[20]: [None, None]
```

After:
```python
In [2]: from tqdm.contrib.concurrent import process_map
   ...: from time import sleep
   ...: from random import random
   ...: from itertools import repeat
   ...: def f(*args):
   ...:     sleep(random() * 3)
   ...: process_map(f, range(2000), range(2), repeat(1))
100%|█████████████████████████████████████████████| 2/2 [00:01<00:00,  1.95it/s]
Out[2]: [None, None]
```