### PR TITLE
mytqdm.app integration

### DIFF
--- a/tqdm/contrib/mytqdm.py
+++ b/tqdm/contrib/mytqdm.py
@@ -19,9 +19,9 @@ except ImportError:
 from ..auto import tqdm as tqdm_auto
 
 __author__ = {"github.com/padmalcom"}
-__all__ = ['tqdm_mytqdm', 'mytqdmrange', 'tqdm', 'trange']
+__all__ = ['mytqdm', 'mytqdmrange', 'tqdm', 'trange']
 
-class tqdm_mytqdm(tqdm_auto):
+class mytqdm(tqdm_auto):
     """
     Standard `tqdm.auto.tqdm` but also sends updates to a mytqdm.app.
 
@@ -33,7 +33,7 @@ class tqdm_mytqdm(tqdm_auto):
     >>> for i in tqdm(iterable, api_key='{api_key}', title='{title}'):
     ...     ...
     """
-    
+
     PROGRESS_URL = "https://mytqdm.app/api/v1/p"
     
     def __init__(self, *args, **kwargs):
@@ -52,11 +52,11 @@ class tqdm_mytqdm(tqdm_auto):
             self.api_key = kwargs.pop('api_key', getenv("MYTQDM_API_KEY"))
             self.title = kwargs.pop('title', getenv("MYTQDM_TITLE"))
         super().__init__(*args, **kwargs)
-        
-    def display(self, **kwargs):
-        super().display(**kwargs)
+
+    def display(self, msg=None, pos=None):
+        super().display(msg=msg, pos=pos)
         current = self.n
-        total = self.total    
+        total = self.total
         headers = {
             "Authorization": f"X-API-Key {self.api_key}",
             "Accept": "application/json",
@@ -75,12 +75,12 @@ class tqdm_mytqdm(tqdm_auto):
         except requests.exceptions.Timeout:
             logging.error("The request to mytqdm.app timed out (connect or read).")
         except requests.exceptions.RequestException as e:
-            logging.error(f"An error occured when updating mytqdm state: {e}")      
+            logging.error(f"An error occured when updating mytqdm state: {e}")
 
 def mytqdmrange(*args, **kwargs):
     """Shortcut for `tqdm.contrib.mytqdm.tqdm(range(*args), **kwargs)`."""
-    return tqdm_mytqdm(range(*args), **kwargs)
+    return mytqdm(range(*args), **kwargs)
 
 # Aliases
-tqdm = tqdm_mytqdm
+tqdm = mytqdm
 trange = mytqdmrange

--- a/tqdm/contrib/mytqdm.py
+++ b/tqdm/contrib/mytqdm.py
@@ -1,0 +1,86 @@
+"""
+Sends updates to mytqdm.app.
+
+Usage:
+>>> from tqdm.contrib.mytqdm import tqdm, trange
+>>> for i in trange(10, api_key='{api_key}', title='{title}'):
+...     ...
+
+![link](https://mytqdm.app/)
+"""
+import logging
+from os import getenv
+
+try:
+    import requests
+except ImportError:
+    raise ImportError("Please `pip install requests`")
+
+from ..auto import tqdm as tqdm_auto
+
+__author__ = {"github.com/padmalcom"}
+__all__ = ['tqdm_mytqdm', 'mytqdmrange', 'tqdm', 'trange']
+
+class tqdm_mytqdm(tqdm_auto):
+    """
+    Standard `tqdm.auto.tqdm` but also sends updates to a mytqdm.app.
+
+    - enter your email adress on https://mytqdm.app to receive an api key.
+    - put this private api key into the call below.
+    - enter an optional title and use the link from the mail to open a
+    widget or use the rest api to query your progress.
+    >>> from tqdm.contrib.mytqdm import tqdm, trange
+    >>> for i in tqdm(iterable, api_key='{api_key}', title='{title}'):
+    ...     ...
+    """
+    
+    PROGRESS_URL = "https://mytqdm.app/api/v1/p"
+    
+    def __init__(self, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        api_key  : str, required. mytqdm api key
+            [default: ${MYTQDM_API_KEY}].
+        title  : str, optional. A title to be displayed in the widget
+            [default: ${MYTQDM_TITLE}].
+
+        See `tqdm.auto.tqdm.__init__` for other parameters.
+        """
+        if not kwargs.get('disable'):
+            kwargs = kwargs.copy()
+            self.api_key = kwargs.pop('api_key', getenv("MYTQDM_API_KEY"))
+            self.title = kwargs.pop('title', getenv("MYTQDM_TITLE"))
+        super().__init__(*args, **kwargs)
+        
+    def display(self, **kwargs):
+        super().display(**kwargs)
+        current = self.n
+        total = self.total    
+        headers = {
+            "Authorization": f"X-API-Key {self.api_key}",
+            "Accept": "application/json",
+        }
+        payload = {
+            "title": self.title,
+            "current": current,
+            "total": total,
+        }
+        try:
+            resp = requests.post(self.PROGRESS_URL, json=payload, headers=headers, timeout=10)
+            if resp.ok:
+                logging.debug("mytqdm state successfully updated.")
+            else:
+                logging.warning(f"Got non-ok response from mytqdm {resp.status_code}")
+        except requests.exceptions.Timeout:
+            logging.error("The request to mytqdm.app timed out (connect or read).")
+        except requests.exceptions.RequestException as e:
+            logging.error(f"An error occured when updating mytqdm state: {e}")      
+
+def mytqdmrange(*args, **kwargs):
+    """Shortcut for `tqdm.contrib.mytqdm.tqdm(range(*args), **kwargs)`."""
+    return tqdm_mytqdm(range(*args), **kwargs)
+
+# Aliases
+tqdm = tqdm_mytqdm
+trange = mytqdmrange


### PR DESCRIPTION
I created https://mytqdm.app, a free, centralized platform to update my progresses and make them accessible via a simple widget or rest api. Mostly built for myself, the purpose was to show current data processing states during reviews or allow stakeholders to observe.

Simply provide an api that comes on request via mail (no registration required) and pass it to the tqdm alias of the new class. Send the widget link (from the mail) to everyone who should be able to see your progress.

This contribution replaces https://pypi.org/project/mytqdm/ which was a simple wrapper around tqdm.

Documentation can be found here https://mytqdm.app/docs