### PR TITLE
desc prefix can be an iterator to plot in terminal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -372,7 +372,7 @@ Parameters
 * iterable  : iterable, optional  
     Iterable to decorate with a progressbar.
     Leave blank to manually manage the updates.
-* desc  : str, optional  
+* desc  : str or iterator, optional  
     Prefix for the progressbar.
 * total  : int or float, optional  
     The number of expected iterations. If unspecified,
@@ -748,6 +748,10 @@ with the ``desc`` and ``postfix`` arguments:
             t.postfix[1]["value"] = i / 2
             t.update()
 
+    iterdata = {"A":1, "B":2, "C":3, "D":4}
+    for i in tqdm(iterdata.values(), desc=iterdata.keys()):
+        time.sleep(0.1)
+
 Points to remember when using ``{postfix[...]}`` in the ``bar_format`` string:
 
 - ``postfix`` also needs to be passed as an initial argument in a compatible
@@ -755,6 +759,9 @@ Points to remember when using ``{postfix[...]}`` in the ``bar_format`` string:
 - ``postfix`` will be auto-converted to a string if it is a ``dict``-like
   object. To prevent this behaviour, insert an extra item into the dictionary
   where the key is not a string.
+
+Another simple way of ``set_description`` is to set ``desc`` iterable, in the loops
+``set_description`` also may reset desc as const string.
 
 Additional ``bar_format`` parameters may also be defined by overriding
 ``format_dict``, and the bar itself may be modified using ``ascii``:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -579,10 +579,17 @@ class tqdm(Comparable):
             eta_dt = datetime.max
 
         # format the stats displayed to the left and right sides of the bar
-        if prefix:
+        if prefix and isinstance(prefix, str):
             # old prefix setup work around
             bool_prefix_colon_already = (prefix[-2:] == ": ")
             l_bar = prefix if bool_prefix_colon_already else prefix + ": "
+        elif prefix:
+            try:
+                iter_prefix = str(next(prefix))
+            except StopIteration:
+                iter_prefix = "StopIteration"
+            bool_prefix_colon_already = (iter_prefix[-2:] == ": ")
+            l_bar = iter_prefix if bool_prefix_colon_already else iter_prefix + ": "
         else:
             l_bar = ''
 
@@ -1023,6 +1030,13 @@ class tqdm(Comparable):
                     if nrows is None:
                         nrows = _nrows
 
+        if desc is None:
+            desc = ''
+        elif not isinstance(desc, str):
+            desc = iter(desc)
+        else:
+            desc = desc or ''
+
         if miniters is None:
             miniters = 0
             dynamic_miniters = True
@@ -1047,7 +1061,7 @@ class tqdm(Comparable):
 
         # Store the arguments
         self.iterable = iterable
-        self.desc = desc or ''
+        self.desc = desc
         self.total = total
         self.leave = leave
         self.fp = file


### PR DESCRIPTION
For solution to Issues #1545 , simple to check parameter `desc` as an iterator.
- `desc` could be string or iterator while init the `tqdm` object. In the other hand, I find its easier to iter dict-like object as following:
```python
    iterdata = {"A":1, "B":2, "C":3, "D":4}
    for i in tqdm(iterdata.values(), desc=iterdata.keys()):
        time.sleep(0.1)
```
- while looping, desc profix can be reset as string by `set_description` or `set_description_str`.

And the pytest info:
```terminal
======================================================================== test session starts ========================================================================
platform linux -- Python 3.12.3, pytest-8.3.3, pluggy-1.5.0 -- /home/xxx/PyVenv/Temp/bin/python
cachedir: .pytest_cache
rootdir: /home/xxx/Projects/tqdm
configfile: pyproject.toml
testpaths: tests
plugins: asyncio-0.24.0, timeout-2.3.1
asyncio: mode=Mode.STRICT, default_loop_scope=None
timeout: 30.0s
timeout method: signal
timeout func_only: False
collected 150 items                                                                                                                                                 

tests/tests_asyncio.py::test_break PASSED                                                                                                                     [  0%]
tests/tests_asyncio.py::test_generators PASSED                                                                                                                [  1%]
tests/tests_asyncio.py::test_range PASSED                                                                                                                     [  2%]
tests/tests_asyncio.py::test_nested PASSED                                                                                                                    [  2%]
tests/tests_asyncio.py::test_coroutines PASSED                                                                                                                [  3%]
tests/tests_asyncio.py::test_as_completed[0.1] PASSED                                                                                                         [  4%]
tests/tests_asyncio.py::test_gather PASSED                                                                                                                    [  4%]
tests/tests_concurrent.py::test_thread_map PASSED                                                                                                             [  5%]
tests/tests_concurrent.py::test_process_map PASSED                                                                                                            [  6%]
tests/tests_concurrent.py::test_chunksize_warning[iterables0-False] PASSED                                                                                    [  6%]
tests/tests_concurrent.py::test_chunksize_warning[iterables1-False] PASSED                                                                                    [  7%]
tests/tests_concurrent.py::test_chunksize_warning[iterables2-False] PASSED                                                                                    [  8%]
tests/tests_concurrent.py::test_chunksize_warning[iterables3-False] PASSED                                                                                    [  8%]
tests/tests_concurrent.py::test_chunksize_warning[iterables4-True] PASSED                                                                                     [  9%]
tests/tests_concurrent.py::test_chunksize_warning[iterables5-True] PASSED                                                                                     [ 10%]
tests/tests_contrib.py::test_enumerate[tqdm_kwargs0] PASSED                                                                                                   [ 10%]
tests/tests_contrib.py::test_enumerate[tqdm_kwargs1] PASSED                                                                                                   [ 11%]
tests/tests_contrib.py::test_enumerate_numpy PASSED                                                                                                           [ 12%]
tests/tests_contrib.py::test_zip[tqdm_kwargs0] PASSED                                                                                                         [ 12%]
tests/tests_contrib.py::test_zip[tqdm_kwargs1] PASSED                                                                                                         [ 13%]
tests/tests_contrib.py::test_map[tqdm_kwargs0] PASSED                                                                                                         [ 14%]
tests/tests_contrib.py::test_map[tqdm_kwargs1] PASSED                                                                                                         [ 14%]
tests/tests_contrib_logging.py::TestTqdmLoggingHandler::test_should_call_tqdm_write PASSED                                                                    [ 15%]
tests/tests_contrib_logging.py::TestTqdmLoggingHandler::test_should_call_handle_error_if_exception_was_thrown PASSED                                          [ 16%]
tests/tests_contrib_logging.py::TestTqdmLoggingHandler::test_should_not_swallow_certain_exceptions[KeyboardInterrupt] PASSED                                  [ 16%]
tests/tests_contrib_logging.py::TestTqdmLoggingHandler::test_should_not_swallow_certain_exceptions[SystemExit] PASSED                                         [ 17%]
tests/tests_contrib_logging.py::TestGetFirstFoundConsoleLoggingHandler::test_should_return_none_for_no_handlers PASSED                                        [ 18%]
tests/tests_contrib_logging.py::TestGetFirstFoundConsoleLoggingHandler::test_should_return_none_without_stream_handler PASSED                                 [ 18%]
tests/tests_contrib_logging.py::TestGetFirstFoundConsoleLoggingHandler::test_should_return_none_for_stream_handler_not_stdout_or_stderr PASSED                [ 19%]
tests/tests_contrib_logging.py::TestGetFirstFoundConsoleLoggingHandler::test_should_return_stream_handler_if_stream_is_stdout PASSED                          [ 20%]
tests/tests_contrib_logging.py::TestGetFirstFoundConsoleLoggingHandler::test_should_return_stream_handler_if_stream_is_stderr PASSED                          [ 20%]
tests/tests_contrib_logging.py::TestRedirectLoggingToTqdm::test_should_add_and_remove_tqdm_handler PASSED                                                     [ 21%]
tests/tests_contrib_logging.py::TestRedirectLoggingToTqdm::test_should_remove_and_restore_console_handlers PASSED                                             [ 22%]
tests/tests_contrib_logging.py::TestRedirectLoggingToTqdm::test_should_inherit_console_logger_formatter PASSED                                                [ 22%]
tests/tests_contrib_logging.py::TestRedirectLoggingToTqdm::test_should_not_remove_stream_handlers_not_for_stdout_or_stderr PASSED                             [ 23%]
tests/tests_contrib_logging.py::TestTqdmWithLoggingRedirect::test_should_add_and_remove_handler_from_root_logger_by_default PASSED                            [ 24%]
tests/tests_contrib_logging.py::TestTqdmWithLoggingRedirect::test_should_add_and_remove_handler_from_custom_logger PASSED                                     [ 24%]
tests/tests_contrib_logging.py::TestTqdmWithLoggingRedirect::test_should_not_fail_with_logger_without_console_handler PASSED                                  [ 25%]
tests/tests_contrib_logging.py::TestTqdmWithLoggingRedirect::test_should_format_message PASSED                                                                [ 26%]
tests/tests_contrib_logging.py::TestTqdmWithLoggingRedirect::test_use_root_logger_by_default_and_write_to_custom_tqdm PASSED                                  [ 26%]
tests/tests_dask.py::test_dask PASSED                                                                                                                         [ 27%]
tests/tests_gui.py::test_gui_import PASSED                                                                                                                    [ 28%]
tests/tests_itertools.py::test_product PASSED                                                                                                                 [ 28%]
tests/tests_keras.py::test_keras PASSED                                                                                                                       [ 29%]
tests/tests_main.py::test_pipes PASSED                                                                                                                        [ 30%]
tests/tests_main.py::test_main_import PASSED                                                                                                                  [ 30%]
tests/tests_main.py::test_main_bytes PASSED                                                                                                                   [ 31%]
tests/tests_main.py::test_main_log PASSED                                                                                                                     [ 32%]
tests/tests_main.py::test_main PASSED                                                                                                                         [ 32%]
tests/tests_main.py::test_manpath PASSED                                                                                                                      [ 33%]
tests/tests_main.py::test_comppath PASSED                                                                                                                     [ 34%]
tests/tests_main.py::test_exceptions PASSED                                                                                                                   [ 34%]
tests/tests_notebook.py::test_notebook_disabled_description PASSED                                                                                            [ 35%]
tests/tests_pandas.py::test_pandas_setup PASSED                                                                                                               [ 36%]
tests/tests_pandas.py::test_pandas_rolling_expanding PASSED                                                                                                   [ 36%]
tests/tests_pandas.py::test_pandas_series PASSED                                                                                                              [ 37%]
tests/tests_pandas.py::test_pandas_data_frame PASSED                                                                                                          [ 38%]
tests/tests_pandas.py::test_pandas_groupby_apply PASSED                                                                                                       [ 38%]
tests/tests_pandas.py::test_pandas_leave PASSED                                                                                                               [ 39%]
tests/tests_pandas.py::test_pandas_apply_args_deprecation PASSED                                                                                              [ 40%]
tests/tests_pandas.py::test_pandas_deprecation PASSED                                                                                                         [ 40%]
tests/tests_perf.py::test_iter_basic_overhead PASSED                                                                                                          [ 41%]
tests/tests_perf.py::test_manual_basic_overhead PASSED                                                                                                        [ 42%]
tests/tests_perf.py::test_lock_args PASSED                                                                                                                    [ 42%]
tests/tests_perf.py::test_iter_overhead_hard PASSED                                                                                                           [ 43%]
tests/tests_perf.py::test_manual_overhead_hard PASSED                                                                                                         [ 44%]
tests/tests_perf.py::test_iter_overhead_simplebar_hard PASSED                                                                                                 [ 44%]
tests/tests_perf.py::test_manual_overhead_simplebar_hard PASSED                                                                                               [ 45%]
tests/tests_rich.py::test_rich_import PASSED                                                                                                                  [ 46%]
tests/tests_synchronisation.py::test_monitor_thread PASSED                                                                                                    [ 46%]
tests/tests_synchronisation.py::test_monitoring_and_cleanup PASSED                                                                                            [ 47%]
tests/tests_synchronisation.py::test_monitoring_multi PASSED                                                                                                  [ 48%]
tests/tests_synchronisation.py::test_imap PASSED                                                                                                              [ 48%]
tests/tests_synchronisation.py::test_threadpool PASSED                                                                                                        [ 49%]
tests/tests_tk.py::test_tk_import PASSED                                                                                                                      [ 50%]
tests/tests_tqdm.py::test_format_interval PASSED                                                                                                              [ 50%]
tests/tests_tqdm.py::test_format_num PASSED                                                                                                                   [ 51%]
tests/tests_tqdm.py::test_format_meter PASSED                                                                                                                 [ 52%]
tests/tests_tqdm.py::test_ansi_escape_codes PASSED                                                                                                            [ 52%]
tests/tests_tqdm.py::test_si_format PASSED                                                                                                                    [ 53%]
tests/tests_tqdm.py::test_bar_formatspec PASSED                                                                                                               [ 54%]
tests/tests_tqdm.py::test_all_defaults PASSED                                                                                                                 [ 54%]
tests/tests_tqdm.py::test_native_string_io_for_default_file PASSED                                                                                            [ 55%]
tests/tests_tqdm.py::test_unicode_string_io_for_specified_file PASSED                                                                                         [ 56%]
tests/tests_tqdm.py::test_write_bytes PASSED                                                                                                                  [ 56%]
tests/tests_tqdm.py::test_iterate_over_csv_rows PASSED                                                                                                        [ 57%]
tests/tests_tqdm.py::test_file_output PASSED                                                                                                                  [ 58%]
tests/tests_tqdm.py::test_leave_option PASSED                                                                                                                 [ 58%]
tests/tests_tqdm.py::test_trange PASSED                                                                                                                       [ 59%]
tests/tests_tqdm.py::test_min_interval PASSED                                                                                                                 [ 60%]
tests/tests_tqdm.py::test_max_interval PASSED                                                                                                                 [ 60%]
tests/tests_tqdm.py::test_delay PASSED                                                                                                                        [ 61%]
tests/tests_tqdm.py::test_min_iters PASSED                                                                                                                    [ 62%]
tests/tests_tqdm.py::test_dynamic_min_iters PASSED                                                                                                            [ 62%]
tests/tests_tqdm.py::test_big_min_interval PASSED                                                                                                             [ 63%]
tests/tests_tqdm.py::test_smoothed_dynamic_min_iters PASSED                                                                                                   [ 64%]
tests/tests_tqdm.py::test_smoothed_dynamic_min_iters_with_min_interval PASSED                                                                                 [ 64%]
tests/tests_tqdm.py::test_rlock_creation PASSED                                                                                                               [ 65%]
tests/tests_tqdm.py::test_disable PASSED                                                                                                                      [ 66%]
tests/tests_tqdm.py::test_infinite_total PASSED                                                                                                               [ 66%]
tests/tests_tqdm.py::test_nototal PASSED                                                                                                                      [ 67%]
tests/tests_tqdm.py::test_unit PASSED                                                                                                                         [ 68%]
tests/tests_tqdm.py::test_ascii PASSED                                                                                                                        [ 68%]
tests/tests_tqdm.py::test_update PASSED                                                                                                                       [ 69%]
tests/tests_tqdm.py::test_close PASSED                                                                                                                        [ 70%]
tests/tests_tqdm.py::test_ema PASSED                                                                                                                          [ 70%]
tests/tests_tqdm.py::test_smoothing PASSED                                                                                                                    [ 71%]
tests/tests_tqdm.py::test_deprecated_nested PASSED                                                                                                            [ 72%]
tests/tests_tqdm.py::test_bar_format PASSED                                                                                                                   [ 72%]
tests/tests_tqdm.py::test_custom_format PASSED                                                                                                                [ 73%]
tests/tests_tqdm.py::test_eta PASSED                                                                                                                          [ 74%]
tests/tests_tqdm.py::test_unpause PASSED                                                                                                                      [ 74%]
tests/tests_tqdm.py::test_disabled_unpause PASSED                                                                                                             [ 75%]
tests/tests_tqdm.py::test_reset PASSED                                                                                                                        [ 76%]
tests/tests_tqdm.py::test_disabled_reset PASSED                                                                                                               [ 76%]
tests/tests_tqdm.py::test_position PASSED                                                                                                                     [ 77%]
tests/tests_tqdm.py::test_set_description PASSED                                                                                                              [ 78%]
tests/tests_tqdm.py::test_deprecated_gui PASSED                                                                                                               [ 78%]
tests/tests_tqdm.py::test_cmp PASSED                                                                                                                          [ 79%]
tests/tests_tqdm.py::test_repr PASSED                                                                                                                         [ 80%]
tests/tests_tqdm.py::test_clear PASSED                                                                                                                        [ 80%]
tests/tests_tqdm.py::test_clear_disabled PASSED                                                                                                               [ 81%]
tests/tests_tqdm.py::test_refresh PASSED                                                                                                                      [ 82%]
tests/tests_tqdm.py::test_disabled_repr PASSED                                                                                                                [ 82%]
tests/tests_tqdm.py::test_disabled_refresh PASSED                                                                                                             [ 83%]
tests/tests_tqdm.py::test_write PASSED                                                                                                                        [ 84%]
tests/tests_tqdm.py::test_len PASSED                                                                                                                          [ 84%]
tests/tests_tqdm.py::test_autodisable_disable PASSED                                                                                                          [ 85%]
tests/tests_tqdm.py::test_autodisable_enable PASSED                                                                                                           [ 86%]
tests/tests_tqdm.py::test_deprecation_exception PASSED                                                                                                        [ 86%]
tests/tests_tqdm.py::test_postfix PASSED                                                                                                                      [ 87%]
tests/tests_tqdm.py::test_postfix_direct PASSED                                                                                                               [ 88%]
tests/tests_tqdm.py::test_file_redirection PASSED                                                                                                             [ 88%]
tests/tests_tqdm.py::test_external_write PASSED                                                                                                               [ 89%]
tests/tests_tqdm.py::test_unit_scale PASSED                                                                                                                   [ 90%]
tests/tests_tqdm.py::test_threading PASSED                                                                                                                    [ 90%]
tests/tests_tqdm.py::test_bool PASSED                                                                                                                         [ 91%]
tests/tests_tqdm.py::test_auto PASSED                                                                                                                         [ 92%]
tests/tests_tqdm.py::test_wrapattr PASSED                                                                                                                     [ 92%]
tests/tests_tqdm.py::test_float_progress PASSED                                                                                                               [ 93%]
tests/tests_tqdm.py::test_screen_shape PASSED                                                                                                                 [ 94%]
tests/tests_tqdm.py::test_initial PASSED                                                                                                                      [ 94%]
tests/tests_tqdm.py::test_colour PASSED                                                                                                                       [ 95%]
tests/tests_tqdm.py::test_closed PASSED                                                                                                                       [ 96%]
tests/tests_tqdm.py::test_reversed PASSED                                                                                                                     [ 96%]
tests/tests_tqdm.py::test_contains PASSED                                                                                                                     [ 97%]
tests/tests_utils.py::test_envwrap PASSED                                                                                                                     [ 98%]
tests/tests_utils.py::test_envwrap_types PASSED                                                                                                               [ 98%]
tests/tests_utils.py::test_envwrap_annotations PASSED                                                                                                         [ 99%]
tests/tests_version.py::test_version PASSED                                                                                                                   [100%]

========================================================================= slowest durations =========================================================================
5.43s call     tests/tests_perf.py::test_lock_args
1.40s call     tests/tests_perf.py::test_iter_overhead_hard
1.36s call     tests/tests_perf.py::test_manual_overhead_hard
1.33s call     tests/tests_keras.py::test_keras
1.20s call     tests/tests_perf.py::test_iter_basic_overhead
0.91s call     tests/tests_asyncio.py::test_as_completed[0.1]
0.83s call     tests/tests_perf.py::test_manual_basic_overhead
0.43s call     tests/tests_dask.py::test_dask
0.15s call     tests/tests_perf.py::test_iter_overhead_simplebar_hard
0.15s call     tests/tests_perf.py::test_manual_overhead_simplebar_hard

(440 durations < 0.1s hidden.  Use -vv to show these durations.)
======================================================================= 150 passed in 13.84s ========================================================================
```