### PR TITLE
fix: keras.TqdmCallback: batch_bar does not always exist on_train_end

### DIFF
--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -94,7 +94,7 @@ class TqdmCallback(keras.callbacks.Callback):
                 raise KeyError('Unknown verbosity')
 
     def on_train_end(self, *_, **__):
-        if self.verbose:
+        if hasattr(self, 'batch_bar'):
             self.batch_bar.close()
         self.epoch_bar.close()
 


### PR DESCRIPTION
when `verbose==2`, TqdmCallback object does not define `batch_bar` inside `__init__` but only in `on_epoch_begin`.
If `keras.model.fit` is run after all training epochs are finished, `on_train_end` throws error because `self.batch_bar` does not exist.

Fix is to check if batch_bar attribute exists before closing it, similar to how it is handled inside `on_epoch_begin`. 