### PR TITLE
drop python<=3.7 support

### DIFF
--- a/examples/7zx.py
+++ b/examples/7zx.py
@@ -17,7 +17,6 @@ Options:
                          NOTSET
   -d, --debug-trace      Print lots of debugging information (-D NOTSET)
 """
-import io
 import logging
 import os
 import pty

--- a/examples/7zx.py
+++ b/examples/7zx.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Usage:
   7zx.py [--help | options] <zipfiles>...
 
@@ -81,7 +80,7 @@ def main():
                 stdout=md,  # subprocess.PIPE,
                 stderr=subprocess.STDOUT)
             os.close(sd)
-            with io.open(md, mode="rU", buffering=1) as m:
+            with open(md, buffering=1) as m:
                 with tqdm(total=sum(fcomp.values()), disable=len(zips) < 2,
                           leave=False, unit="B", unit_scale=True) as t:
                     if not hasattr(t, "start_t"):  # disabled
@@ -89,7 +88,7 @@ def main():
                     while True:
                         try:
                             l_raw = m.readline()
-                        except IOError:
+                        except OSError:
                             break
                         ln = l_raw.strip()
                         if ln.startswith("Extracting"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dynamic = ["version"]
 maintainers = [{name = "tqdm developers", email = "devs@tqdm.ml"}]
 description = "Fast, Extensible Progress Meter"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = ["progressbar", "progressmeter", "progress", "bar", "meter", "rate", "eta", "console", "terminal", "time"]
 license = {text = "MPL-2.0 AND MIT"}
 # Trove classifiers (https://pypi.org/pypi?%3Aaction=list_classifiers)
@@ -54,7 +54,6 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,10 @@ def pretest_posttest():
         n = len(tqdm._instances)
         if n:
             tqdm._instances.clear()
-            raise EnvironmentError(f"{n} `tqdm` instances still in existence PRE-test")
+            raise OSError(f"{n} `tqdm` instances still in existence PRE-test")
     yield
     if getattr(tqdm, "_instances", False):
         n = len(tqdm._instances)
         if n:
             tqdm._instances.clear()
-            raise EnvironmentError(f"{n} `tqdm` instances still in existence POST-test")
+            raise OSError(f"{n} `tqdm` instances still in existence POST-test")

--- a/tests/tests_itertools.py
+++ b/tests/tests_itertools.py
@@ -8,13 +8,12 @@ from tqdm.contrib.itertools import product
 from .tests_tqdm import StringIO, closing
 
 
-class NoLenIter(object):
+class NoLenIter:
     def __init__(self, iterable):
         self._it = iterable
 
     def __iter__(self):
-        for i in self._it:
-            yield i
+        yield from self._it
 
 
 def test_product():

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -47,10 +47,8 @@ def test_pipes():
     assert b"it/s" in err
     assert b"Error" not in err
 
-
-if sys.version_info[:2] >= (3, 8):
-    test_pipes = mark.filterwarnings("ignore:unclosed file:ResourceWarning")(
-        test_pipes)
+test_pipes = mark.filterwarnings("ignore:unclosed file:ResourceWarning")(
+    test_pipes)
 
 
 def test_main_import():

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -60,7 +60,7 @@ def test_main_import():
     sys.argv = ['', '--desc', 'Test CLI import',
                 '--ascii', 'True', '--unit_scale', 'True']
     try:
-        import tqdm.__main__  # NOQA, pylint: disable=unused-variable
+        pass  # NOQA, pylint: disable=unused-variable
     finally:
         sys.stdin, sys.argv = _SYS
 

--- a/tests/tests_synchronisation.py
+++ b/tests/tests_synchronisation.py
@@ -7,7 +7,7 @@ from tqdm import TMonitor, tqdm, trange
 from .tests_tqdm import StringIO, closing, importorskip, patch_lock, skip
 
 
-class Time(object):
+class Time:
     """Fake time class class providing an offset"""
     offset = 0
 
@@ -78,7 +78,7 @@ def cpu_timify(t, timer=Time):
     return timer
 
 
-class FakeTqdm(object):
+class FakeTqdm:
     _instances = set()
     get_lock = tqdm.get_lock
 

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Advice: use repr(our_file.read()) to print the full output of tqdm
 # (else '\r' will replace the previous lines and you'll see only the latest.
 import csv
@@ -80,7 +79,7 @@ def pos_line_diff(res_list, expected_list, raise_nonempty=True):
     return res
 
 
-class DiscreteTimer(object):
+class DiscreteTimer:
     """Virtual discrete time manager, to precisely control time for tests"""
     def __init__(self):
         self.t = 0.0
@@ -353,7 +352,7 @@ def test_native_string_io_for_default_file():
     """Native strings written to unspecified files"""
     stderr = sys.stderr
     try:
-        sys.stderr = WriteTypeChecker(expected_type=type(''))
+        sys.stderr = WriteTypeChecker(expected_type=str)
         for _ in tqdm(range(3)):
             pass
         sys.stderr.encoding = None  # py2 behaviour
@@ -365,20 +364,20 @@ def test_native_string_io_for_default_file():
 
 def test_unicode_string_io_for_specified_file():
     """Unicode strings written to specified files"""
-    for _ in tqdm(range(3), file=WriteTypeChecker(expected_type=type(u''))):
+    for _ in tqdm(range(3), file=WriteTypeChecker(expected_type=str)):
         pass
 
 
 def test_write_bytes():
     """Test write_bytes argument with and without `file`"""
     # specified file (and bytes)
-    for _ in tqdm(range(3), file=WriteTypeChecker(expected_type=type(b'')),
+    for _ in tqdm(range(3), file=WriteTypeChecker(expected_type=bytes),
                   write_bytes=True):
         pass
     # unspecified file (and unicode)
     stderr = sys.stderr
     try:
-        sys.stderr = WriteTypeChecker(expected_type=type(u''))
+        sys.stderr = WriteTypeChecker(expected_type=str)
         for _ in tqdm(range(3), write_bytes=False):
             pass
     finally:
@@ -869,9 +868,9 @@ def test_ascii():
             for _ in range(3):
                 t.update()
         res = our_file.getvalue().strip("\r").split("\r")
-    assert u"7%|\u258b" in res[1]
-    assert u"13%|\u2588\u258e" in res[2]
-    assert u"20%|\u2588\u2588" in res[3]
+    assert "7%|\u258b" in res[1]
+    assert "13%|\u2588\u258e" in res[2]
+    assert "20%|\u2588\u2588" in res[3]
 
     # Test custom bar
     for bars in [" .oO0", " #"]:
@@ -1323,7 +1322,7 @@ def test_set_description():
     # unicode
     with closing(StringIO()) as our_file:
         with tqdm(total=10, file=our_file) as t:
-            t.set_description(u"\xe1\xe9\xed\xf3\xfa")
+            t.set_description("\xe1\xe9\xed\xf3\xfa")
 
 
 def test_deprecated_gui():
@@ -1446,8 +1445,8 @@ def test_refresh():
         t2.close()
 
         # Check that refreshing indeed forced the display to use realtime state
-        assert before == [u'pos0 bar:   0%|', u'pos1 bar:   0%|']
-        assert after == [u'pos0 bar:  10%|', u'pos1 bar:  10%|']
+        assert before == ['pos0 bar:   0%|', 'pos1 bar:   0%|']
+        assert after == ['pos0 bar:  10%|', 'pos1 bar:  10%|']
 
 
 def test_disabled_repr(capsys):

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -1,10 +1,6 @@
 from warnings import warn
 
 from .std import TqdmDeprecationWarning
-from .utils import (  # NOQA, pylint: disable=unused-import
-    CUR_OS, IS_NIX, IS_WIN, RE_ANSI, Comparable, FormatReplace, SimpleTextIOWrapper,
-    _environ_cols_wrapper, _is_ascii, _is_utf, _screen_shape_linux, _screen_shape_tput,
-    _screen_shape_windows, _screen_shape_wrapper, _supports_unicode, _term_move_up, colorama)
 
 warn("This function will be removed in tqdm==5.0.0\n"
      "Please use `tqdm.utils.*` instead of `tqdm._utils.*`",

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -249,7 +249,7 @@ Options:
         manpath = tqdm_args.pop('manpath', None)
         comppath = tqdm_args.pop('comppath', None)
         if tqdm_args.pop('null', False):
-            class stdout(object):
+            class stdout:
                 @staticmethod
                 def write(_):
                     pass
@@ -278,7 +278,7 @@ Options:
             stdout_write = stdout.write
             fp_write = getattr(fp, 'buffer', fp).write
 
-            class stdout(object):  # pylint: disable=function-redefined
+            class stdout:  # pylint: disable=function-redefined
                 @staticmethod
                 def write(x):
                     with tqdm.external_write_mode(file=fp):

--- a/tqdm/contrib/__init__.py
+++ b/tqdm/contrib/__init__.py
@@ -76,8 +76,7 @@ def tzip(iter1, *iter2plus, **tqdm_kwargs):
     """
     kwargs = tqdm_kwargs.copy()
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
-    for i in zip(tqdm_class(iter1, **kwargs), *iter2plus):
-        yield i
+    yield from zip(tqdm_class(iter1, **kwargs), *iter2plus)
 
 
 def tmap(function, *sequences, **tqdm_kwargs):

--- a/tqdm/contrib/utils_worker.py
+++ b/tqdm/contrib/utils_worker.py
@@ -10,7 +10,7 @@ __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['MonoWorker']
 
 
-class MonoWorker(object):
+class MonoWorker:
     """
     Supports one running task and one waiting task.
     The waiting task is the most recent submitted (others are discarded).

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -157,7 +157,7 @@ class tqdm_notebook(std_tqdm):
         pbar.value = self.n
 
         if msg:
-            msg = msg.replace(' ', u'\u2007')  # fix html space padding
+            msg = msg.replace(' ', '\u2007')  # fix html space padding
             # html escape special characters (like '&')
             if '<bar/>' in msg:
                 left, right = map(escape, re.split(r'\|?<bar/>\|?', msg, maxsplit=1))
@@ -247,9 +247,7 @@ class tqdm_notebook(std_tqdm):
     def __iter__(self):
         try:
             it = super().__iter__()
-            for obj in it:
-                # return super(tqdm...) will not catch exception
-                yield obj
+            yield from it
         # NB: except ... [ as ...] breaks IPython async KeyboardInterrupt
         except:  # NOQA
             self.disp(bar_style='danger')

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -73,7 +73,7 @@ def TRLock(*args, **kwargs):
         pass
 
 
-class TqdmDefaultWriteLock(object):
+class TqdmDefaultWriteLock:
     """
     Provide a default write lock for thread and multiprocessing safety.
     Works only on platforms supporting `fork` (so Windows is excluded).
@@ -128,7 +128,7 @@ class TqdmDefaultWriteLock(object):
         warn("create_th_lock not needed anymore", TqdmDeprecationWarning, stacklevel=2)
 
 
-class Bar(object):
+class Bar:
     """
     `str.format`-able bar with format specifiers: `[width][type]`
 
@@ -142,7 +142,7 @@ class Bar(object):
       + `b`: blank (`charset="  "` override)
     """
     ASCII = " 123456789#"
-    UTF = u" " + u''.join(map(chr, range(0x258F, 0x2587, -1)))
+    UTF = " " + ''.join(map(chr, range(0x258F, 0x2587, -1)))
     BLANK = "  "
     COLOUR_RESET = '\x1b[0m'
     COLOUR_RGB = '\x1b[38;2;%d;%d;%dm'
@@ -178,7 +178,7 @@ class Bar(object):
             else:
                 raise KeyError
         except (KeyError, AttributeError):
-            warn("Unknown colour (%s); valid choices: [hex (#00ff00), %s]" % (
+            warn("Unknown colour ({}); valid choices: [hex (#00ff00), {}]".format(
                  value, ", ".join(self.COLOURS)),
                  TqdmWarning, stacklevel=2)
             self._colour = None
@@ -211,7 +211,7 @@ class Bar(object):
         return self.colour + res + self.COLOUR_RESET if self.colour else res
 
 
-class EMA(object):
+class EMA:
     """
     Exponential moving average: smoothing to give progressively lower
     weights to older values.

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -99,7 +99,7 @@ def envwrap(prefix, types=None, is_method=False):
     return wrap
 
 
-class FormatReplace(object):
+class FormatReplace:
     """
     >>> a = FormatReplace('something')
     >>> f"{a:5d}"
@@ -114,7 +114,7 @@ class FormatReplace(object):
         return self.replace
 
 
-class Comparable(object):
+class Comparable:
     """Assumes child has self._comparable attr/@property"""
     def __lt__(self, other):
         return self._comparable < other._comparable
@@ -135,7 +135,7 @@ class Comparable(object):
         return not self < other
 
 
-class ObjectWrapper(object):
+class ObjectWrapper:
     def __getattr__(self, name):
         return getattr(self._wrapped, name)
 
@@ -251,7 +251,7 @@ class CallbackIOWrapper(ObjectWrapper):
 
 def _is_utf(encoding):
     try:
-        u'\u2588\u2589'.encode(encoding)
+        '\u2588\u2589'.encode(encoding)
     except UnicodeEncodeError:
         return False
     except Exception:


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.