### PR TITLE
Add support for Spyder in tqdm.auto

### DIFF
--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -6,7 +6,6 @@ Usage:
 >>> for i in trange(10):
 ...     ...
 """
-import os
 import sys
 from warnings import warn
 
@@ -22,8 +21,9 @@ try:
 except Exception:
     from .std import tqdm, trange
 else:  # pragma: no cover
-    if "SPY_TESTING" in os.environ:
-        # we are running in the Spyder environment
+    if get_ipython().__class__.__name__ == 'SpyderShell':
+        # we are running in the Spyder environment,
+        # see https://github.com/spyder-ide/spyder/issues/21929
         from .std import tqdm, trange
     else:
         from .notebook import tqdm, trange

--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -23,7 +23,7 @@ except Exception:
     from .std import tqdm, trange
 else:  # pragma: no cover
     if "SPY_TESTING" in os.environ:
-        # we are running in the Spyder environment, 
+        # we are running in the Spyder environment
         from .std import tqdm, trange
     else:
         from .notebook import tqdm, trange

--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -6,6 +6,7 @@ Usage:
 >>> for i in trange(10):
 ...     ...
 """
+import os
 import sys
 from warnings import warn
 
@@ -21,7 +22,11 @@ try:
 except Exception:
     from .std import tqdm, trange
 else:  # pragma: no cover
-    from .notebook import tqdm, trange
+    if "SPY_TESTING" in os.environ:
+        # we are running in the Spyder environment, 
+        from .std import tqdm, trange
+    else:
+        from .notebook import tqdm, trange
     from .std import TqdmExperimentalWarning
     warn("Using `tqdm.autonotebook.tqdm` in notebook mode."
          " Use `tqdm.tqdm` instead to force console mode"


### PR DESCRIPTION
The [Spyder](https://github.com/spyder-ide/spyder) environment console uses IPython, and are therefore recognized by tqdm as notebooks. The progress bar does only work with `tqmd.std` though. In this PR we detect Spyder and import the correct packages. 

The reason for making the change here is that with third-party packages we cannot always control whether `tqdm` is imported from `auto`, `autonotebook` or `std`.

An alternative would be to check in `tqdm.autonotebook` for a special environment variable that overrides the automatic detection.

