### PR TITLE
Give a solution to #1484 and #1588

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1965,8 +1965,11 @@ def test_closed():
 
 def test_reversed(capsys):
     """Test reversed()"""
-    for _ in reversed(tqdm(range(9))):
-        pass
+    expected_result = list(reversed(range(9)))
+    real_result = list(reversed(tqdm(range(9))))
+
+    assert expected_result == real_result
+
     out, err = capsys.readouterr()
     assert not out
     assert '  0%' in err

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -10,6 +10,7 @@ Usage:
 import sys
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
+import copy
 from datetime import datetime, timedelta, timezone
 from numbers import Number
 from time import time
@@ -1123,8 +1124,13 @@ class tqdm(Comparable):
         except AttributeError:
             raise TypeError("'tqdm' object is not reversible")
         else:
-            self.iterable = reversed(self.iterable)
-            return self.__iter__()
+            # Shallow copies the object.
+            reversed_obj = copy.copy(self)
+
+            # Replaces the iterable with the reversed iterable.
+            reversed_obj.iterable = reversed(self.iterable)
+
+            return reversed_obj
         finally:
             self.iterable = orig
 


### PR DESCRIPTION
I try to give a simplest solution for the unexpected result of reversed in #1484 and #1588.
The functionality of the built-in function reversed should return a reversed iterator of the input.
However, the tqdm does not behave as the common behavior when warped with reversed.
The further detail of the are well-mentioned in the previous issues, #1484 and #1588.
I try to come up with a solution that requires the minimum modification of the original code, and small impact to the performance.
The solution is to use the standard library of Python, `copy`, to shallow copy the original object of the tqdm and replace the self.iterable by the reversed of it.
Hope this non-intuitive behavior can be changed.
Thanks.

P.S. Due to the unsigned commit in the previous PR, I open a new one.