### PR TITLE
add name for the monitoring thread

### DIFF
--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -29,6 +29,7 @@ class TMonitor(Thread):
 
     def __init__(self, tqdm_cls, sleep_interval):
         Thread.__init__(self)
+        self.name = "tqdm_monitor"
         self.daemon = True  # kill thread when main killed (KeyboardInterrupt)
         self.woken = 0  # last time woken up, to sync with monitor
         self.tqdm_cls = tqdm_cls


### PR DESCRIPTION
Added name for monitoring thread for tqdm bars.

Before:
![image](https://github.com/user-attachments/assets/e9f465b6-70a4-417c-b66f-b2837c12bb31)

After:
![image](https://github.com/user-attachments/assets/24b0182d-c8c9-4463-a2c7-ec0dcd68537a)
