### PR TITLE
Update `tqdm.rich`

### DIFF
--- a/tests/tests_rich.py
+++ b/tests/tests_rich.py
@@ -15,6 +15,19 @@ def test_rich_no_total(capsys):
     assert '5it' in err
 
 
+@mark.filterwarnings("ignore:rich is experimental/alpha:"
+                     "tqdm.std.TqdmExperimentalWarning")
+def test_rich_ascii(capsys):
+    """Test `trrange` with `ascii=True`, i.e. rendering via `ASCIIConsole`"""
+    rich = importorskip('tqdm.rich')
+    with rich.trange(3, ascii=True, ncols=60) as pbar:
+        assert list(pbar) == [0, 1, 2]
+    out, err = capsys.readouterr()
+    assert not out
+    assert err.isascii()
+    assert '---' in err
+
+
 def test_rich_fraction_column():
     """Test `FractionColumn` for different totals & unit scaling"""
     rich = importorskip('tqdm.rich')
@@ -34,3 +47,29 @@ def test_rich_fraction_column():
     assert str(rich.FractionColumn().render(SizedTask(unit_scale=False))) == "3/1000"
     assert str(rich.FractionColumn().render(SizedTask(
         unit_scale=True, unit_divisor=1000))) == "3.00/1.00k"
+
+
+def test_rich_rate_column():
+    """Test `RateColumn` fallback, derivation, inversion"""
+    rich = importorskip('tqdm.rich')
+
+    class Task:
+        def __init__(self, **fields):
+            self.fields = dict(
+                {'unit': 'it', 'unit_scale': False, 'rate': None, 'elapsed': 0}, **fields)
+        completed = 10
+
+    assert str(rich.RateColumn().render(Task())) == "?it/s"
+    assert str(rich.RateColumn().render(Task(elapsed=5))) == " 2.00it/s"
+    assert str(rich.RateColumn().render(Task(rate=0.5))) == " 2.00s/it"
+
+
+def test_rich_completed_column():
+    """Test `UnitCompletedColumn` with total shows percentage."""
+    rich = importorskip('tqdm.rich')
+
+    class SizedTask:
+        percentage = 75.0
+        total = 4
+
+    assert str(rich.UnitCompletedColumn().render(SizedTask())) == " 75%"

--- a/tests/tests_rich.py
+++ b/tests/tests_rich.py
@@ -11,22 +11,26 @@ def test_rich_no_total(capsys):
         for _ in pbar:
             pass
     out, err = capsys.readouterr()
-    assert not err
-    assert '5/?' in out
+    assert not out
+    assert '5it' in err
 
 
-def test_rich_fraction_column_no_total():
-    """Test `FractionColumn` renders a `?` placeholder when total is unknown"""
+def test_rich_fraction_column():
+    """Test `FractionColumn` for different totals & unit scaling"""
     rich = importorskip('tqdm.rich')
 
     class Task:
         completed = 5
         total = None
 
-    assert rich.FractionColumn().render(Task()).plain == "5/? "
+    assert str(rich.FractionColumn().render(Task())) == ""
 
     class SizedTask:
+        def __init__(self, **fields):
+            self.fields = fields
         completed = 3
-        total = 10
+        total = 1000
 
-    assert rich.FractionColumn().render(SizedTask()).plain == "3/10 "
+    assert str(rich.FractionColumn().render(SizedTask(unit_scale=False))) == "3/1000"
+    assert str(rich.FractionColumn().render(SizedTask(
+        unit_scale=True, unit_divisor=1000))) == "3.00/1.00k"

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -78,7 +78,7 @@ class UnitCompletedColumn(UnitScaleColumn):
     def render(self, task: Task) -> Text:
         if task.total is None:
             completed = self.unit_format(task, task.completed)
-            return Text(f"{completed:>3}it", style="progress.percentage")
+            return Text(f"{completed:>3}{task.fields['unit']}", style="progress.percentage")
         else:
             return Text(f"{task.percentage:>3.0f}%", style="progress.percentage")
 

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -55,8 +55,8 @@ class RateColumn(UnitScaleColumn):
     def render(self, task: Task):
         """Show data transfer speed."""
         speed = task.fields["rate"]
-        if task.elapsed and speed is None:
-            speed = task.completed / task.elapsed
+        if task.fields["elapsed"] and speed is None:
+            speed = task.completed / task.fields["elapsed"]
         if speed is not None:
             inv_speed = 1 / speed if speed != 0 else None
             if inv_speed and inv_speed > 1:
@@ -85,7 +85,7 @@ class UnitCompletedColumn(UnitScaleColumn):
 
 class CompactTimeElapsedColumn(ProgressColumn):
     def render(self, task: Task) -> Text:
-        elapsed = task.finished_time if task.finished else task.elapsed
+        elapsed = task.fields["elapsed"]
         formatted = std_tqdm.format_interval(int(elapsed)) if elapsed else "--:--"
         return Text(formatted, style="progress.elapsed")
 

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -265,13 +265,12 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
             return
         with cls._progress._lock:
             if not self._task.finished:
-                self.display()
-                if not self.leave:
-                    self._task.visible = False
                 cls._progress.stop_task(self._task.id)
                 self._task.finished_time = self._task.stop_time
+            if not self.leave:
+                self._task.visible = False
+            self.display(refresh=cls._progress.console.is_jupyter)   # print 100%, vis #1306
             if all(t.finished for t in cls._progress.tasks):
-                self.display(refresh=cls._progress.console.is_jupyter)   # print 100%, vis #1306
                 cls._progress.__exit__(None, None, None)
                 cls._progress = None
 

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -280,7 +280,7 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
 
     def display(self, refresh=False, *_, **__):
         cls = self.__class__
-        if cls._progress is None or self._task is None:
+        if not hasattr(cls, "_progress") or cls._progress is None or self._task is None:
             return
         if not self._task.started and self.n > 0:
             cls._progress.start_task(self._task.id)

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -6,75 +6,132 @@ Usage:
 >>> for i in trange(10):
 ...     ...
 """
+
+from contextlib import nullcontext
+from typing import Iterable
 from warnings import warn
 
+from rich.console import Console
 from rich.progress import (
-    BarColumn, Progress, ProgressColumn, Text, TimeElapsedColumn, TimeRemainingColumn, filesize)
+    BarColumn, Progress, ProgressColumn, Table, Task, Text, TimeRemainingColumn)
 
-from .std import TqdmExperimentalWarning
+from .std import TqdmExperimentalWarning, TqdmWarning
 from .std import tqdm as std_tqdm
 
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['tqdm_rich', 'trrange', 'tqdm', 'trange']
 
 
-class FractionColumn(ProgressColumn):
-    """Renders completed/total, e.g. '0.5/2.3 G'."""
+class UnitScaleColumn(ProgressColumn):
     def __init__(self, unit_scale=False, unit_divisor=1000):
         self.unit_scale = unit_scale
         self.unit_divisor = unit_divisor
         super().__init__()
 
-    def render(self, task):
-        """Calculate common unit for completed and total."""
-        completed = int(task.completed)
-        # total is None when the iterable has no length (e.g. a generator)
-        total = int(task.total) if task.total is not None else None
-        base = total if total is not None else completed
-        if self.unit_scale:
-            unit, suffix = filesize.pick_unit_and_suffix(
-                base,
-                ["", "K", "M", "G", "T", "P", "E", "Z", "Y"],
-                self.unit_divisor,
-            )
+    def unit_format(self, task: Task, num, fmt=""):
+        if task.fields["unit_scale"]:
+            return std_tqdm.format_sizeof(num, divisor=task.fields["unit_divisor"])
+        return f"{num:{fmt}}"
+
+
+class FractionColumn(UnitScaleColumn):
+    def render(self, task: Task):
+        has_total = task.total is not None
+        if has_total:
+            n_fmt = self.unit_format(task, task.completed)
+            total_fmt = self.unit_format(task, task.total)
+            return Text(f"{n_fmt}/{total_fmt}", style="progress.download")
         else:
-            unit, suffix = filesize.pick_unit_and_suffix(base, [""], 1)
-        precision = 0 if unit == 1 else 1
-        total_str = f"{total/unit:,.{precision}f}" if total is not None else "?"
-        return Text(
-            f"{completed/unit:,.{precision}f}/{total_str} {suffix}",
-            style="progress.download")
+            return ""
 
 
-class RateColumn(ProgressColumn):
+class RateColumn(UnitScaleColumn):
     """Renders human readable transfer speed."""
-    def __init__(self, unit="", unit_scale=False, unit_divisor=1000):
-        self.unit = unit
-        self.unit_scale = unit_scale
-        self.unit_divisor = unit_divisor
-        super().__init__()
 
-    def render(self, task):
+    def __init__(self, unit="it", unit_scale=False, unit_divisor=1000):
+        super().__init__(unit_scale=unit_scale, unit_divisor=unit_divisor)
+        self.unit = unit
+
+    def render(self, task: Task):
         """Show data transfer speed."""
-        speed = task.speed
-        if speed is None:
-            return Text(f"? {self.unit}/s", style="progress.data.speed")
-        if self.unit_scale:
-            unit, suffix = filesize.pick_unit_and_suffix(
-                speed,
-                ["", "K", "M", "G", "T", "P", "E", "Z", "Y"],
-                self.unit_divisor,
-            )
+        speed = task.fields["rate"]
+        if task.elapsed and speed is None:
+            speed = task.completed / task.elapsed
+        if speed is not None:
+            inv_speed = 1 / speed if speed != 0 else None
+            if inv_speed and inv_speed > 1:
+                unit_fmt = f"s/{task.fields['unit']}"
+                speed_ = inv_speed
+            else:
+                unit_fmt = f"{task.fields['unit']}/s"
+                speed_ = speed
+
+            speed_fmt = self.unit_format(task, speed_, fmt="5.2f")
         else:
-            unit, suffix = filesize.pick_unit_and_suffix(speed, [""], 1)
-        precision = 0 if unit == 1 else 1
-        return Text(f"{speed/unit:,.{precision}f} {suffix}{self.unit}/s",
-                    style="progress.data.speed")
+            speed_fmt = "?"
+            unit_fmt = f"{task.fields['unit']}/s"
+
+        return Text(f"{speed_fmt}{unit_fmt}", style="progress.data.speed")
+
+
+class UnitCompletedColumn(UnitScaleColumn):
+    def render(self, task: Task) -> Text:
+        if task.total is None:
+            completed = self.unit_format(task, task.completed)
+            return Text(f"{completed:>3}it", style="progress.percentage")
+        else:
+            return Text(f"{task.percentage:>3.0f}%", style="progress.percentage")
+
+
+class CompactTimeElapsedColumn(ProgressColumn):
+    def render(self, task: Task) -> Text:
+        elapsed = task.finished_time if task.finished else task.elapsed
+        formatted = std_tqdm.format_interval(int(elapsed)) if elapsed else "--:--"
+        return Text(formatted, style="progress.elapsed")
+
+
+class PrefixTimeRemainingColumn(TimeRemainingColumn):
+    def __init__(self, prefix_str: str = "<", *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.prefix_txt = Text(prefix_str)
+
+    def render(self, task: Task) -> Text:
+        return (
+            (self.prefix_txt + super().render(task)) if task.total is not None else ""
+        )
+
+
+class PostFixColumn(ProgressColumn):
+    def render(self, task: Task) -> Text:
+        postfix = task.fields.get("postfix")
+        return Text(f", {postfix}", style="progress.percentage") if postfix else ""
+
+
+class NoPaddingProgress(Progress):
+    def make_tasks_table(self, tasks: Iterable[Task]) -> Table:
+        table = super().make_tasks_table(tasks)
+        table.padding = 0
+        return table
+
+
+class ASCIIConsole(Console):
+    @property
+    def encoding(self):
+        return "ascii"
 
 
 class tqdm_rich(std_tqdm):  # pragma: no cover
     """Experimental rich.progress GUI version of tqdm!"""
     # TODO: @classmethod: write()?
+    _progress: Progress
+
+    def __new__(cls, *_, **__):
+        return object.__new__(cls)
+
+    @staticmethod
+    def _get_free_pos(*_, **__):
+        pass
+
     def __init__(self, *args, **kwargs):
         """
         This class accepts the following parameters *in addition* to
@@ -86,50 +143,165 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
             arguments for `rich.progress.Progress()`.
         options  : dict, optional
             keyword arguments for `rich.progress.Progress()`.
+        bar_options : dict, optional
+            keyword arguments for `rich.progress.BarColumn()`.
         """
         kwargs = kwargs.copy()
-        kwargs['gui'] = True
-        # convert disable = None to False
-        kwargs['disable'] = bool(kwargs.get('disable', False))
-        progress = kwargs.pop('progress', None)
-        options = kwargs.pop('options', {}).copy()
+        kwargs["gui"] = True
+
+        progress_columns = kwargs.pop("progress", None)
+        options = kwargs.pop("options", {}).copy()
+        bar_options = kwargs.pop("bar_options", {}).copy()
+        for k in ("position", "bar_format"):
+            if kwargs.pop(k, None) is not None:
+                warn(
+                    f"tqdm.rich does not support the `{k}` option. ",
+                    TqdmWarning,
+                    stacklevel=2,
+                )
+
+        self._lock = (
+            nullcontext()
+        )  # NOTE: temporary dummy_lock to reuse std_tqdm's __init__
+        self._instances = [self]
         super().__init__(*args, **kwargs)
+        del self._lock
+        del self._instances
 
         if self.disable:
             return
 
         warn("rich is experimental/alpha", TqdmExperimentalWarning, stacklevel=2)
         d = self.format_dict
-        if progress is None:
-            progress = (
-                "[progress.description]{task.description}"
-                "[progress.percentage]{task.percentage:>4.0f}%",
-                BarColumn(bar_width=None),
-                FractionColumn(
-                    unit_scale=d['unit_scale'], unit_divisor=d['unit_divisor']),
-                "[", TimeElapsedColumn(), "<", TimeRemainingColumn(),
-                ",", RateColumn(unit=d['unit'], unit_scale=d['unit_scale'],
-                                unit_divisor=d['unit_divisor']), "]"
+        if progress_columns is None:
+            description = (
+                "[progress.description]{task.description}: " if self.desc else ""
             )
-        options.setdefault('transient', not self.leave)
-        self._prog = Progress(*progress, **options)
-        self._prog.__enter__()
-        self._task_id = self._prog.add_task(self.desc or "", **d)
+            completed = UnitCompletedColumn(
+                unit_scale=d["unit_scale"], unit_divisor=d["unit_divisor"]
+            )
+            bar_options.setdefault("bar_width", None)
+            if d["colour"] is not None:
+                bar_options.setdefault("complete_style", d["colour"])
+                bar_options.setdefault("finished_style", d["colour"])
+                bar_options.setdefault("pulse_style", d["colour"])
+            progress_columns = (
+                description,
+                completed,
+                " ",
+                BarColumn(**bar_options),
+                " ",
+                FractionColumn(
+                    unit_scale=d["unit_scale"], unit_divisor=d["unit_divisor"]
+                ),
+                " [",
+                CompactTimeElapsedColumn(),
+                PrefixTimeRemainingColumn(compact=True),
+                ", ",
+                RateColumn(
+                    unit=d["unit"],
+                    unit_scale=d["unit_scale"],
+                    unit_divisor=d["unit_divisor"],
+                ),
+                PostFixColumn(),
+                "]",
+            )
+
+        cls = self.__class__
+        if not hasattr(cls, "_progress") or cls._progress is None:
+            options.setdefault("transient", not self.leave)
+
+            if options.get("console") is not None:
+                console: Console = options["console"]
+                console.file = self.fp
+                console.width = d["ncols"]
+                console.height = d["nrows"]
+                if d["ascii"] and not console.encoding == "ascii":
+                    warn(
+                        "ascii output requested but passed console's encoding is not 'ascii'. "
+                        "See `tqdm.rich.ASCIIConsole` to force ASCII rendering.",
+                        TqdmWarning,
+                        stacklevel=2,
+                    )
+            else:
+                console_cls = ASCIIConsole if d["ascii"] else Console
+                options["console"] = console_cls(
+                    width=d["ncols"], height=d["nrows"], file=self.fp
+                )
+
+            cls._progress = NoPaddingProgress(*progress_columns, **options)
+            cls._progress.__enter__()
+        else:
+            if options.get("console") is not None:
+                warn(
+                    "ignoring passed `console` since tqdm_rich._progress exists",
+                    TqdmWarning,
+                    stacklevel=2,
+                )
+
+            if kwargs.get("ascii") is True and not isinstance(
+                cls._progress.console, ASCIIConsole
+            ):
+                warn(
+                    "ascii=True but global console is not ASCIIConsole. "
+                    "Using (non-ascii) global console.",
+                    TqdmWarning,
+                    stacklevel=2,
+                )
+
+        with cls._progress._lock:
+            # workaround to not refresh on task addition
+            _disable, cls._progress.disable = cls._progress.disable, True
+            task_id = cls._progress.add_task(self.desc or "", **d, start=False)
+            self._task = next(t for t in cls._progress.tasks if t.id == task_id)
+            cls._progress.disable = _disable
 
     def close(self):
         if self.disable:
             return
-        self.display()  # print 100%, vis #1306
-        super().close()
-        self._prog.__exit__(None, None, None)
+
+        cls = self.__class__
+        if not self._task.finished:
+            self.display()  # print 100%, vis #1306
+            if not self.leave:
+                self._task.visible = False
+            cls._progress.stop_task(self._task.id)
+            self._task.finished_time = self._task.stop_time
+
+        with cls._progress._lock:
+            if cls._progress is not None and all(
+                t.finished for t in cls._progress.tasks
+            ):
+                cls._progress.__exit__(None, None, None)
+                cls._progress = None
 
     def clear(self, *_, **__):
         pass
 
-    def display(self, *_, **__):
-        if not hasattr(self, '_task_id'):
+    def display(self, refresh=False, *_, **__):
+        cls = self.__class__
+        if cls._progress is None or self._task is None:
             return
-        self._prog.update(self._task_id, completed=self.n, description=self.desc)
+        if not self._task.started and self.n > 0:
+            cls._progress.start_task(self._task.id)
+
+        self._task.fields["rate"] = self.format_dict["rate"]
+        self._task.fields["postfix"] = self.format_dict["postfix"]
+
+        cls._progress.update(
+            self._task.id,
+            completed=self.n,
+            description=self.desc,
+            refresh=refresh,
+            **self.format_dict,
+        )
+
+        cls._progress.console.width = self.format_dict["ncols"]
+        cls._progress.console.height = self.format_dict["nrows"]
+        cls._progress.console.file = self.fp
+
+    def refresh(self, *_, **__):
+        self.display()
 
     def reset(self, total=None):
         """
@@ -139,8 +311,9 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
         ----------
         total  : int or float, optional. Total to use for the new bar.
         """
-        if hasattr(self, '_prog'):
-            self._prog.reset(total=total)
+        cls = self.__class__
+        if cls._progress is not None:
+            cls._progress.reset(task_id=self._task.id)  # see #1378
         super().reset(total=total)
 
 

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -271,7 +271,7 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
                 cls._progress.stop_task(self._task.id)
                 self._task.finished_time = self._task.stop_time
             if all(t.finished for t in cls._progress.tasks):
-                self.display(refresh=True)   # print 100%, vis #1306
+                self.display(refresh=cls._progress.console.is_jupyter)   # print 100%, vis #1306
                 cls._progress.__exit__(None, None, None)
                 cls._progress = None
 

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -23,11 +23,6 @@ __all__ = ['tqdm_rich', 'trrange', 'tqdm', 'trange']
 
 
 class UnitScaleColumn(ProgressColumn):
-    def __init__(self, unit_scale=False, unit_divisor=1000):
-        self.unit_scale = unit_scale
-        self.unit_divisor = unit_divisor
-        super().__init__()
-
     def unit_format(self, task: Task, num, fmt=""):
         if task.fields["unit_scale"]:
             return std_tqdm.format_sizeof(num, divisor=task.fields["unit_divisor"])
@@ -47,11 +42,6 @@ class FractionColumn(UnitScaleColumn):
 
 class RateColumn(UnitScaleColumn):
     """Renders human readable transfer speed."""
-
-    def __init__(self, unit="it", unit_scale=False, unit_divisor=1000):
-        super().__init__(unit_scale=unit_scale, unit_divisor=unit_divisor)
-        self.unit = unit
-
     def render(self, task: Task):
         """Show data transfer speed."""
         speed = task.fields["rate"]
@@ -177,9 +167,7 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
             description = (
                 "[progress.description]{task.description}: " if self.desc else ""
             )
-            completed = UnitCompletedColumn(
-                unit_scale=d["unit_scale"], unit_divisor=d["unit_divisor"]
-            )
+            completed = UnitCompletedColumn()
             bar_options.setdefault("bar_width", None)
             if d["colour"] is not None:
                 bar_options.setdefault("complete_style", d["colour"])
@@ -191,18 +179,12 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
                 " ",
                 BarColumn(**bar_options),
                 " ",
-                FractionColumn(
-                    unit_scale=d["unit_scale"], unit_divisor=d["unit_divisor"]
-                ),
+                FractionColumn(),
                 " [",
                 CompactTimeElapsedColumn(),
                 PrefixTimeRemainingColumn(compact=True),
                 ", ",
-                RateColumn(
-                    unit=d["unit"],
-                    unit_scale=d["unit_scale"],
-                    unit_divisor=d["unit_divisor"],
-                ),
+                RateColumn(),
                 PostFixColumn(),
                 "]",
             )

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -285,19 +285,20 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
         if not self._task.started and self.n > 0:
             cls._progress.start_task(self._task.id)
 
-        self._task.fields["rate"] = self.format_dict["rate"]
-        self._task.fields["postfix"] = self.format_dict["postfix"]
+        d = self.format_dict
+        self._task.fields["rate"] = d["rate"]
+        self._task.fields["postfix"] = d["postfix"]
 
         cls._progress.update(
             self._task.id,
             completed=self.n,
             description=self.desc,
             refresh=refresh,
-            **self.format_dict,
+            **d,
         )
 
-        cls._progress.console.width = self.format_dict["ncols"]
-        cls._progress.console.height = self.format_dict["nrows"]
+        cls._progress.console.width = d["ncols"]
+        cls._progress.console.height = d["nrows"]
         cls._progress.console.file = self.fp
 
     def refresh(self, *_, **__):

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -190,7 +190,7 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
             )
 
         cls = self.__class__
-        if not hasattr(cls, "_progress") or cls._progress is None:
+        if getattr(cls, '_progress', None) is None:
             options.setdefault("transient", not self.leave)
 
             if options.get("console") is not None:
@@ -243,7 +243,7 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
             return
         cls = self.__class__
 
-        if cls._progress is None or self._task is None:
+        if getattr(cls, '_progress', None) is None or getattr(self, '_task', None) is None:
             return
         with cls._progress._lock:
             if not self._task.finished:
@@ -261,7 +261,7 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
 
     def display(self, refresh=False, *_, **__):
         cls = self.__class__
-        if not hasattr(cls, "_progress") or cls._progress is None or self._task is None:
+        if getattr(cls, '_progress', None) is None or getattr(self, '_task', None) is None:
             return
         if not self._task.started and self.n > 0:
             cls._progress.start_task(self._task.id)

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -259,19 +259,19 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
     def close(self):
         if self.disable:
             return
-
         cls = self.__class__
-        if not self._task.finished:
-            self.display()  # print 100%, vis #1306
-            if not self.leave:
-                self._task.visible = False
-            cls._progress.stop_task(self._task.id)
-            self._task.finished_time = self._task.stop_time
 
+        if cls._progress is None or self._task is None:
+            return
         with cls._progress._lock:
-            if cls._progress is not None and all(
-                t.finished for t in cls._progress.tasks
-            ):
+            if not self._task.finished:
+                self.display()
+                if not self.leave:
+                    self._task.visible = False
+                cls._progress.stop_task(self._task.id)
+                self._task.finished_time = self._task.stop_time
+            if all(t.finished for t in cls._progress.tasks):
+                self.display(refresh=True)   # print 100%, vis #1306
                 cls._progress.__exit__(None, None, None)
                 cls._progress = None
 

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -6,7 +6,6 @@ Usage:
 >>> for i in trange(10):
 ...     ...
 """
-
 from contextlib import nullcontext
 from typing import Iterable
 from warnings import warn
@@ -18,35 +17,33 @@ from rich.progress import (
 from .std import TqdmExperimentalWarning, TqdmWarning
 from .std import tqdm as std_tqdm
 
-__author__ = {"github.com/": ["casperdcl"]}
+__author__ = {"github.com/": ["casperdcl", "klamike"]}
 __all__ = ['tqdm_rich', 'trrange', 'tqdm', 'trange']
 
 
 class UnitScaleColumn(ProgressColumn):
     def unit_format(self, task: Task, num, fmt=""):
-        if task.fields["unit_scale"]:
-            return std_tqdm.format_sizeof(num, divisor=task.fields["unit_divisor"])
+        if task.fields['unit_scale']:
+            return std_tqdm.format_sizeof(num, divisor=task.fields['unit_divisor'])
         return f"{num:{fmt}}"
 
 
 class FractionColumn(UnitScaleColumn):
     def render(self, task: Task):
-        has_total = task.total is not None
-        if has_total:
-            n_fmt = self.unit_format(task, task.completed)
-            total_fmt = self.unit_format(task, task.total)
-            return Text(f"{n_fmt}/{total_fmt}", style="progress.download")
-        else:
+        if task.total is None:
             return ""
+        n_fmt = self.unit_format(task, task.completed)
+        total_fmt = self.unit_format(task, task.total)
+        return Text(f"{n_fmt}/{total_fmt}", style='progress.download')
 
 
 class RateColumn(UnitScaleColumn):
     """Renders human readable transfer speed."""
     def render(self, task: Task):
         """Show data transfer speed."""
-        speed = task.fields["rate"]
-        if task.fields["elapsed"] and speed is None:
-            speed = task.completed / task.fields["elapsed"]
+        speed = task.fields['rate']
+        if task.fields['elapsed'] and speed is None:
+            speed = task.completed / task.fields['elapsed']
         if speed is not None:
             inv_speed = 1 / speed if speed != 0 else None
             if inv_speed and inv_speed > 1:
@@ -55,29 +52,28 @@ class RateColumn(UnitScaleColumn):
             else:
                 unit_fmt = f"{task.fields['unit']}/s"
                 speed_ = speed
-
-            speed_fmt = self.unit_format(task, speed_, fmt="5.2f")
+            speed_fmt = self.unit_format(task, speed_, fmt='5.2f')
         else:
             speed_fmt = "?"
             unit_fmt = f"{task.fields['unit']}/s"
-
-        return Text(f"{speed_fmt}{unit_fmt}", style="progress.data.speed")
+        return Text(f"{speed_fmt}{unit_fmt}", style='progress.data.speed')
 
 
 class UnitCompletedColumn(UnitScaleColumn):
     def render(self, task: Task) -> Text:
         if task.total is None:
             completed = self.unit_format(task, task.completed)
-            return Text(f"{completed:>3}{task.fields['unit']}", style="progress.percentage")
+            res = f"{completed:>3}{task.fields['unit']}"
         else:
-            return Text(f"{task.percentage:>3.0f}%", style="progress.percentage")
+            res = f"{task.percentage:>3.0f}%"
+        return Text(res, style='progress.percentage')
 
 
 class CompactTimeElapsedColumn(ProgressColumn):
     def render(self, task: Task) -> Text:
-        elapsed = task.fields["elapsed"]
+        elapsed = task.fields['elapsed']
         formatted = std_tqdm.format_interval(int(elapsed)) if elapsed else "--:--"
-        return Text(formatted, style="progress.elapsed")
+        return Text(formatted, style='progress.elapsed')
 
 
 class PrefixTimeRemainingColumn(TimeRemainingColumn):
@@ -86,15 +82,13 @@ class PrefixTimeRemainingColumn(TimeRemainingColumn):
         self.prefix_txt = Text(prefix_str)
 
     def render(self, task: Task) -> Text:
-        return (
-            (self.prefix_txt + super().render(task)) if task.total is not None else ""
-        )
+        return (self.prefix_txt + super().render(task)) if task.total is not None else ""
 
 
 class PostFixColumn(ProgressColumn):
     def render(self, task: Task) -> Text:
-        postfix = task.fields.get("postfix")
-        return Text(f", {postfix}", style="progress.percentage") if postfix else ""
+        postfix = task.fields.get('postfix')
+        return Text(f", {postfix}", style='progress.percentage') if postfix else ""
 
 
 class NoPaddingProgress(Progress):
@@ -107,7 +101,7 @@ class NoPaddingProgress(Progress):
 class ASCIIConsole(Console):
     @property
     def encoding(self):
-        return "ascii"
+        return 'ascii'
 
 
 class tqdm_rich(std_tqdm):  # pragma: no cover
@@ -137,22 +131,16 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
             keyword arguments for `rich.progress.BarColumn()`.
         """
         kwargs = kwargs.copy()
-        kwargs["gui"] = True
+        kwargs['gui'] = True
 
-        progress_columns = kwargs.pop("progress", None)
-        options = kwargs.pop("options", {}).copy()
-        bar_options = kwargs.pop("bar_options", {}).copy()
-        for k in ("position", "bar_format"):
+        progress_columns = kwargs.pop('progress', None)
+        options = kwargs.pop('options', {}).copy()
+        bar_options = kwargs.pop('bar_options', {}).copy()
+        for k in ('position', 'bar_format'):
             if kwargs.pop(k, None) is not None:
-                warn(
-                    f"tqdm.rich does not support the `{k}` option. ",
-                    TqdmWarning,
-                    stacklevel=2,
-                )
-
-        self._lock = (
-            nullcontext()
-        )  # NOTE: temporary dummy_lock to reuse std_tqdm's __init__
+                warn(f"`tqdm.rich` does not support the `{k}` option.",
+                     TqdmWarning, stacklevel=2)
+        self._lock = nullcontext()  # temporary dummy lock to reuse std_tqdm's __init__
         self._instances = [self]
         super().__init__(*args, **kwargs)
         del self._lock
@@ -164,15 +152,13 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
         warn("rich is experimental/alpha", TqdmExperimentalWarning, stacklevel=2)
         d = self.format_dict
         if progress_columns is None:
-            description = (
-                "[progress.description]{task.description}: " if self.desc else ""
-            )
+            description = "[progress.description]{task.description}: " if self.desc else ""
             completed = UnitCompletedColumn()
-            bar_options.setdefault("bar_width", None)
-            if d["colour"] is not None:
-                bar_options.setdefault("complete_style", d["colour"])
-                bar_options.setdefault("finished_style", d["colour"])
-                bar_options.setdefault("pulse_style", d["colour"])
+            bar_options.setdefault('bar_width', None)
+            if d['colour'] is not None:
+                bar_options.setdefault('complete_style', d['colour'])
+                bar_options.setdefault('finished_style', d['colour'])
+                bar_options.setdefault('pulse_style', d['colour'])
             progress_columns = (
                 description,
                 completed,
@@ -191,46 +177,33 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
 
         cls = self.__class__
         if getattr(cls, '_progress', None) is None:
-            options.setdefault("transient", not self.leave)
+            options.setdefault('transient', not self.leave)
 
             if options.get("console") is not None:
-                console: Console = options["console"]
+                console: Console = options['console']
                 console.file = self.fp
-                console.width = d["ncols"]
-                console.height = d["nrows"]
-                if d["ascii"] and not console.encoding == "ascii":
-                    warn(
-                        "ascii output requested but passed console's encoding is not 'ascii'. "
-                        "See `tqdm.rich.ASCIIConsole` to force ASCII rendering.",
-                        TqdmWarning,
-                        stacklevel=2,
-                    )
+                console.width = d['ncols']
+                console.height = d['nrows']
+                if d['ascii'] and not console.encoding == 'ascii':
+                    warn("ascii output requested but passed console's encoding is not 'ascii'."
+                         "See `tqdm.rich.ASCIIConsole` to force ASCII rendering.",
+                         TqdmWarning, stacklevel=2)
             else:
-                console_cls = ASCIIConsole if d["ascii"] else Console
-                options["console"] = console_cls(
-                    width=d["ncols"], height=d["nrows"], file=self.fp
-                )
-
+                console_cls = ASCIIConsole if d['ascii'] else Console
+                options['console'] = console_cls(
+                    width=d['ncols'], height=d['nrows'], file=self.fp)
             cls._progress = NoPaddingProgress(*progress_columns, **options)
             cls._progress.__enter__()
         else:
-            if options.get("console") is not None:
-                warn(
-                    "ignoring passed `console` since tqdm_rich._progress exists",
-                    TqdmWarning,
-                    stacklevel=2,
-                )
-
-            if kwargs.get("ascii") is True and not isinstance(
+            if options.get('console') is not None:
+                warn("ignoring passed `console` since tqdm_rich._progress exists",
+                     TqdmWarning, stacklevel=2)
+            if kwargs.get('ascii') is True and not isinstance(
                 cls._progress.console, ASCIIConsole
             ):
-                warn(
-                    "ascii=True but global console is not ASCIIConsole. "
-                    "Using (non-ascii) global console.",
-                    TqdmWarning,
-                    stacklevel=2,
-                )
-
+                warn("ascii=True but global console is not ASCIIConsole. "
+                     "Using (non-ascii) global console.",
+                     TqdmWarning, stacklevel=2)
         with cls._progress._lock:
             # workaround to not refresh on task addition
             _disable, cls._progress.disable = cls._progress.disable, True
@@ -242,7 +215,6 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
         if self.disable:
             return
         cls = self.__class__
-
         if getattr(cls, '_progress', None) is None or getattr(self, '_task', None) is None:
             return
         with cls._progress._lock:
@@ -267,19 +239,14 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
             cls._progress.start_task(self._task.id)
 
         d = self.format_dict
-        self._task.fields["rate"] = d["rate"]
-        self._task.fields["postfix"] = d["postfix"]
+        self._task.fields['rate'] = d['rate']
+        self._task.fields['postfix'] = d['postfix']
 
         cls._progress.update(
-            self._task.id,
-            completed=self.n,
-            description=self.desc,
-            refresh=refresh,
-            **d,
-        )
+            self._task.id, completed=self.n, description=self.desc, refresh=refresh, **d)
 
-        cls._progress.console.width = d["ncols"]
-        cls._progress.console.height = d["nrows"]
+        cls._progress.console.width = d['ncols']
+        cls._progress.console.height = d['nrows']
         cls._progress.console.file = self.fp
 
     def refresh(self, *_, **__):


### PR DESCRIPTION
To try it out for yourself, use:
```bash
pip install --force-reinstall git+https://github.com/klamike/tqdm.git@mk/update_tqdmrich
```


___
This PR updates `tqdm.rich` to better match `tqdm.std`. It's a lot packed into one PR, but I hope you will still consider merging as it significantly extends the current functionality.

- use `tqdm.std.format_*` instead of `rich.filesize` for unit number formatting
- support iterators without` __len__`
- add inverse speed support
- add `NoPaddingProgress` & `ProgressColumn` classes to match `tqdm.std` style
- add `set_postfix` support (#1510)
- add `ascii` support
- use only the lock in rich -- avoid the tqdm lock
- add `bar_options` kwarg to customize `BarColumn`
- support `colour` kwarg on init
- support simultaneous `tqdm.rich` bars via global `cls._progress`
- use lazy auto refresh from `rich`
- support `dynamic_ncols`
- refresh on last display (#1580)

Closes #1674
Closes #1644

