### PR TITLE
contrib.concurrent: Use python default max_workers

### DIFF
--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -3,7 +3,6 @@ Thin wrappers around `concurrent.futures`.
 """
 from contextlib import contextmanager
 from operator import length_hint
-from os import cpu_count
 
 from ..auto import tqdm as tqdm_auto
 from ..std import TqdmWarning
@@ -33,7 +32,7 @@ def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
     Parameters
     ----------
     tqdm_class  : [default: tqdm.auto.tqdm].
-    max_workers  : [default: min(32, cpu_count() + 4)].
+    max_workers  : [default: None].
     chunksize  : [default: 1].
     lock_name  : [default: "":str].
     """
@@ -41,7 +40,7 @@ def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
     if "total" not in kwargs:
         kwargs["total"] = length_hint(iterables[0])
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
-    max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))
+    max_workers = kwargs.pop("max_workers", None)
     chunksize = kwargs.pop("chunksize", 1)
     lock_name = kwargs.pop("lock_name", "")
     with ensure_lock(tqdm_class, lock_name=lock_name) as lk:
@@ -71,7 +70,6 @@ def thread_map(fn, *iterables, **tqdm_kwargs):
     max_workers  : int, optional
         Maximum number of workers to spawn; passed to
         `concurrent.futures.ThreadPoolExecutor.__init__`.
-        [default: max(32, cpu_count() + 4)].
     """
     from concurrent.futures import ThreadPoolExecutor
     return _executor_map(ThreadPoolExecutor, fn, *iterables, **tqdm_kwargs)
@@ -89,7 +87,6 @@ def process_map(fn, *iterables, **tqdm_kwargs):
     max_workers  : int, optional
         Maximum number of workers to spawn; passed to
         `concurrent.futures.ProcessPoolExecutor.__init__`.
-        [default: min(32, cpu_count() + 4)].
     chunksize  : int, optional
         Size of chunks sent to worker processes; passed to
         `concurrent.futures.ProcessPoolExecutor.map`. [default: 1].


### PR DESCRIPTION
I noticed that contrib.concurrent defines its own default for max_workers, which is the same as CPython's default for [ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor) in CPython 3.8+, but differs from the default for [ProcessPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor):
> If max_workers is None or not given, it will default to the number of processors on the machine...If max_workers is None, then the default chosen will be at most 61, even if more processors are available.

This was surprising to me. If the running code is CPU-bound, which is usually why you'd use `process_map` instead of `thread_map`, there usually isn't a noticeable speed improvement to spawn more processes than the number of available CPUs. In my case, `cpu_count + 4` ended up using more RAM than necessary for maximum speed improvement. I'm using a package that loads an index into memory at 800 MB per process, so that's an unnecessary extra 3.2 GB used by default.

Obsoletes #1530 and #1518.