### PR TITLE
Fix DeprecationWarning for datetime.utcfromtimestamp in Python 3.12

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -10,7 +10,7 @@ Usage:
 import sys
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from numbers import Number
 from time import time
 from warnings import warn
@@ -577,7 +577,7 @@ class tqdm(Comparable):
         remaining_str = tqdm.format_interval(remaining) if rate else '?'
         try:
             eta_dt = (datetime.now() + timedelta(seconds=remaining)
-                      if rate and total else datetime.utcfromtimestamp(0))
+                      if rate and total else datetime.fromtimestamp(0, timezone.utc))
         except OverflowError:
             eta_dt = datetime.max
 


### PR DESCRIPTION
## Summary
This PR fixes the DeprecationWarning that is raised when using `datetime.datetime.utcfromtimestamp` in Python 3.12.

## Changes made
In the `tqdm/std.py` file:
- Changed the import statement from `from datetime import datetime, timedelta` to `from datetime import datetime, timedelta, timezone`.
- Replaced `datetime.datetime.utcfromtimestamp(0)` with `datetime.datetime.fromtimestamp(0, datetime.timezone.utc)`.

## Linked Issue
This PR fixes issue [#1517]: "Use of datetime.datetime.utcfromtimestamp shows DeprecationWarning in Python 3.12".

## How to test
The changes have been tested on Python 3.12 and the warning is no longer raised.

Fixes [#1517]