### PR TITLE
cli: Fix docstring processing with Python 3.13+

### DIFF
--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -4,6 +4,7 @@ Module version for monitoring CLI pipes (`... | python -m tqdm | ...`).
 import logging
 import re
 import sys
+import textwrap
 from ast import literal_eval as numeric
 
 from .std import TqdmKeyError, TqdmTypeError, tqdm
@@ -177,7 +178,11 @@ def main(fp=sys.stderr, argv=None):
     logging.basicConfig(level=getattr(logging, logLevel),
                         format="%(levelname)s:%(module)s:%(lineno)d:%(message)s")
 
-    d = tqdm.__doc__ + CLI_EXTRA_DOC
+    d = tqdm.__doc__
+    if sys.version_info >= (3, 13):
+        # Python 3.13+ automatically dedents docstrings
+        d = textwrap.indent(d, "    ")
+    d += CLI_EXTRA_DOC
 
     opt_types = dict(RE_OPTS.findall(d))
     # opt_types['delim'] = 'chr'

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -4,8 +4,8 @@ Module version for monitoring CLI pipes (`... | python -m tqdm | ...`).
 import logging
 import re
 import sys
-import textwrap
 from ast import literal_eval as numeric
+from textwrap import indent
 
 from .std import TqdmKeyError, TqdmTypeError, tqdm
 from .version import __version__
@@ -178,11 +178,9 @@ def main(fp=sys.stderr, argv=None):
     logging.basicConfig(level=getattr(logging, logLevel),
                         format="%(levelname)s:%(module)s:%(lineno)d:%(message)s")
 
-    d = tqdm.__doc__
-    if sys.version_info >= (3, 13):
-        # Python 3.13+ automatically dedents docstrings
-        d = textwrap.indent(d, "    ")
-    d += CLI_EXTRA_DOC
+    # py<3.13 doesn't dedent docstrings
+    d = (tqdm.__doc__ if sys.version_info < (3, 13)
+         else indent(tqdm.__doc__, "    ")) + CLI_EXTRA_DOC
 
     opt_types = dict(RE_OPTS.findall(d))
     # opt_types['delim'] = 'chr'


### PR DESCRIPTION
Fix docstring processing code to reindent the docstrings if using Python 3.13 or newer.  Starting with this version, all docstrings are automatically dedented by Python, which causes the regular expression to fail to match.

Fixes #1585