### PR TITLE
Fix console output bug in logging_redirect_tqdm

### DIFF
--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -87,9 +87,9 @@ def logging_redirect_tqdm(
             if orig_handler is not None:
                 tqdm_handler.setFormatter(orig_handler.formatter)
                 tqdm_handler.stream = orig_handler.stream
-            logger.handlers = [
-                handler for handler in logger.handlers
-                if not _is_console_logging_handler(handler)] + [tqdm_handler]
+                logger.handlers = [
+                    handler for handler in logger.handlers
+                    if not _is_console_logging_handler(handler)] + [tqdm_handler]
         yield
     finally:
         for logger, original_handlers in zip(loggers, original_handlers_list):


### PR DESCRIPTION
Fixes #1501

When using a logger that has no console-logging handlers, `logging_redirect_tqdm` adds its own console-logging handler anyway. The solution is to simply indent a few lines so that the existing handlers are not modified unless a console-logging handler is present.