### PR TITLE
Clarify supported Python versions in installation docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ Python and an environment supporting ``carriage return \r`` and
 
 Installation
 ------------
+tqdm officially supports Python 3.7 and above.
 
 Latest PyPI stable release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR improves the installation documentation by explicitly stating the
supported Python versions for tqdm.

### What was the issue?
The README and installation instructions did not clearly mention the
minimum Python version supported by tqdm. This could cause confusion for users on
older Python environments.

Related issue: https://github.com/tqdm/tqdm/issues/1675

### What was changed?
- Added a line in `README.rst` under the Installation section:
  > tqdm officially supports Python 3.7 and above.

### Why is this useful?
- Improves clarity for new users
- Aligns documentation with the `python_requires >=3.7` specified in `setup.cfg`
- Reduces compatibility-related questions from users

### Notes
This PR modifies documentation only and does not affect code behavior.
