### PR TITLE
fix HTML-escaped space padding in notebook

### DIFF
--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -157,6 +157,8 @@ class tqdm_notebook(std_tqdm):
         pbar.value = self.n
 
         if msg:
+            # take care of space padding in html
+            msg=msg.translate({ord(' ') : u'\u2007'})
             # html escape special characters (like '&')
             if '<bar/>' in msg:
                 left, right = map(escape, re.split(r'\|?<bar/>\|?', msg, maxsplit=1))

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -157,8 +157,7 @@ class tqdm_notebook(std_tqdm):
         pbar.value = self.n
 
         if msg:
-            # take care of space padding in html
-            msg=msg.translate({ord(' ') : u'\u2007'})
+            msg = msg.replace(' ', u'\u2007')  # fix html space padding
             # html escape special characters (like '&')
             if '<bar/>' in msg:
                 left, right = map(escape, re.split(r'\|?<bar/>\|?', msg, maxsplit=1))


### PR DESCRIPTION
The progress bar in Jupyter was misaligned (jumping when the number of digits changes) because html escape eats simple spaces. Replacing with UTF "Figure Space".