### PR TITLE
Add support for enumerate

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1980,3 +1980,8 @@ def test_contains(capsys):
     assert not out
     assert '  0%' in err
     assert '100%' not in err
+
+
+def test_enumerate():
+    t = tqdm(enumerate(range(10)))
+    assert t.total == 10

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -976,7 +976,10 @@ class tqdm(Comparable):
 
         if total is None and iterable is not None:
             try:
-                total = len(iterable)
+                if isinstance(iterable, enumerate):
+                    total = len(list(iterable))
+                else:
+                    total = len(iterable)
             except (TypeError, AttributeError):
                 total = None
         if total == float("inf"):


### PR DESCRIPTION
Enable the use of "enumerate" as iterable of tqdm. With this feature, tqdm automatically compute the total number of iterations when the argument of tqdm is of type "enumerate"