### PR TITLE
Added support for 'metrics' parameter in Keras TQDM Callback

### DIFF
--- a/tests/tests_keras.py
+++ b/tests/tests_keras.py
@@ -6,17 +6,18 @@ pytestmark = mark.slow
 @mark.filterwarnings("ignore:.*:DeprecationWarning")
 def test_keras(capsys):
     """Test tqdm.keras.TqdmCallback"""
-    TqdmCallback = importorskip('tqdm.keras').TqdmCallback
-    np = importorskip('numpy')
+    TqdmCallback = importorskip("tqdm.keras").TqdmCallback
+    np = importorskip("numpy")
     try:
         import keras as K
     except ImportError:
-        K = importorskip('tensorflow.keras')
+        K = importorskip("tensorflow.keras")
 
     # 1D autoencoder
     dtype = np.float32
-    model = K.models.Sequential([
-        K.layers.InputLayer((1, 1), dtype=dtype), K.layers.Conv1D(1, 1)])
+    model = K.models.Sequential(
+        [K.layers.InputLayer((1, 1), dtype=dtype), K.layers.Conv1D(1, 1)]
+    )
     model.compile("adam", "mse")
     x = np.random.rand(100, 1, 1).astype(dtype)
     batch_size = 10
@@ -38,14 +39,16 @@ def test_keras(capsys):
                 data_size=len(x),
                 batch_size=batch_size,
                 metrics=["loss"],
-                verbose=0)])
+                verbose=0,
+            )
+        ],
+    )
     _, res = capsys.readouterr()
     assert "training: " in res
     assert f"{epochs}/{epochs}" in res
     assert f"{batches}/{batches}" not in res
     assert "loss" in res
     assert "val_loss" not in res
-
 
     # full (epoch and batch) progress
     model.fit(
@@ -62,7 +65,10 @@ def test_keras(capsys):
                 data_size=len(x),
                 batch_size=batch_size,
                 metrics=["loss", "val_loss"],
-                verbose=2)])
+                verbose=2,
+            )
+        ],
+    )
     _, res = capsys.readouterr()
     assert "training: " in res
     assert f"{epochs}/{epochs}" in res
@@ -78,7 +84,8 @@ def test_keras(capsys):
         batch_size=batch_size,
         validation_data=(x, x),
         verbose=False,
-        callbacks=[TqdmCallback(desc="training", verbose=2)])
+        callbacks=[TqdmCallback(desc="training", verbose=2)],
+    )
     _, res = capsys.readouterr()
     assert "training: " in res
     assert f"{epochs}/{epochs}" in res
@@ -95,8 +102,12 @@ def test_keras(capsys):
         epochs=epochs,
         batch_size=batch_size,
         verbose=False,
-        callbacks=[TqdmCallback(desc="training", verbose=0,
-                                miniters=1, mininterval=0, maxinterval=0)])
+        callbacks=[
+            TqdmCallback(
+                desc="training", verbose=0, miniters=1, mininterval=0, maxinterval=0
+            )
+        ],
+    )
     _, res = capsys.readouterr()
     assert "training: " in res
     assert f"{initial_epoch - 1}/{initial_epoch - 1}" not in res

--- a/tests/tests_keras.py
+++ b/tests/tests_keras.py
@@ -30,17 +30,22 @@ def test_keras(capsys):
         epochs=epochs,
         batch_size=batch_size,
         verbose=False,
+        validation_data=(x, x),
         callbacks=[
             TqdmCallback(
                 epochs,
                 desc="training",
                 data_size=len(x),
                 batch_size=batch_size,
+                metrics=["loss"],
                 verbose=0)])
     _, res = capsys.readouterr()
     assert "training: " in res
     assert f"{epochs}/{epochs}" in res
     assert f"{batches}/{batches}" not in res
+    assert "loss" in res
+    assert "val_loss" not in res
+
 
     # full (epoch and batch) progress
     model.fit(
@@ -48,6 +53,7 @@ def test_keras(capsys):
         x,
         epochs=epochs,
         batch_size=batch_size,
+        validation_data=(x, x),
         verbose=False,
         callbacks=[
             TqdmCallback(
@@ -55,11 +61,14 @@ def test_keras(capsys):
                 desc="training",
                 data_size=len(x),
                 batch_size=batch_size,
+                metrics=["loss", "val_loss"],
                 verbose=2)])
     _, res = capsys.readouterr()
     assert "training: " in res
     assert f"{epochs}/{epochs}" in res
     assert f"{batches}/{batches}" in res
+    assert "loss" in res
+    assert "val_loss" in res
 
     # auto-detect epochs and batches
     model.fit(
@@ -67,12 +76,15 @@ def test_keras(capsys):
         x,
         epochs=epochs,
         batch_size=batch_size,
+        validation_data=(x, x),
         verbose=False,
         callbacks=[TqdmCallback(desc="training", verbose=2)])
     _, res = capsys.readouterr()
     assert "training: " in res
     assert f"{epochs}/{epochs}" in res
     assert f"{batches}/{batches}" in res
+    assert "loss" in res
+    assert "val_loss" in res
 
     # continue training (start from epoch != 0)
     initial_epoch = 3

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -1,3 +1,5 @@
+"""Submodule for Keras callbacks."""
+
 from copy import copy
 from functools import partial
 
@@ -5,32 +7,61 @@ from .auto import tqdm as tqdm_auto
 
 try:
     import keras
-except (ImportError, AttributeError) as e:
+except (ImportError, AttributeError) as keras_import_exception:
     try:
         from tensorflow import keras
-    except ImportError:
-        raise e
+    except ImportError as tensorflow_import_exception:
+        raise ImportError(
+            "Could not import `keras` or `tensorflow.keras`."
+        ) from tensorflow_import_exception
 __author__ = {"github.com/": ["casperdcl"]}
-__all__ = ['TqdmCallback']
+__all__ = ["TqdmCallback"]
 
 
 class TqdmCallback(keras.callbacks.Callback):
     """Keras callback for epoch and batch progress."""
+
     @staticmethod
-    def bar2callback(bar, pop=None, delta=(lambda logs: 1)):
+    def bar2callback(tqdm_instance, pop=None, delta=(lambda logs: 1), metrics=None):
+        """Converts a `tqdm` bar to a Keras callback.
+
+        Parameters
+        ----------
+        tqdm_instance  : `tqdm` instance
+        pop  : list, optional
+            List of keys to remove from logs.
+        delta  : callable, optional
+            Function to calculate the delta from logs.
+        metrics  : list, optional
+            List of metrics to display.
+        """
+
         def callback(_, logs=None):
             n = delta(logs)
             if logs:
                 if pop:
                     logs = copy(logs)
-                    [logs.pop(i, 0) for i in pop]
-                bar.set_postfix(logs, refresh=False)
-            bar.update(n)
+                    _ = [logs.pop(i, 0) for i in pop]
+                if metrics:
+                    logs = copy(logs)
+                    logs = {
+                        metric: logs[metric] for metric in metrics if metric in logs
+                    }
+                tqdm_instance.set_postfix(logs, refresh=False)
+            tqdm_instance.update(n)
 
         return callback
 
-    def __init__(self, epochs=None, data_size=None, batch_size=None, verbose=1,
-                 tqdm_class=tqdm_auto, **tqdm_kwargs):
+    def __init__(
+        self,
+        epochs=None,
+        data_size=None,
+        batch_size=None,
+        verbose=1,
+        metrics=None,
+        tqdm_class=tqdm_auto,
+        **tqdm_kwargs,
+    ):
         """
         Parameters
         ----------
@@ -43,6 +74,8 @@ class TqdmCallback(keras.callbacks.Callback):
             0: epoch, 1: batch (transient), 2: batch. [default: 1].
             Will be set to `0` unless both `data_size` and `batch_size`
             are given.
+        metrics  : list, optional
+            List of metrics to display
         tqdm_class  : optional
             `tqdm` class to use for bars [default: `tqdm.auto.tqdm`].
         tqdm_kwargs  : optional
@@ -51,61 +84,77 @@ class TqdmCallback(keras.callbacks.Callback):
         if tqdm_kwargs:
             tqdm_class = partial(tqdm_class, **tqdm_kwargs)
         self.tqdm_class = tqdm_class
-        self.epoch_bar = tqdm_class(total=epochs, unit='epoch')
-        self.on_epoch_end = self.bar2callback(self.epoch_bar)
+        self.epoch_bar = tqdm_class(total=epochs, unit="epoch")
+        self.on_epoch_end = self.bar2callback(self.epoch_bar, metrics=metrics)
         if data_size and batch_size:
             self.batches = batches = (data_size + batch_size - 1) // batch_size
         else:
             self.batches = batches = None
         self.verbose = verbose
+        self.metrics = metrics
         if verbose == 1:
-            self.batch_bar = tqdm_class(total=batches, unit='batch', leave=False)
+            self.batch_bar = tqdm_class(total=batches, unit="batch", leave=False)
             self.on_batch_end = self.bar2callback(
-                self.batch_bar, pop=['batch', 'size'],
-                delta=lambda logs: logs.get('size', 1))
+                self.batch_bar,
+                pop=["batch", "size"],
+                delta=lambda logs: logs.get("size", 1),
+                metrics=self.metrics,
+            )
 
     def on_train_begin(self, *_, **__):
+        """Called at the beginning of training to reset the bars."""
         params = self.params.get
-        auto_total = params('epochs', params('nb_epoch', None))
+        auto_total = params("epochs", params("nb_epoch", None))
         if auto_total is not None and auto_total != self.epoch_bar.total:
             self.epoch_bar.reset(total=auto_total)
 
     def on_epoch_begin(self, epoch, *_, **__):
+        """Called at the beginning of each epoch to reset the bars."""
         if self.epoch_bar.n < epoch:
             ebar = self.epoch_bar
             ebar.n = ebar.last_print_n = ebar.initial = epoch
         if self.verbose:
             params = self.params.get
-            total = params('samples', params(
-                'nb_sample', params('steps', None))) or self.batches
+            total = (
+                params("samples", params("nb_sample", params("steps", None)))
+                or self.batches
+            )
             if self.verbose == 2:
-                if hasattr(self, 'batch_bar'):
+                if hasattr(self, "batch_bar"):
                     self.batch_bar.close()
                 self.batch_bar = self.tqdm_class(
-                    total=total, unit='batch', leave=True,
-                    unit_scale=1 / (params('batch_size', 1) or 1))
+                    total=total,
+                    unit="batch",
+                    leave=True,
+                    unit_scale=1 / (params("batch_size", 1) or 1),
+                )
                 self.on_batch_end = self.bar2callback(
-                    self.batch_bar, pop=['batch', 'size'],
-                    delta=lambda logs: logs.get('size', 1))
+                    self.batch_bar,
+                    pop=["batch", "size"],
+                    delta=lambda logs: logs.get("size", 1),
+                    metrics=self.metrics,
+                )
             elif self.verbose == 1:
-                self.batch_bar.unit_scale = 1 / (params('batch_size', 1) or 1)
+                self.batch_bar.unit_scale = 1 / (params("batch_size", 1) or 1)
                 self.batch_bar.reset(total=total)
             else:
-                raise KeyError('Unknown verbosity')
+                raise KeyError("Unknown verbosity")
 
     def on_train_end(self, *_, **__):
-        if hasattr(self, 'batch_bar'):
+        """Called at the end of training to close the bars."""
+        if hasattr(self, "batch_bar"):
             self.batch_bar.close()
         self.epoch_bar.close()
 
     def display(self):
         """Displays in the current cell in Notebooks."""
-        container = getattr(self.epoch_bar, 'container', None)
+        container = getattr(self.epoch_bar, "container", None)
         if container is None:
             return
-        from .notebook import display
+        from tqdm.notebook import display  # pylint: disable=import-outside-toplevel
+
         display(container)
-        batch_bar = getattr(self, 'batch_bar', None)
+        batch_bar = getattr(self, "batch_bar", None)
         if batch_bar is not None:
             display(batch_bar.container)
 

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -10,10 +10,10 @@ try:
 except (ImportError, AttributeError) as keras_import_exception:
     try:
         from tensorflow import keras
-    except ImportError as tensorflow_import_exception:
+    except ImportError:
         raise ImportError(
             "Could not import `keras` or `tensorflow.keras`."
-        ) from tensorflow_import_exception
+        ) from keras_import_exception
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ["TqdmCallback"]
 


### PR DESCRIPTION
This pull request resolves issue #1619 by introducing a `metrics` keyword argument to specify which metrics should be displayed. Furthermore, it resolves code smells reported by Pylint within the TqdmCallback document.