### PR TITLE
Install UV instead of setup-python.  Use uv tool install instead of pip.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,12 +52,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with: {fetch-depth: 0}
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python }}
-    - name: install
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+    - name: install tox & tox-gh-actions (with uv tool install)
       run: |
-        pip install -U tox tox-gh-actions
+        uv tool install --python ${{ matrix.python }} --with tox-gh-actions tox
         mkdir -p "$HOME/bin"
         curl -sfL https://coverage.codacy.com/get.sh > "$HOME/bin/codacy"
         chmod +x "$HOME/bin/codacy"


### PR DESCRIPTION
Fixes #1642 

Note:  The PyPi deploy job should still fail (although I've still managed to push something to Docker)