### PR TITLE
fix: pass unit_divisor to format_sizeof when formatting rate

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -551,10 +551,10 @@ class tqdm(Comparable):
             rate = (n - initial) / elapsed
         inv_rate = 1 / rate if rate else None
         format_sizeof = tqdm.format_sizeof
-        rate_noinv_fmt = ((format_sizeof(rate) if unit_scale else f'{rate:5.2f}')
+        rate_noinv_fmt = ((format_sizeof(rate, divisor=unit_divisor) if unit_scale else f'{rate:5.2f}')
                           if rate else '?') + unit + '/s'
         rate_inv_fmt = (
-            (format_sizeof(inv_rate) if unit_scale else f'{inv_rate:5.2f}')
+            (format_sizeof(inv_rate, divisor=unit_divisor) if unit_scale else f'{inv_rate:5.2f}')
             if inv_rate else '?') + 's/' + unit
         rate_fmt = rate_inv_fmt if inv_rate and inv_rate > 1 else rate_noinv_fmt
 


### PR DESCRIPTION
## Summary
- When `unit_scale=True` and a custom `unit_divisor` is set (e.g., 1024 for binary units), `rate_fmt` and `rate_inv_fmt` were not respecting the `unit_divisor` value
- The `format_sizeof` calls for rate formatting were missing the `divisor=unit_divisor` parameter, causing them to always use the default divisor of 1000
- This made the rate display inconsistent with `n_fmt` and `total_fmt`, which correctly passed `unit_divisor`

Fixes #1690

## Test plan
- All 71 existing tests pass
- Verified that `format_meter(n=5000, total=10000, elapsed=10, unit='B', unit_scale=True, unit_divisor=1024, rate=2048)` now correctly shows `2.00kB/s` (using 1024 divisor) instead of the previous incorrect `2.05kB/s` (using 1000 divisor)