### PR TITLE
docs: fix minor typos and improve clarity in documentation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 This file describes how to
 
 - contribute changes to the project, and
-- upload released to the PyPI repository.
+- upload releases to the PyPI repository.
 
 Most of the management commands have been directly placed inside the
 Makefile:

--- a/README.rst
+++ b/README.rst
@@ -215,7 +215,7 @@ Perhaps the most wonderful use of ``tqdm`` is in a script or on the command
 line. Simply inserting ``tqdm`` (or ``python -m tqdm``) between pipes will pass
 through all ``stdin`` to ``stdout`` while printing progress to ``stderr``.
 
-The example below demonstrate counting the number of lines in all Python files
+The example below demonstrates counting the number of lines in all Python files
 in the current directory, with timing information included.
 
 .. code:: sh
@@ -665,7 +665,7 @@ Submodules
         """IPython/Jupyter Notebook widget."""
 
     class tqdm.auto.tqdm(tqdm.tqdm):
-        """Automatically chooses beween `tqdm.notebook` and `tqdm.tqdm`."""
+        """Automatically chooses between `tqdm.notebook` and `tqdm.tqdm`."""
 
     class tqdm.asyncio.tqdm(tqdm.tqdm):
       """Asynchronous version."""
@@ -1280,7 +1280,7 @@ Redirecting writing
 ~~~~~~~~~~~~~~~~~~~
 
 If using a library that can print messages to the console, editing the library
-by  replacing ``print()`` with ``tqdm.write()`` may not be desirable.
+by replacing ``print()`` with ``tqdm.write()`` may not be desirable.
 In that case, redirecting ``sys.stdout`` to ``tqdm.write()`` is an option.
 
 To redirect ``sys.stdout``, create a file-like class that will write
@@ -1365,7 +1365,7 @@ Monitoring thread, intervals and miniters
   A clever adjustment system ``dynamic_miniters`` will automatically adjust
   ``miniters`` to the amount of iterations that fit into time ``mininterval``.
   Essentially, ``tqdm`` will check if it's time to print without actually
-  checking time. This behaviour can be still be bypassed by manually setting
+  checking time. This behaviour can still be bypassed by manually setting
   ``miniters``.
 
 However, consider a case with a combination of fast and slow iterations.

--- a/README.rst
+++ b/README.rst
@@ -1272,7 +1272,7 @@ display, a ``.write()`` method is provided:
             tqdm.write("Done task %i" % i)
         # Can also use bar.write()
 
-By default, this will print to standard output ``sys.stdout``. but you can
+By default, this will print to standard output ``sys.stdout``. But you can
 specify any file-like object using the ``file`` argument. For example, this
 can be used to redirect the messages writing to a log file or class.
 

--- a/examples/paper.md
+++ b/examples/paper.md
@@ -92,7 +92,7 @@ Supported features include:
 - Display customisation via arguments such as `desc`, `postfix` and `bar_format`
 - Automatic limiting of display updates to avoid slowing down due to excessive
   iteration rates [@stdout]
-- Automatic detection of console width to fill  the display
+- Automatic detection of console width to fill the display
 - Automatic use of Unicode to render smooth-filling progress bars on supported
   terminals
 - Support for custom rendering frontends, including:
@@ -105,7 +105,7 @@ Supported features include:
 
 ## Command-line Interface (CLI)
 
-A CLI is also provided, where `tqdm` may be used a pipe:
+A CLI is also provided, where `tqdm` may be used as a pipe:
 
 ```sh
  # count lines of text in all *.txt files


### PR DESCRIPTION
Hello this is my first contribution to tqdm. Here's the changelog

**Change log:**
- Minor typo fixes