### PR TITLE
Improve robustness of IPykernel detection

### DIFF
--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -10,8 +10,14 @@ import sys
 from warnings import warn
 
 try:
+    if 'ipykernel' not in sys.modules:
+        raise ImportError("console")
     get_ipython = sys.modules['IPython'].get_ipython
-    if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover
+    ipython = get_ipython()
+    if not ipython:
+        raise ImportError("console")
+    from ipykernel.zmqshell import ZMQInteractiveShell
+    if not isinstance(ipython, ZMQInteractiveShell):
         raise ImportError("console")
     from .notebook import WARN_NOIPYW, IProgress
     if IProgress is None:


### PR DESCRIPTION
This is not perfect (it's technically impossible to really know) but should help; in particular it is possible to launch ipykernel without `'IPykernel'` being present in the config, in the case of cloud based launcher (like
https://gateway-provisioners.readthedocs.io/en/latest/).

Note that with the ubiquitousness of tqdm, if this makes it easier for you; I'm open to add a

```
try:
    import tqdm
    tqdm.in_ipykernel(...)
except ImportError:
    pass
```

Or anything similar if this helps detecting in which frontend you are run from. I'm guessing this coudl help as sometime ipykernel is in a notebook, but sometime in QT (like in spyder), and I guess it could help decide what to do without user interactions.