### PR TITLE
Fix comment in sample code in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1314,7 +1314,7 @@ A reusable canonical example is given below:
     def some_fun(i):
         print("Fee, fi, fo,".split()[i])
 
-    # Redirect stdout to tqdm.write() (don't forget the `as save_stdout`)
+    # Redirect stdout to tqdm.write() (don't forget the `as orig_stdout`)
     with std_out_err_redirect_tqdm() as orig_stdout:
         # tqdm needs the original stdout
         # and dynamic_ncols=True to autodetect console width


### PR DESCRIPTION
The comment referred to `as save_stdout` but the sample code used `as orig_stdout`. I'm guessing the comment hadn't been updated. So, I updated the comment.