### PR TITLE
add keyword 'repeat' for tqdm.contrib.itertools.product

### DIFF
--- a/tests/tests_itertools.py
+++ b/tests/tests_itertools.py
@@ -24,3 +24,5 @@ def test_product():
         assert list(product(a, a[::-1], file=our_file)) == list(it.product(a, a[::-1]))
 
         assert list(product(a, NoLenIter(a), file=our_file)) == list(it.product(a, NoLenIter(a)))
+
+        assert list(product(a, repeat=2, file=our_file)) == list(it.product(a, repeat=2))

--- a/tqdm/contrib/itertools.py
+++ b/tqdm/contrib/itertools.py
@@ -9,7 +9,7 @@ __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['product']
 
 
-def product(*iterables, **tqdm_kwargs):
+def product(*iterables, repeat=1, **tqdm_kwargs):
     """
     Equivalent of `itertools.product`.
 
@@ -29,7 +29,7 @@ def product(*iterables, **tqdm_kwargs):
             total *= i
         kwargs.setdefault("total", total)
     with tqdm_class(**kwargs) as t:
-        it = itertools.product(*iterables)
+        it = itertools.product(*iterables, repeat=repeat)
         for i in it:
             yield i
             t.update()


### PR DESCRIPTION
At now keyword 'repeat' don't work in tqdm.contrib.itertools.product()

From itertools docs:

> itertools.product(*iterables, repeat=1)
> ....
> To compute the product of an iterable with itself, specify the number of repetitions with the optional repeat keyword argument. For example, product(A, repeat=4) means the same as product(A, A, A, A).

There is my solution for this problem.
