### PR TITLE
Fix semaphore leak

### DIFF
--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -37,6 +37,7 @@ class tqdm_asyncio(std_tqdm):
         return self
 
     def __del__(self):
+        self.close()
         if hasattr(tqdm_asyncio, "_lock"):
             del tqdm_asyncio._lock
         if hasattr(tqdm_asyncio, "monitor") and tqdm_asyncio.monitor is not None:

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -38,10 +38,11 @@ class tqdm_asyncio(std_tqdm):
 
     def __del__(self):
         self.close()
-        if hasattr(tqdm_asyncio, "_lock"):
-            del tqdm_asyncio._lock
-        if hasattr(tqdm_asyncio, "monitor") and tqdm_asyncio.monitor is not None:
-            tqdm_asyncio.monitor.exit()
+        if len(tqdm_asyncio._instances) == 0:
+            if hasattr(tqdm_asyncio, "_lock"):
+                del tqdm_asyncio._lock
+            if hasattr(tqdm_asyncio, "monitor") and tqdm_asyncio.monitor is not None:
+                tqdm_asyncio.monitor.exit()
 
     async def __anext__(self):
         try:

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -36,6 +36,12 @@ class tqdm_asyncio(std_tqdm):
     def __aiter__(self):
         return self
 
+    def __del__(self):
+        if hasattr(tqdm_asyncio, "_lock"):
+            del tqdm_asyncio._lock
+        if hasattr(tqdm_asyncio, "monitor") and tqdm_asyncio.monitor is not None:
+            tqdm_asyncio.monitor.exit()
+
     async def __anext__(self):
         try:
             if self.iterable_awaitable:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -114,7 +114,7 @@ class TqdmDefaultWriteLock(object):
         self.release()
 
     def __del__(self):
-        if TqdmDefaultWriteLock.mp_lock is not None:
+        if hasattr(TqdmDefaultWriteLock, 'mp_lock') and TqdmDefaultWriteLock.mp_lock is not None:
             del TqdmDefaultWriteLock.mp_lock
 
     @classmethod

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -116,7 +116,7 @@ class TqdmDefaultWriteLock(object):
     def __del__(self):
         if TqdmDefaultWriteLock.mp_lock is not None:
             del TqdmDefaultWriteLock.mp_lock
-        
+
     @classmethod
     def create_mp_lock(cls):
         if not hasattr(cls, 'mp_lock'):

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1152,6 +1152,8 @@ class tqdm(Comparable):
         self.close()
         if hasattr(tqdm, "_lock"):
             del tqdm._lock
+        if hasattr(tqdm, "monitor") and tqdm.monitor is not None:
+            tqdm.monitor.exit()
 
     def __str__(self):
         return self.format_meter(**self.format_dict)

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -113,6 +113,10 @@ class TqdmDefaultWriteLock(object):
     def __exit__(self, *exc):
         self.release()
 
+    def __del__(self):
+        if TqdmDefaultWriteLock.mp_lock is not None:
+            del TqdmDefaultWriteLock.mp_lock
+        
     @classmethod
     def create_mp_lock(cls):
         if not hasattr(cls, 'mp_lock'):
@@ -1146,6 +1150,8 @@ class tqdm(Comparable):
 
     def __del__(self):
         self.close()
+        if hasattr(tqdm, "_lock"):
+            del tqdm._lock
 
     def __str__(self):
         return self.format_meter(**self.format_dict)

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -989,7 +989,7 @@ class tqdm(Comparable):
         if disable:
             self.iterable = iterable
             self.disable = disable
-            with self._lock:
+            with self.get_lock():
                 self.pos = self._get_free_pos(self)
                 self._instances.remove(self)
             self.n = initial
@@ -999,7 +999,7 @@ class tqdm(Comparable):
 
         if kwargs:
             self.disable = True
-            with self._lock:
+            with self.get_lock():
                 self.pos = self._get_free_pos(self)
                 self._instances.remove(self)
             raise (
@@ -1091,7 +1091,7 @@ class tqdm(Comparable):
 
         # if nested, at initial sp() call we replace '\r' by '\n' to
         # not overwrite the outer progress bar
-        with self._lock:
+        with self.get_lock():
             # mark fixed positions as negative
             self.pos = self._get_free_pos(self) if position is None else -position
 
@@ -1150,10 +1150,11 @@ class tqdm(Comparable):
 
     def __del__(self):
         self.close()
-        if hasattr(tqdm, "_lock"):
-            del tqdm._lock
-        if hasattr(tqdm, "monitor") and tqdm.monitor is not None:
-            tqdm.monitor.exit()
+        if len(tqdm._instances) == 0:
+            if hasattr(tqdm, "_lock"):
+                del tqdm._lock
+            if hasattr(tqdm, "monitor") and tqdm.monitor is not None:
+                tqdm.monitor.exit()
 
     def __str__(self):
         return self.format_meter(**self.format_dict)
@@ -1303,7 +1304,7 @@ class tqdm(Comparable):
 
         leave = pos == 0 if self.leave is None else self.leave
 
-        with self._lock:
+        with self.get_lock():
             if leave:
                 # stats for overall rate (no weighted average)
                 self._ema_dt = lambda: None


### PR DESCRIPTION
```
/root/.pyenv/versions/3.12.11/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```

and

```
Exception in thread Thread-2:
Exception in threading.excepthook:
Exception ignored in thread started by: <bound method Thread._bootstrap of <TMonitor(Thread-2, started daemon 132951006242368)>>
Exception ignored in sys.unraisablehook: <built-in function unraisablehook>
```

Both errors happen when the program stop normally or after error.
Python garbage collector is seems to be not smart enough to clean memory after dynamic class property assignment.
TMonitor is also not released properly because of async code.
This is the minimal irreducible change.

https://github.com/apple/ml-stable-diffusion/issues/8
https://www.reddit.com/r/comfyui/comments/1c0n5de/there_appear_to_be_1_leaked_semaphore_objects_to/
https://discuss.python.org/t/leaked-semaphore-objects-to-clean-up-error-when-using-concurrent-futures/54510
https://github.com/modelscope/ms-swift/issues/4689
https://github.com/search?q=%22UserWarning%3A+resource_tracker%3A+There+appear+to+be+1+leaked+semaphore+objects+to+clean+up+at+shutdown%22+tqdm&type=issues
