### PR TITLE
docs: mention supported Python versions in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,11 @@ Latest PyPI stable release
 
     pip install tqdm
 
+.. note::
+
+   ``tqdm`` officially supports **Python 3.7 and above**.  
+   For older Python versions, please install an earlier release from PyPI.
+   
 Latest development release on GitHub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add a note under the "Latest PyPI stable release" section of README.rst to specify that tqdm officially supports Python 3.7 and above. This helps users with older Python environments quickly determine compatibility before installing.