### PR TITLE
Bugfix for logging.py (correct logging level)

### DIFF
--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -87,6 +87,7 @@ def logging_redirect_tqdm(
             if orig_handler is not None:
                 tqdm_handler.setFormatter(orig_handler.formatter)
                 tqdm_handler.stream = orig_handler.stream
+                tqdm_handler.setLevel(orig_handler.level)
             logger.handlers = [
                 handler for handler in logger.handlers
                 if not _is_console_logging_handler(handler)] + [tqdm_handler]


### PR DESCRIPTION
The context manager `tqdm.contrib.logging.logging_redirect_tqdm()` currently does not respect the log level of the stream handlers it redirects to `tqdm.write(...)`. This commit adds a line to fix that.