### PR TITLE
Add support for `TQDM_NOTEBOOK` environment variable

### DIFF
--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -3,7 +3,7 @@ import logging
 import subprocess  # nosec
 import sys
 from functools import wraps
-from os import linesep
+from os import linesep, environ
 
 from tqdm.cli import TqdmKeyError, TqdmTypeError, main
 from tqdm.utils import IS_WIN
@@ -242,3 +242,19 @@ def test_exceptions(capsysbinary):
     for i in ('-h', '--help', '-v', '--version'):
         with raises(SystemExit):
             main(argv=[i])
+
+
+def test_tqdm_notebook_env_set():
+    """Test if TQDM_NOTEBOOK environment variable is set, tqdm uses tqdm.notebook"""
+    environ['TQDM_NOTEBOOK'] = '1'
+    from tqdm import tqdm
+    from tqdm.notebook import tqdm as notebook_tqdm
+    assert tqdm == notebook_tqdm
+    del environ['TQDM_NOTEBOOK']
+
+
+def test_tqdm_notebook_env_not_set():
+    """Test if TQDM_NOTEBOOK environment variable is not set, tqdm uses tqdm"""
+    from tqdm import tqdm
+    from tqdm.std import tqdm as std_tqdm
+    assert tqdm == std_tqdm

--- a/tqdm/__init__.py
+++ b/tqdm/__init__.py
@@ -1,3 +1,4 @@
+import os
 from ._monitor import TMonitor, TqdmSynchronisationWarning
 from ._tqdm_pandas import tqdm_pandas
 from .cli import main  # TODO: remove in v5.0.0
@@ -7,6 +8,10 @@ from .std import (
     TqdmDeprecationWarning, TqdmExperimentalWarning, TqdmKeyError, TqdmMonitorWarning,
     TqdmTypeError, TqdmWarning, tqdm, trange)
 from .version import __version__
+
+if os.getenv('TQDM_NOTEBOOK'):
+    from .notebook import tqdm, trange # noqa: F811
+
 
 __all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_pandas',
            'tqdm_notebook', 'tnrange', 'main', 'TMonitor',


### PR DESCRIPTION
Add support for `TQDM_NOTEBOOK` environment variable to use `tqdm.notebook` instead of `tqdm`.

* **tqdm/__init__.py**
  - Import `os` at the top of the file.
  - Add a check for the `TQDM_NOTEBOOK` environment variable outside the `tqdm_notebook` function.
  - If the `TQDM_NOTEBOOK` environment variable is set, use `tqdm.notebook` instead of `tqdm`.

* **tests/tests_main.py**
  - Add a test case to check if `TQDM_NOTEBOOK` environment variable is set, `tqdm` uses `tqdm.notebook`.
  - Add a test case to check if `TQDM_NOTEBOOK` environment variable is not set, `tqdm` uses `tqdm`.

---
**Use case:**
 - It avoids modifying the dependant libraries https://github.com/huggingface/transformers/pull/35726.

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tqdm/tqdm/pull/1655?shareId=bb936eaf-e88e-40ce-93d3-e500a53428d2).