### PR TITLE
Replace deprecated disco-py client in tqdm.contrib.discord by discord.py

### DIFF
--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -125,8 +125,8 @@ class tqdm_discord(tqdm_auto):
                     )
             else:
                 self.dio = DiscordIO(
-                    kwargs.pop('token', getenv("TQDM_DISCORD_TOKEN")),
-                    kwargs.pop('channel_id', getenv("TQDM_DISCORD_CHANNEL_ID"))
+                    token=kwargs.pop('token', getenv("TQDM_DISCORD_TOKEN")),
+                    channel_id=kwargs.pop('channel_id', getenv("TQDM_DISCORD_CHANNEL_ID"))
                     )
             kwargs['mininterval'] = max(1.5, kwargs.get('mininterval', 1.5))
         super(tqdm_discord, self).__init__(*args, **kwargs)

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -63,7 +63,7 @@ class DiscordIO(MonoWorker):
 
     async def start_bot(self):
         if self.loop.is_running():
-        await self.client.start(self.token)
+            await self.client.start(self.token)
         else:
             self.loop.create_task(self.client.start(self.token))
 

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -31,7 +31,7 @@ class DiscordIO(MonoWorker):
             intents = discord.Intents(messages=True, guilds=True)
             instance.client = discord.Client(intents=intents)
             instance.loop = asyncio.get_event_loop()
-            instance.start_bot()
+            await instance.start_bot()
             # Wait for the bot to be ready before continuing
             instance.loop.run_until_complete(instance.client.wait_until_ready())
             # Attempt to get the channel

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -1,89 +1,92 @@
-import logging
 from os import getenv
-import asyncio
-import nest_asyncio
+from warnings import warn
 
-try:
-    import discord
-except ImportError:
-    raise ImportError("Please `pip install discord.py`")
+import requests
 
 from ..auto import tqdm as tqdm_auto
+from ..std import TqdmWarning
 from .utils_worker import MonoWorker
+from ..version import __version__
 
-nest_asyncio.apply()
-
-__author__ = {"github.com/": ["casperdcl", "Guigoruiz1", "xx-05"]}
-__all__ = ['DiscordIO', 'tqdm_discord', 'tdrange', 'tqdm', 'trange']
+__author__ = {"github.com/": ["casperdcl"]}
+__all__ = ["DiscordIO", "tqdm_discord", "ddrange", "tqdm", "drange"]
 
 
 class DiscordIO(MonoWorker):
     """Non-blocking file-like IO using a Discord Bot."""
-    def __init__(self):
+
+    API = "https://discord.com/api/v10"
+
+    def __init__(self, token, channel_id):
+        """Creates a new message in the given `channel_id`."""
         super(DiscordIO, self).__init__()
+        self.token = token
+        self.channel_id = channel_id
         self.text = self.__class__.__name__
-        self.message = None
+        self.message_id
 
-    @classmethod
-    def from_token(cls, token, channel_id):
-        """Create a new DiscordIO instance using a bot token and channel ID."""
-        instance = cls()
-        instance.channel_id = channel_id
-        instance.token = token
+    @property
+    def message_id(self):
+        if hasattr(self, "_message_id"):
+            return self._message_id
         try:
-            intents = discord.Intents(messages=True, guilds=True)
-            instance.loop = asyncio.new_event_loop()
-            instance.client = discord.Client(intents=intents, loop=instance.loop)
-            instance.loop.create_task(instance.start_bot())
-            # Wait for the bot to be ready before continuing
-            instance.loop.run_until_complete(instance.client.wait_until_ready())
-            # Attempt to get the channel
-            channel = instance.client.get_channel(int(channel_id))
-            if channel:
-                # Ensure the bot has the necessary permissions to send messages
-                if channel.permissions_for(channel.guild.me).send_messages:
-                    # Send the initial message and store it in self.message
-                    instance.message = instance.loop.run_until_complete(channel.send(instance.text))
-                else:
-                    tqdm_auto.write("Error: Bot doesn't have permission to send messages to the channel.")
-            else:
-                tqdm_auto.write(f"Error: Unable to find channel with ID {channel_id}")
+            headers = {
+                "Authorization": f"Bot {self.token}",
+                "User-Agent": f"TQDM Discord progress bar (http://github.com/tqdm/tqdm, {__version__})",
+            }
+            data = {"content": "`" + self.text + "`"}
+            res = requests.post(
+                f"{self.API}/channels/{self.channel_id}/messages",
+                headers=headers,
+                json=data,
+            ).json()
         except Exception as e:
             tqdm_auto.write(str(e))
-        return instance
-
-    @classmethod
-    def from_webhook(cls, webhook_url):
-        """Create a new DiscordIO instance using a webhook URL."""
-        instance = cls()
-        instance.webhook_url = webhook_url
-        try:
-            webhook = discord.SyncWebhook.from_url(webhook_url)
-            instance.message = webhook.send(instance.text, wait=True)
-        except Exception as e:
-            tqdm_auto.write(str(e))
-        return instance
-
-    async def start_bot(self):
-        await self.client.start(self.token)
-
-    def _edit_message(self, content):
-        """Wraps the `message.edit` method to make the `content` keyword argument positional."""
-        if hasattr(self, "loop"):
-            self.loop.run_until_complete(self.message.edit(content=content))
         else:
-            self.message.edit(content=content)
+            if "id" in res:
+                self._message_id = res["id"]
+                return self._message_id
 
     def write(self, s):
-        """Replaces internal `message`'s text with `s`."""
+        """Replaces internal `message_id`'s text with `s`."""
         if not s:
             s = "..."
-        s = s.replace('\r', '').strip()
-        if s == self.text or self.message is None:
-            return  # skip duplicate message or if message is not available
+        s = s.replace("\r", "").strip()
+        if s == self.text:
+            return  # avoid duplicate message Bot error
+        message_id = self.message_id
+        if message_id is None:
+            return
         self.text = s
         try:
-            future = self.submit(self._edit_message, '`' + s + '`')
+            headers = {
+                "Authorization": f"Bot {self.token}",
+                "User-Agent": f"TQDM Discord progress bar (http://github.com/tqdm/tqdm, {__version__})",
+            }
+            data = {"content": "`" + s + "`"}
+            future = self.submit(
+                requests.patch,
+                f"{self.API}/channels/{self.channel_id}/messages/{message_id}",
+                headers=headers,
+                json=data,
+            )
+        except Exception as e:
+            tqdm_auto.write(str(e))
+        else:
+            return future
+
+    def delete(self):
+        """Deletes internal `message_id`."""
+        try:
+            headers = {
+                "Authorization": f"Bot {self.token}",
+                "User-Agent": f"TQDM Discord progress bar (http://github.com/tqdm/tqdm, {__version__})",
+            }
+            future = self.submit(
+                requests.delete,
+                f"{self.API}/channels/{self.channel_id}/messages/{self.message_id}",
+                headers=headers,
+            )
         except Exception as e:
             tqdm_auto.write(str(e))
         else:
@@ -95,54 +98,41 @@ class tqdm_discord(tqdm_auto):
     Standard `tqdm.auto.tqdm` but also sends updates to a Discord Bot.
     May take a few seconds to create (`__init__`).
 
-    - create a discord bot (not public, no requirement of OAuth2 code
-      grant, only send message permissions) & invite it to a channel:
-      <https://discordpy.readthedocs.io/en/latest/discord.html>
-    - copy the bot `{token}` & `{channel_id}` and paste below
-
-    >>> from tqdm.contrib.discord import tqdm, trange
+    >>> from tqdm.contrib.discord import tqdm, drange
     >>> for i in tqdm(iterable, token='{token}', channel_id='{channel_id}'):
     ...     ...
     """
+
     def __init__(self, *args, **kwargs):
         """
         Parameters
         ----------
-        token  : str, required if not using webhook_url. Discord token
+        token  : str, required. Discord bot token
             [default: ${TQDM_DISCORD_TOKEN}].
-        channel_id  : int, required if not using webhook_url. Discord channel ID
+        channel_id  : str, required. Discord channel ID
             [default: ${TQDM_DISCORD_CHANNEL_ID}].
-        webhook_url  : str, required if not using token and channel_id. Discord channel webhook url
-            [default: ${TQDM_DISCORD_WEBHOOK_URL}].
-        webhook: bool, optional. If True, use a webhook instead of a bot. Defaults to False.
-        mininterval  : float, optional.
-          Minimum of [default: 1.5] to avoid rate limit.
 
         See `tqdm.auto.tqdm.__init__` for other parameters.
         """
-        if not kwargs.get('disable'):
+        if not kwargs.get("disable"):
             kwargs = kwargs.copy()
-            logging.getLogger("HTTPClient").setLevel(logging.WARNING)
-            if kwargs.get("webhook", False) or "webhook_url" in kwargs:
-                self.dio = DiscordIO.from_webhook(
-                    webhook_url=kwargs.pop('webhook_url', getenv("TQDM_DISCORD_WEBHOOK_URL"))
-                    )
-            else:
-                self.dio = DiscordIO.from_token(
-                    token=kwargs.pop('token', getenv("TQDM_DISCORD_TOKEN")),
-                    channel_id=kwargs.pop('channel_id', getenv("TQDM_DISCORD_CHANNEL_ID"))
-                    )
-            kwargs['mininterval'] = max(1.5, kwargs.get('mininterval', 1.5))
+            self.dio = DiscordIO(
+                kwargs.pop("token", getenv("TQDM_DISCORD_TOKEN")),
+                kwargs.pop("channel_id", getenv("TQDM_DISCORD_CHANNEL_ID")),
+            )
         super(tqdm_discord, self).__init__(*args, **kwargs)
 
     def display(self, **kwargs):
         super(tqdm_discord, self).display(**kwargs)
         fmt = self.format_dict
-        if fmt.get('bar_format', None):
-            fmt['bar_format'] = fmt['bar_format'].replace(
-                '<bar/>', '{bar:10u}').replace('{bar}', '{bar:10u}')
+        if fmt.get("bar_format", None):
+            fmt["bar_format"] = (
+                fmt["bar_format"]
+                .replace("<bar/>", "{bar:10u}")
+                .replace("{bar}", "{bar:10u}")
+            )
         else:
-            fmt['bar_format'] = '{l_bar}{bar:10u}{r_bar}'
+            fmt["bar_format"] = "{l_bar}{bar:10u}{r_bar}"
         self.dio.write(self.format_meter(**fmt))
 
     def clear(self, *args, **kwargs):
@@ -150,12 +140,19 @@ class tqdm_discord(tqdm_auto):
         if not self.disable:
             self.dio.write("")
 
+    def close(self):
+        if self.disable:
+            return
+        super(tqdm_discord, self).close()
+        if not (self.leave or (self.leave is None and self.pos == 0)):
+            self.dio.delete()
 
-def tdrange(*args, **kwargs):
+
+def ddrange(*args, **kwargs):
     """Shortcut for `tqdm.contrib.discord.tqdm(range(*args), **kwargs)`."""
     return tqdm_discord(range(*args), **kwargs)
 
 
 # Aliases
 tqdm = tqdm_discord
-trange = tdrange
+drange = ddrange

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -10,7 +10,7 @@ except ImportError:
 from ..auto import tqdm as tqdm_auto
 from .utils_worker import MonoWorker
 
-__author__ = {"github.com/": ["casperdcl"]}
+__author__ = {"github.com/": ["casperdcl", "Guigoruiz1", "xx-05"]}
 __all__ = ['DiscordIO', 'tqdm_discord', 'tdrange', 'tqdm', 'trange']
 
 

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -1,20 +1,10 @@
-"""
-Sends updates to a Discord bot.
-
-Usage:
->>> from tqdm.contrib.discord import tqdm, trange
->>> for i in trange(10, token='{token}', channel_id='{channel_id}'):
-...     ...
-
-![screenshot](https://tqdm.github.io/img/screenshot-discord.png)
-"""
 import logging
 from os import getenv
 
 try:
-    from disco.client import Client, ClientConfig
+    import discord
 except ImportError:
-    raise ImportError("Please `pip install disco-py`")
+    raise ImportError("Please `pip install discord.py`")
 
 from ..auto import tqdm as tqdm_auto
 from .utils_worker import MonoWorker
@@ -28,12 +18,13 @@ class DiscordIO(MonoWorker):
     def __init__(self, token, channel_id):
         """Creates a new message in the given `channel_id`."""
         super(DiscordIO, self).__init__()
-        config = ClientConfig()
-        config.token = token
-        client = Client(config)
+        self.token = token
+        self.channel_id = channel_id
         self.text = self.__class__.__name__
         try:
-            self.message = client.api.channels_messages_create(channel_id, self.text)
+            self.client = discord.Client(intents=discord.Intents.default())
+            self.client.run(token)
+            self.message = self.client.get_channel(channel_id).send(self.text)
         except Exception as e:
             tqdm_auto.write(str(e))
             self.message = None

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -34,15 +34,15 @@ class DiscordIO(MonoWorker):
             instance.loop = asyncio.get_event_loop()
 
             if instance.loop.is_running():
+                print("loop is running")
                 instance.start_bot()
             else:
+                print("loop is not running")
                 asyncio.set_event_loop(instance.loop)
                 instance.start_bot()
                 instance.loop.run_until_complete(instance.client.wait_until_ready())
 
             # Attempt to get the channel
-            print(instance.client)
-            print(instance.client.get_channel(channel_id))
             channel = instance.client.get_channel(int(channel_id))
             if channel:
                 # Ensure the bot has the necessary permissions to send messages

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -30,7 +30,7 @@ class DiscordIO(MonoWorker):
             # Wait for the bot to be ready before continuing
             self.loop.run_until_complete(self.client.wait_until_ready())
             # Attempt to get the channel
-            channel = self.client.get_channel(channel_id)
+            channel = self.client.get_channel(int(channel_id))
             if channel:
                 # Ensure the bot has the necessary permissions to send messages
                 if channel.permissions_for(channel.guild.me).send_messages:

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -38,7 +38,7 @@ class DiscordIO(MonoWorker):
             # Wait for the bot to be ready before continuing
             instance.loop.run_until_complete(instance.client.wait_until_ready())
             # Attempt to get the channel
-            channel = instance.client.get_channel(int(channel_id))
+            channel = instance.client.get_channel(channel_id)
             if channel:
                 # Ensure the bot has the necessary permissions to send messages
                 if channel.permissions_for(channel.guild.me).send_messages:

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -71,9 +71,10 @@ class DiscordIO(MonoWorker):
 
     def start_bot(self):
         if self.loop.is_running():
-            self.loop.run_until_complete(self.client.start(self.token))
+            asyncio.ensure_future(self.client.start(self.token))
         else:
-            self.loop.create_task(self.client.start(self.token))
+            self.loop.run_until_complete(self.client.start(self.token))
+
 
 
     def _edit_message(self, content):

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -31,7 +31,7 @@ class DiscordIO(MonoWorker):
             intents = discord.Intents(messages=True, guilds=True)
             instance.client = discord.Client(intents=intents)
             instance.loop = asyncio.get_event_loop()
-            instance.loop.create_task(instance.start_bot())
+            instance.start_bot()
             # Wait for the bot to be ready before continuing
             instance.loop.run_until_complete(instance.client.wait_until_ready())
             # Attempt to get the channel
@@ -62,7 +62,10 @@ class DiscordIO(MonoWorker):
         return instance
 
     async def start_bot(self):
+        if self.loop.is_running():
         await self.client.start(self.token)
+        else:
+            self.loop.create_task(self.client.start(self.token))
 
     def _edit_message(self, content):
         """Wraps the `message.edit` method to make the `content` keyword argument positional."""

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -1,7 +1,7 @@
 import logging
 from os import getenv
 import asyncio
-import nest_asyncio  # Import nest_asyncio
+import nest_asyncio
 
 try:
     import discord
@@ -11,7 +11,7 @@ except ImportError:
 from ..auto import tqdm as tqdm_auto
 from .utils_worker import MonoWorker
 
-nest_asyncio.apply()  # Apply nest_asyncio
+nest_asyncio.apply()
 
 __author__ = {"github.com/": ["casperdcl", "Guigoruiz1", "xx-05"]}
 __all__ = ['DiscordIO', 'tqdm_discord', 'tdrange', 'tqdm', 'trange']
@@ -52,7 +52,43 @@ class DiscordIO(MonoWorker):
             tqdm_auto.write(str(e))
         return instance
 
-    # ... (rest of your class definitions remain the same)
+    @classmethod
+    def from_webhook(cls, webhook_url):
+        """Create a new DiscordIO instance using a webhook URL."""
+        instance = cls()
+        instance.webhook_url = webhook_url
+        try:
+            webhook = discord.SyncWebhook.from_url(webhook_url)
+            instance.message = webhook.send(instance.text, wait=True)
+        except Exception as e:
+            tqdm_auto.write(str(e))
+        return instance
+
+    async def start_bot(self):
+        await self.client.start(self.token)
+
+    def _edit_message(self, content):
+        """Wraps the `message.edit` method to make the `content` keyword argument positional."""
+        if hasattr(self, "loop"):
+            self.loop.run_until_complete(self.message.edit(content=content))
+        else:
+            self.message.edit(content=content)
+
+    def write(self, s):
+        """Replaces internal `message`'s text with `s`."""
+        if not s:
+            s = "..."
+        s = s.replace('\r', '').strip()
+        if s == self.text or self.message is None:
+            return  # skip duplicate message or if message is not available
+        self.text = s
+        try:
+            future = self.submit(self._edit_message, '`' + s + '`')
+        except Exception as e:
+            tqdm_auto.write(str(e))
+        else:
+            return future
+
 
 class tqdm_discord(tqdm_auto):
     """
@@ -99,7 +135,26 @@ class tqdm_discord(tqdm_auto):
             kwargs['mininterval'] = max(1.5, kwargs.get('mininterval', 1.5))
         super(tqdm_discord, self).__init__(*args, **kwargs)
 
-    # ... (rest of your class definitions remain the same)
+    def display(self, **kwargs):
+        super(tqdm_discord, self).display(**kwargs)
+        fmt = self.format_dict
+        if fmt.get('bar_format', None):
+            fmt['bar_format'] = fmt['bar_format'].replace(
+                '<bar/>', '{bar:10u}').replace('{bar}', '{bar:10u}')
+        else:
+            fmt['bar_format'] = '{l_bar}{bar:10u}{r_bar}'
+        self.dio.write(self.format_meter(**fmt))
+
+    def clear(self, *args, **kwargs):
+        super(tqdm_discord, self).clear(*args, **kwargs)
+        if not self.disable:
+            self.dio.write("")
+
+
+def tdrange(*args, **kwargs):
+    """Shortcut for `tqdm.contrib.discord.tqdm(range(*args), **kwargs)`."""
+    return tqdm_discord(range(*args), **kwargs)
+
 
 # Aliases
 tqdm = tqdm_discord

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -119,7 +119,7 @@ class tqdm_discord(tqdm_auto):
         if not kwargs.get('disable'):
             kwargs = kwargs.copy()
             logging.getLogger("HTTPClient").setLevel(logging.WARNING)
-            if kwargs.get("webhook", False):
+            if kwargs.get("webhook", False) or "webhook_url" in kwargs:
                 self.dio = DiscordIO.from_webhook(
                     webhook_url=kwargs.pop('webhook_url', getenv("TQDM_DISCORD_WEBHOOK_URL"))
                     )

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -37,6 +37,9 @@ class DiscordIO(MonoWorker):
         except Exception as e:
             tqdm_auto.write(str(e))
             self.message = None
+    
+    async def start_bot(self):
+        await self.client.start(self.token)
 
     def write(self, s):
         """Replaces internal `message`'s text with `s`."""

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -1,6 +1,8 @@
 import logging
 from os import getenv
 import asyncio
+import nest_asyncio
+nest_asyncio.apply()
 
 try:
     import discord
@@ -28,8 +30,7 @@ class DiscordIO(MonoWorker):
         instance.channel_id = channel_id
         instance.token = token
         try:
-            instance.loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(instance.loop)
+            instance.loop = asyncio.get_event_loop()
             intents = discord.Intents(messages=True, guilds=True)
             instance.client = discord.Client(intents=intents, loop=instance.loop)
             instance.loop.create_task(instance.start_bot())

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -38,7 +38,7 @@ class DiscordIO(MonoWorker):
             # Wait for the bot to be ready before continuing
             instance.loop.run_until_complete(instance.client.wait_until_ready())
             # Attempt to get the channel
-            channel = instance.client.get_channel(channel_id)
+            channel = instance.client.get_channel(int(channel_id))
             if channel:
                 # Ensure the bot has the necessary permissions to send messages
                 if channel.permissions_for(channel.guild.me).send_messages:

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -105,10 +105,12 @@ class tqdm_discord(tqdm_auto):
         """
         Parameters
         ----------
-        token  : str, required. Discord token
+        token  : str, required if not using webhook_url. Discord token
             [default: ${TQDM_DISCORD_TOKEN}].
-        channel_id  : int, required. Discord channel ID
+        channel_id  : int, required if not using webhook_url. Discord channel ID
             [default: ${TQDM_DISCORD_CHANNEL_ID}].
+        webhook_url  : str, required if not using token and channel_id. Discord channel webhook url
+            [default: ${TQDM_DISCORD_WEBHOOK_URL}].
         mininterval  : float, optional.
           Minimum of [default: 1.5] to avoid rate limit.
 
@@ -117,9 +119,15 @@ class tqdm_discord(tqdm_auto):
         if not kwargs.get('disable'):
             kwargs = kwargs.copy()
             logging.getLogger("HTTPClient").setLevel(logging.WARNING)
-            self.dio = DiscordIO(
-                kwargs.pop('token', getenv("TQDM_DISCORD_TOKEN")),
-                kwargs.pop('channel_id', getenv("TQDM_DISCORD_CHANNEL_ID")))
+            if "webhook_url" in kwargs:
+                self.dio = DiscordIO(
+                    webhook_url=kwargs.pop('webhook_url', getenv("TQDM_DISCORD_WEBHOOK_URL"))
+                    )
+            else:
+                self.dio = DiscordIO(
+                    kwargs.pop('token', getenv("TQDM_DISCORD_TOKEN")),
+                    kwargs.pop('channel_id', getenv("TQDM_DISCORD_CHANNEL_ID"))
+                    )
             kwargs['mininterval'] = max(1.5, kwargs.get('mininterval', 1.5))
         super(tqdm_discord, self).__init__(*args, **kwargs)
 

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -33,12 +33,12 @@ class DiscordIO(MonoWorker):
     
             if not instance.loop.is_running():
                 instance.loop.create_task(instance.start_bot())
-                instance.loop.run_until_complete(instance.wait_until_bot_ready())
+                asyncio.run_coroutine_threadsafe(instance.wait_until_bot_ready(), instance.loop)
             else:
                 # Run the coroutine in the correct thread
                 asyncio.run_coroutine_threadsafe(instance.start_bot(), instance.loop)
-                instance.loop.run_until_complete(instance.wait_until_bot_ready())
-    
+                asyncio.run_coroutine_threadsafe(instance.wait_until_bot_ready(), instance.loop)
+
             # Attempt to get the channel
             channel = instance.client.get_channel(int(channel_id))
             if channel:

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -4,7 +4,6 @@ import asyncio
 
 try:
     import discord
-    from discord.ext import commands
 except ImportError:
     raise ImportError("Please `pip install discord.py`")
 
@@ -25,7 +24,7 @@ class DiscordIO(MonoWorker):
         self.text = self.__class__.__name__
         try:
             intents = discord.Intents(messages=True, guilds=True)
-            self.client = commands.Bot(command_prefix="!", intents=intents)
+            self.client = discord.Client(intents=intents)
             self.loop = asyncio.get_event_loop()
             self.loop.create_task(self.start_bot())
             # Wait for the bot to be ready before continuing

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -31,6 +31,8 @@ class DiscordIO(MonoWorker):
 
         if token and channel_id:
             # Bot-based initialization
+            self.token = token
+            self.channel_id = channel_id
             try:
                 intents = discord.Intents(messages=True, guilds=True)
                 self.client = discord.Client(intents=intents)
@@ -39,7 +41,7 @@ class DiscordIO(MonoWorker):
                 # Wait for the bot to be ready before continuing
                 self.loop.run_until_complete(self.client.wait_until_ready())
                 # Attempt to get the channel
-                channel = self.client.get_channel(int(channel_id))
+                channel = self.client.get_channel(int(self.channel_id))
                 if channel:
                     # Ensure the bot has the necessary permissions to send messages
                     if channel.permissions_for(channel.guild.me).send_messages:
@@ -53,6 +55,7 @@ class DiscordIO(MonoWorker):
                 tqdm_auto.write(str(e))
         elif webhook_url:
             # Webhook-based initialization
+            self.webhook_url = webhook_url
             try:
                 webhook = discord.SyncWebhook.from_url(webhook_url)
                 self.message = webhook.send(self.text, wait=True)

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -41,6 +41,8 @@ class DiscordIO(MonoWorker):
                 instance.loop.run_until_complete(instance.client.wait_until_ready())
 
             # Attempt to get the channel
+            print(instance.client)
+            print(instance.client.get_channel(channel_id))
             channel = instance.client.get_channel(int(channel_id))
             if channel:
                 # Ensure the bot has the necessary permissions to send messages

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -1,7 +1,9 @@
 import logging
 from os import getenv
+import asyncio
 
 try:
+    import discord
     from discord.ext import commands
 except ImportError:
     raise ImportError("Please `pip install discord.py`")

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -54,7 +54,10 @@ class DiscordIO(MonoWorker):
             tqdm_auto.write(str(e))
         return instance
 
-
+    async def wait_until_bot_ready(self):
+        """Wait until the Discord bot is ready."""
+        while not self.client.is_ready():
+            await asyncio.sleep(1)
 
     @classmethod
     def from_webhook(cls, webhook_url):


### PR DESCRIPTION
This PR is an extension to PR #1383 with the capability of choosing which `channel_id` to post the progress bar maintained. In this PR the user can choose between the simplified webhook method used in PR #1383 or using a `token` and `channel_id` as done before with disco-py. The handling of the client when using token and channel_id is asynchronous and relies on `asyncio`.  I have tested all variations and it works, although the webhook method is slightly faster to start.