### PR TITLE
Refactoring: Use startswith with all options

### DIFF
--- a/examples/7zx.py
+++ b/examples/7zx.py
@@ -97,19 +97,25 @@ def main():
                             s = fcomp.get(exname, 0)  # 0 is likely folders
                             t.update(s)
                             tall.update(s)
-                        elif ln:
-                            if not any(
-                                    ln.startswith(i)
-                                    for i in ("7-Zip ", "p7zip Version ",
-                                              "Everything is Ok", "Folders: ",
-                                              "Files: ", "Size: ", "Compressed: ")):
-                                if ln.startswith("Processing archive: "):
-                                    if not args.silent:
-                                        t.write(t.format_interval(
-                                            t.start_t - tall.start_t) + ' ' +
-                                            ln.replace("Processing archive: ", ""))
-                                else:
-                                    t.write(ln)
+                        elif ln.startswith("Processing archive: "):
+                            if not args.silent:
+                                t.write(
+                                    t.format_interval(t.start_t - tall.start_t)
+                                    + " "
+                                    + ln.replace("Processing archive: ", "")
+                                )
+                        elif ln and not ln.startswith(
+                            (
+                                "7-Zip ",
+                                "p7zip Version ",
+                                "Everything is Ok",
+                                "Folders: ",
+                                "Files: ",
+                                "Size: ",
+                                "Compressed: ",
+                            )
+                        ):
+                            t.write(ln)
             ex.wait()
 
 

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -13,8 +13,8 @@ from weakref import proxy
 
 _range, _unich, _unicode, _basestring = range, chr, str, str
 CUR_OS = sys.platform
-IS_WIN = any(CUR_OS.startswith(i) for i in ['win32', 'cygwin'])
-IS_NIX = any(CUR_OS.startswith(i) for i in ['aix', 'linux', 'darwin', 'freebsd'])
+IS_WIN = CUR_OS.startswith(('win32', 'cygwin'))
+IS_NIX = CUR_OS.startswith(('aix', 'linux', 'darwin', 'freebsd'))
 RE_ANSI = re.compile(r"\x1b\[[;\d]*[A-Za-z]")
 
 try:


### PR DESCRIPTION
This PR only updates the usage of `.startswith` to use a tuple of all options, which is functionally equivalent to the current `any()` construct.