### PR TITLE
docs: remove "unity" reference in tqdm.std.tqdm.format_sizeof

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -370,13 +370,12 @@ class tqdm(Comparable):
     @staticmethod
     def format_sizeof(num, suffix='', divisor=1000):
         """
-        Formats a number (greater than unity) with SI Order of Magnitude
-        prefixes.
+        Formats a number (>= 1) with SI Order of Magnitude prefixes.
 
         Parameters
         ----------
         num  : float
-            Number ( >= 1) to format.
+            Number (>= 1) to format.
         suffix  : str, optional
             Post-postfix [default: ''].
         divisor  : float, optional


### PR DESCRIPTION
This dates to ee6c3ce95c4452b4829f2e6685334386ad8fda51 and is the only reference to "unity" in the tqdm codebase. It's replaced with the equivalent explanatory text from the parameters section.

To see the change as a user would, run `pydoc .tqdm.std.tqdm.format_sizeof` in the source root.