### PR TITLE
Fix Display Issue in Notebook for Dynamic Totals

### DIFF
--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -159,6 +159,7 @@ class tqdm_notebook(std_tqdm):
             msg = self.format_meter(**d)
 
         ltext, pbar, rtext = self.container.children
+        pbar.max = self.total
         pbar.value = self.n
 
         if msg:


### PR DESCRIPTION
#1145 describes the issue of the progress bar filling up completely when the total changes. This PR addresses the issue by updating the _max value_ of the underlying ``ipywidgets.FloatProgress`` object in the ``display()`` method of ``tqdm.notebook.tqdm_notebook``.

Fixes #1145