### PR TITLE
misc framework updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,12 +42,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        python: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
         include:
         - os: macos
-          python: 3.11
+          python: 3.12
         - os: windows
-          python: 3.11
+          python: 3.12
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 35
     defaults:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     - pytest-timeout
     - pytest-asyncio
 - repo: https://github.com/PyCQA/flake8
-  rev: 7.0.0
+  rev: 7.1.0
   hooks:
   - id: flake8
     args: [-j8]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Note: to install all versions of the Python interpreter that are specified
 in [tox.ini](https://github.com/tqdm/tqdm/blob/master/tox.ini),
 you can use `MiniConda` to install a minimal setup. You must also ensure
 that each distribution has an alias to call the Python interpreter
-(e.g. `python311` for Python 3.11's interpreter).
+(e.g. `python312` for Python 3.12's interpreter).
 
 ### Alternative unit tests with pytest
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -6,7 +6,7 @@
     "environment_type": "virtualenv",
     "build_command": ["PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} ."],
     "show_commit_url": "https://github.com/tqdm/tqdm/commit/",
-    // "pythons": ["3.7", "3.11"],
+    // "pythons": ["3.7", "3.12"],
     // "conda_channels": ["conda-forge", "defaults"],
     "matrix": {
         "alive-progress": [""],

--- a/environment.yml
+++ b/environment.yml
@@ -43,5 +43,5 @@ dependencies:
 - pip:
   - py-make >=0.1.0                                          # `make/pymake`
   - mkdocs-minify-plugin                                     # `cd docs && pymake`
-  - git+https://github.com/tqdm/jsmin@python3-only#egg=jsmin # `cd docs && pymake`
+  - git+https://github.com/tqdm/jsmin@fix-pip#egg=jsmin      # `cd docs && pymake`
   - pydoc-markdown >=4.6                                     # `cd docs && pymake`

--- a/environment.yml
+++ b/environment.yml
@@ -38,10 +38,10 @@ dependencies:
 - build              # `python -m build`
 # `cd docs && pymake`
 - mkdocs-material
-- pydoc-markdown
 - pygments
 - pymdown-extensions
 - pip:
   - py-make >=0.1.0                                          # `make/pymake`
   - mkdocs-minify-plugin                                     # `cd docs && pymake`
   - git+https://github.com/tqdm/jsmin@python3-only#egg=jsmin # `cd docs && pymake`
+  - pydoc-markdown >=4.6                                     # `cd docs && pymake`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation",
     "Programming Language :: Python :: Implementation :: IronPython",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist=py{37,38,39,310,311,py3}{,-tf}{,-keras}, perf, check
+envlist=py{37,38,39,310,311,312,py3}{,-tf}{,-keras}, perf, check
 isolated_build=True
 
 [gh-actions]
@@ -14,6 +14,7 @@ python=
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
     pypy-3.7: pypy3
 [gh-actions:env]
 PLATFORM=

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -14,7 +14,7 @@ from weakref import proxy
 _range, _unich, _unicode, _basestring = range, chr, str, str
 CUR_OS = sys.platform
 IS_WIN = any(CUR_OS.startswith(i) for i in ['win32', 'cygwin'])
-IS_NIX = any(CUR_OS.startswith(i) for i in ['aix', 'linux', 'darwin'])
+IS_NIX = any(CUR_OS.startswith(i) for i in ['aix', 'linux', 'darwin', 'freebsd'])
 RE_ANSI = re.compile(r"\x1b\[[;\d]*[A-Za-z]")
 
 try:


### PR DESCRIPTION
- utils: support `ncols` auto-detection on FreeBSD (https://github.com/casperdcl/git-fame/issues/98)
- add official Python 3.12 support
- docs
  + bump `pydoc-markdown` (work-around for https://github.com/NiklasRosenstein/pydoc-markdown/issues/329)
  + bump `jsmin` (work-around for https://github.com/tikitu/jsmin/pull/44)
- bump `flake8`
