### PR TITLE
A solution for `reversed` issue in #1484 and #1588

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1965,8 +1965,9 @@ def test_closed():
 
 def test_reversed(capsys):
     """Test reversed()"""
-    for _ in reversed(tqdm(range(9))):
-        pass
+    expected_result = list(reversed(range(9)))
+    real_result = list(reversed(tqdm(range(9))))
+    assert expected_result == real_result
     out, err = capsys.readouterr()
     assert not out
     assert '  0%' in err

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1119,13 +1119,14 @@ class tqdm(Comparable):
             else getattr(self, "total", None))
 
     def __reversed__(self):
-         # Uses the built-in `copy.copy` to shallow copy the object, replaces the original iterable as the reverse one.
         try:
             orig = self.iterable
         except AttributeError:
             raise TypeError("'tqdm' object is not reversible")
         else:
+            # Uses the built-in `copy.copy` to shallow copy the object.
             reversed_iterator = copy.copy(self)
+            # Replaces the original iterable as the reverse one.
             reversed_iterator.iterable = reversed(self.iterable)
             return reversed_iterator
         finally:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -15,6 +15,7 @@ from numbers import Number
 from time import time
 from warnings import warn
 from weakref import WeakSet
+import copy
 
 from ._monitor import TMonitor
 from .utils import (
@@ -1118,13 +1119,15 @@ class tqdm(Comparable):
             else getattr(self, "total", None))
 
     def __reversed__(self):
+         # Uses the built-in `copy.copy` to shallow copy the object, replaces the original iterable as the reverse one.
         try:
             orig = self.iterable
         except AttributeError:
             raise TypeError("'tqdm' object is not reversible")
         else:
-            self.iterable = reversed(self.iterable)
-            return self.__iter__()
+            reversed_iterator = copy.copy(self)
+            reversed_iterator.iterable = reversed(self.iterable)
+            return reversed_iterator
         finally:
             self.iterable = orig
 


### PR DESCRIPTION
I have try to give a simplest solution for the unexpected result of reversed in #1484 and #1588.
The functionality of the built-in function `reversed` should return a reversed iterator of the input.
However, the `tqdm` does not behave as the common behavior when warped with `reversed`.
The further detail of the are well-mentioned in the previous issues, #1484 and #1588.
I try to come up with a solution that requires the minimum modification of the original code, and small impact to the performance.
The solution is to use the standard library of Python, `copy`, to shallow copy the original object of the `tqdm` and replace the `self.iterable` by the reversed of it.
Hope this non-intuitive behavior can be changed.
Thanks.