### PR TITLE
Avoid Python 3.13+ RuntimeWarning: coroutine method 'aclose' of 'acount' was never awaited

### DIFF
--- a/tests/tests_asyncio.py
+++ b/tests/tests_asyncio.py
@@ -48,10 +48,14 @@ async def test_generators(capsys):
     _, err = capsys.readouterr()
     assert '9it' in err
 
-    with tqdm(acount(), desc="async_counter") as pbar:
-        async for i in pbar:
-            if i >= 8:
-                break
+    acounter = acount()
+    try:
+        with tqdm(acounter, desc="async_counter") as pbar:
+            async for i in pbar:
+                if i >= 8:
+                    break
+    finally:
+        await acounter.aclose()
     _, err = capsys.readouterr()
     assert '9it' in err
 


### PR DESCRIPTION
See https://github.com/python/cpython/issues/117536#issuecomment-2036883124

Built on https://github.com/tqdm/tqdm/pull/1594

---

This makes the warning go away. However, perhaps `tqdm.close()` should try awaiting `self.iterable.aclose()` if it exists and is awaitable -- that way callers won't need to do that.

Let me know if you prefer that and I can propose an alternate PR.