### PR TITLE
chore: replace deprecated exceptions

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -998,7 +998,7 @@ are files (rather than folders):
         # total=1 assumes `path` is a file
         t = tqdm(total=1, unit="file", disable=not show_progress)
         if not os.path.exists(path):
-            raise IOError("Cannot find:" + path)
+            raise OSError("Cannot find:" + path)
 
         def append_found_file(f):
             files.append(f)

--- a/README.rst
+++ b/README.rst
@@ -1215,7 +1215,7 @@ are files (rather than folders):
         # total=1 assumes `path` is a file
         t = tqdm(total=1, unit="file", disable=not show_progress)
         if not os.path.exists(path):
-            raise IOError("Cannot find:" + path)
+            raise OSError("Cannot find:" + path)
 
         def append_found_file(f):
             files.append(f)

--- a/examples/7zx.py
+++ b/examples/7zx.py
@@ -89,7 +89,7 @@ def main():
                     while True:
                         try:
                             l_raw = m.readline()
-                        except IOError:
+                        except OSError:
                             break
                         ln = l_raw.strip()
                         if ln.startswith("Extracting"):


### PR DESCRIPTION
IOError deprecated since py version 3.3, use OSError instead