### PR TITLE
fix wrong bar scaling when in notebook and using unit_scale

### DIFF
--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -228,8 +228,7 @@ class tqdm_notebook(std_tqdm):
         self.ncols = '100%' if self.dynamic_ncols else kwargs.get("ncols", None)
 
         # Replace with IPython progress bar display (with correct total)
-        unit_scale = 1 if self.unit_scale is True else self.unit_scale or 1
-        total = self.total * unit_scale if self.total else self.total
+        total = self.total
         self.container = self.status_printer(self.fp, total, self.desc, self.ncols)
         self.container.pbar = proxy(self)
         self.displayed = False


### PR DESCRIPTION
When using `tqdm.notebook.tqdm` with the `unit_scale` option, the progress bar is not drawn properly, as `total` is multiplied by `unit_scale` twice. This PR aims to fix the problem.

Minimum example of the issue:

```python
from tqdm.notebook import tqdm
from time import sleep

for _ in tqdm(range(0, 100, 10), unit_scale=10):
    sleep(0.1)
```