### PR TITLE
chore(python): add Python 3.12 in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        python: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
         include:
         - os: macos
           python: 3.11
@@ -60,6 +60,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
+        allow-prereleases: true
     - name: install
       run: |
         pip install -U tox tox-gh-actions

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist=py{37,38,39,310,311,py3}{,-tf}{,-keras}, perf, check
+envlist=py{37,38,39,310,311,312,py3}{,-tf}{,-keras}, perf, check
 isolated_build=True
 
 [gh-actions]
@@ -14,6 +14,7 @@ python=
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
     pypy-3.7: pypy3
 [gh-actions:env]
 PLATFORM=


### PR DESCRIPTION
This PR adds Python 3.12 in test matrix.

Note: I had to allow pre releases as Python 3.12 is still in beta and will soon land in release candidate.