### PR TITLE
Fix docstring of thread_map

### DIFF
--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -63,7 +63,7 @@ def thread_map(fn, *iterables, **tqdm_kwargs):
     max_workers  : int, optional
         Maximum number of workers to spawn; passed to
         `concurrent.futures.ThreadPoolExecutor.__init__`.
-        [default: max(32, cpu_count() + 4)].
+        [default: min(32, cpu_count() + 4)].
     """
     from concurrent.futures import ThreadPoolExecutor
     return _executor_map(ThreadPoolExecutor, fn, *iterables, **tqdm_kwargs)


### PR DESCRIPTION
Replace `max` with `min` in `contrib.concurrent.thread_map` docstring about default `max_workers`.