### PR TITLE
Respect console handler log levels

### DIFF
--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -86,6 +86,7 @@ def logging_redirect_tqdm(
             orig_handler = _get_first_found_console_logging_handler(logger.handlers)
             if orig_handler is not None:
                 tqdm_handler.setFormatter(orig_handler.formatter)
+                tqdm_handler.level = orig_handler.level
                 tqdm_handler.stream = orig_handler.stream
             logger.handlers = [
                 handler for handler in logger.handlers


### PR DESCRIPTION
The `tqdm.contrib.logging.logging_redirect_tqdm` context manager ignores the log-level of the original console handler that it replaces.

Minimal reproducible example:
```python
import logging
import tqdm.contrib.logging

console_handler = logging.StreamHandler()
console_handler.setLevel(logging.WARN)
logging.getLogger().addHandler(console_handler)
logging.getLogger().setLevel(logging.DEBUG)

logging.info("This is ignored")
logging.warning("This is shown")
with tqdm.contrib.logging.logging_redirect_tqdm():
    logging.info("This is shown (incorrectly!)")
    logging.warning("This is shown")
```