### PR TITLE
fix `envwrap` types, update docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,16 +69,13 @@ jobs:
         echo "$HOME/bin" >> $GITHUB_PATH
     - name: tox
       run: |
-        TIMEOUT=10m
-        if [[ "${{ matrix.python }}" = "2.7" ]]; then
-          TIMEOUT=15m
-        elif [[ "py${{ matrix.python }}-${{ matrix.os }}" = "py3.8-ubuntu" ]]; then
-          export TOXENV="py38-tf,py38-tf-keras"  # full
+        if [[ "py${{ matrix.python }}-${{ matrix.os }}" = "py3.11-ubuntu" ]]; then
+          export TOXENV="py311-tf,py311-tf-keras"  # full
         fi
         if [[ "${{ matrix.os }}" != "ubuntu" ]]; then
-          tox -e py${PYVER/./}                   # basic
+          tox -e py${PYVER/./}                     # basic
         else
-          timeout $TIMEOUT tox || timeout $TIMEOUT tox || timeout $TIMEOUT tox
+          timeout 5m tox || timeout 5m tox || timeout 5m tox
         fi
       env:
         PYVER: ${{ matrix.python }}

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -327,9 +327,6 @@ of a neat one-line progress bar.
   * The same applies to ``itertools``.
   * Some useful convenience functions can be found under ``tqdm.contrib``.
 
-- `Hanging pipes in python2 <https://github.com/tqdm/tqdm/issues/359>`__:
-  when using ``tqdm`` on the CLI, you may need to use Python 3.5+ for correct
-  buffering.
 - `No intermediate output in docker-compose <https://github.com/tqdm/tqdm/issues/771>`__:
   use ``docker-compose run`` instead of ``docker-compose up`` and ``tty: true``.
 - Overriding defaults via environment variables:

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -291,6 +291,12 @@ The most common issues relate to excessive output on multiple lines, instead
 of a neat one-line progress bar.
 
 - Consoles in general: require support for carriage return (``CR``, ``\r``).
+
+  * Some cloud logging consoles which don't support ``\r`` properly
+    (`cloudwatch <https://github.com/tqdm/tqdm/issues/966>`__,
+    `K8s <https://github.com/tqdm/tqdm/issues/1319>`__) may benefit from
+    ``export TQDM_POSITION=-1``.
+
 - Nested progress bars:
 
   * Consoles in general: require support for moving cursors up to the
@@ -329,8 +335,9 @@ of a neat one-line progress bar.
 
 - `No intermediate output in docker-compose <https://github.com/tqdm/tqdm/issues/771>`__:
   use ``docker-compose run`` instead of ``docker-compose up`` and ``tty: true``.
+
 - Overriding defaults via environment variables:
-  e.g. in CI jobs, ``export TQDM_MININTERVAL=5`` to avoid log spam.
+  e.g. in CI/cloud jobs, ``export TQDM_MININTERVAL=5`` to avoid log spam.
   This override logic is handled by the ``tqdm.utils.envwrap`` decorator
   (useful independent of ``tqdm``).
 
@@ -346,7 +353,7 @@ Documentation
     class tqdm():
       """{DOC_tqdm}"""
 
-      @envwrap("TQDM_", is_method=True)  # override defaults via env vars
+      @envwrap("TQDM_")  # override defaults via env vars
       def __init__(self, iterable=None, desc=None, total=None, leave=True,
                    file=None, ncols=None, mininterval=0.1,
                    maxinterval=10.0, miniters=None, ascii=None, disable=False,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,9 @@ versions of Python.)
 
 Note: to install all versions of the Python interpreter that are specified
 in [tox.ini](https://github.com/tqdm/tqdm/blob/master/tox.ini),
-you can use `MiniConda` to install a minimal setup. You must also make sure
-that each distribution has an alias to call the Python interpreter:
-`python27` for Python 2.7's interpreter, `python32` for Python 3.2's, etc.
+you can use `MiniConda` to install a minimal setup. You must also ensure
+that each distribution has an alias to call the Python interpreter
+(e.g. `python311` for Python 3.11's interpreter).
 
 ### Alternative unit tests with pytest
 

--- a/README.rst
+++ b/README.rst
@@ -291,6 +291,12 @@ The most common issues relate to excessive output on multiple lines, instead
 of a neat one-line progress bar.
 
 - Consoles in general: require support for carriage return (``CR``, ``\r``).
+
+  * Some cloud logging consoles which don't support ``\r`` properly
+    (`cloudwatch <https://github.com/tqdm/tqdm/issues/966>`__,
+    `K8s <https://github.com/tqdm/tqdm/issues/1319>`__) may benefit from
+    ``export TQDM_POSITION=-1``.
+
 - Nested progress bars:
 
   * Consoles in general: require support for moving cursors up to the
@@ -329,8 +335,9 @@ of a neat one-line progress bar.
 
 - `No intermediate output in docker-compose <https://github.com/tqdm/tqdm/issues/771>`__:
   use ``docker-compose run`` instead of ``docker-compose up`` and ``tty: true``.
+
 - Overriding defaults via environment variables:
-  e.g. in CI jobs, ``export TQDM_MININTERVAL=5`` to avoid log spam.
+  e.g. in CI/cloud jobs, ``export TQDM_MININTERVAL=5`` to avoid log spam.
   This override logic is handled by the ``tqdm.utils.envwrap`` decorator
   (useful independent of ``tqdm``).
 
@@ -350,7 +357,7 @@ Documentation
       progressbar every time a value is requested.
       """
 
-      @envwrap("TQDM_", is_method=True)  # override defaults via env vars
+      @envwrap("TQDM_")  # override defaults via env vars
       def __init__(self, iterable=None, desc=None, total=None, leave=True,
                    file=None, ncols=None, mininterval=0.1,
                    maxinterval=10.0, miniters=None, ascii=None, disable=False,

--- a/README.rst
+++ b/README.rst
@@ -327,9 +327,6 @@ of a neat one-line progress bar.
   * The same applies to ``itertools``.
   * Some useful convenience functions can be found under ``tqdm.contrib``.
 
-- `Hanging pipes in python2 <https://github.com/tqdm/tqdm/issues/359>`__:
-  when using ``tqdm`` on the CLI, you may need to use Python 3.5+ for correct
-  buffering.
 - `No intermediate output in docker-compose <https://github.com/tqdm/tqdm/issues/771>`__:
   use ``docker-compose run`` instead of ``docker-compose up`` and ``tty: true``.
 - Overriding defaults via environment variables:

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -6,7 +6,7 @@
     "environment_type": "virtualenv",
     "build_command": ["PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} ."],
     "show_commit_url": "https://github.com/tqdm/tqdm/commit/",
-    // "pythons": ["2.7", "3.6"],
+    // "pythons": ["3.7", "3.11"],
     // "conda_channels": ["conda-forge", "defaults"],
     "matrix": {
         "alive-progress": [""],

--- a/examples/async_coroutines.py
+++ b/examples/async_coroutines.py
@@ -1,6 +1,4 @@
-"""
-Asynchronous examples using `asyncio`, `async` and `await` on `python>=3.7`.
-"""
+"""Asynchronous examples using `asyncio`, `async` and `await`."""
 import asyncio
 
 from tqdm.asyncio import tqdm, trange

--- a/examples/parallel_bars.py
+++ b/examples/parallel_bars.py
@@ -21,8 +21,7 @@ def progresser(n, auto_position=True, write_safe=False, blocking=True, progress=
         sleep(interval)
     # NB: may not clear instances with higher `position` upon completion
     # since this worker may not know about other bars #796
-    if write_safe:
-        # we think we know about other bars (currently only py3 threading)
+    if write_safe:  # we think we know about other bars
         if n == 6:
             tqdm.write("n == 6 completed")
     return n + 1

--- a/tests/tests_asyncio.py
+++ b/tests/tests_asyncio.py
@@ -1,4 +1,4 @@
-"""Tests `tqdm.asyncio` on `python>=3.7`."""
+"""Tests `tqdm.asyncio`."""
 import asyncio
 from functools import partial
 from sys import platform

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps=
     numpy
     pandas
     rich
-    !py311-tf: tensorflow!=2.5.0
+    tf: tensorflow!=2.5.0
     keras: keras
 commands=
     pytest --cov=tqdm --cov-report= -W=ignore tests_notebook.ipynb --nbval --current-env --sanitize-with=.meta/nbval.ini

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -10,6 +10,7 @@ Usage:
 # import compatibility functions and utilities
 import re
 import sys
+from html import escape
 from weakref import proxy
 
 # to inherit from the tqdm class
@@ -57,12 +58,6 @@ if True:  # pragma: no cover
         from IPython.display import display  # , clear_output
     except ImportError:
         pass
-
-    # HTML encoding
-    try:  # Py3
-        from html import escape
-    except ImportError:  # Py2
-        from cgi import escape
 
 __author__ = {"github.com/": ["lrq3000", "casperdcl", "alexanderkuk"]}
 __all__ = ['tqdm_notebook', 'tnrange', 'tqdm', 'trange']

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -949,13 +949,15 @@ class tqdm(Comparable):
         elif _Rolling_and_Expanding is not None:
             _Rolling_and_Expanding.progress_apply = inner_generator()
 
-    @envwrap("TQDM_", is_method=True)  # override defaults via env vars
+    # override defaults via env vars
+    @envwrap("TQDM_", is_method=True, types={'total': float, 'ncols': int, 'miniters': float,
+                                             'position': int, 'nrows': int})
     def __init__(self, iterable=None, desc=None, total=None, leave=True, file=None,
                  ncols=None, mininterval=0.1, maxinterval=10.0, miniters=None,
                  ascii=None, disable=False, unit='it', unit_scale=False,
                  dynamic_ncols=False, smoothing=0.3, bar_format=None, initial=0,
                  position=None, postfix=None, unit_divisor=1000, write_bytes=False,
-                 lock_args=None, nrows=None, colour=None, delay=0, gui=False,
+                 lock_args=None, nrows=None, colour=None, delay=0.0, gui=False,
                  **kwargs):
         """see tqdm.tqdm for arguments"""
         if file is None:


### PR DESCRIPTION
- fix `utils.envwrap` types (follow-up to #1491, fixes #966, fixes #1319, closes #1320)
  + e.g. cloudwatch & kubernetes workaround: `export TQDM_POSITION=-1`
- drop mentions of unsupported Python versions