### PR TITLE
Add `formatters` option to customize progress output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -446,6 +446,10 @@ Parameters
     remaining, remaining_s, eta.
     Note that a trailing ": " is automatically removed after {desc}
     if the latter is empty.
+* formatters  : dict, optional  
+    Dictionary mapping field names to format specifiers used to
+    customise default numeric representations. Keys include ``n``,
+    ``total``, ``rate``, ``percentage`` and ``postfix_float``.
 * initial  : int or float, optional  
     The initial counter value. Useful when restarting a progress
     bar [default: 0]. If using float, consider specifying ``{n:.3f}``

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -274,6 +274,25 @@ def test_format_meter():
                         bar_format=r'{bar}|test') == unich(0x258f) + "|test"
 
 
+def test_formatters():
+    """Test numeric field formatters"""
+    with closing(StringIO()) as our_file:
+        t = tqdm(total=2.0, file=our_file, mininterval=0, miniters=1,
+                 smoothing=0,
+                 formatters={'n': '.3f', 'total': '.1f', 'rate': '.1f',
+                             'percentage': '3.1f', 'postfix_float': '.2f'})
+        timer = cpu_timify(t)
+        timer.sleep(1)
+        t.update(1.23456)
+        t.set_postfix(v=1.23456)
+        t.close()
+        bar = get_bar(our_file.getvalue())[-1]
+    assert '1.235/2.0' in bar
+    assert '61.7%|' in bar
+    assert '1.2it/s' in bar
+    assert 'v=1.23' in bar
+
+
 def test_ansi_escape_codes():
     """Test stripping of ANSI escape codes"""
     ansi = {'BOLD': '\033[1m', 'RED': '\033[91m', 'END': '\033[0m'}


### PR DESCRIPTION
**Summary**
Add a new `formatters: dict` option to `tqdm` to override default numeric formatting for common fields.

**What changed**

* Accept `formatters` in `tqdm.__init__` and `format_meter`.
* Supported keys: `n`, `total`, `rate`, `percentage`, `postfix_float`.
* `set_postfix` uses `postfix_float` for numeric postfix formatting.
* Adds `{percentage_fmt}` for bar formats when `formatters['percentage']` is used.
* README updated and a unit test (`test_formatters`) added.

**Example**

```py
tqdm(total=2.0, formatters={'n':'.3f','total':'.1f','rate':'.1f',
                            'percentage':'3.1f','postfix_float':'.2f'})
# -> "1.235/2.0", "61.7%|", "1.2it/s", postfix "v=1.23"
```

**Compatibility**

* No behavior change when `formatters=None`.
* Minor risk only for callers using positional args after `bar_format`; recommend keyword args.
