### PR TITLE
fix Poor time estimation for concurrent processing

### DIFF
--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -32,7 +32,7 @@ def _min_map_len(iterables):
 
 def _executor_map(
     PoolExecutor, fn, *iterables, max_workers=None, timeout=None, chunksize=1, lock_name="",
-    tqdm_class=tqdm_auto, **tqdm_kwargs
+    tqdm_class=tqdm_auto, smoothing=0.0, **tqdm_kwargs
 ):
     """
     Implementation of `thread_map` and `process_map`.
@@ -57,6 +57,7 @@ def _executor_map(
     for k in ('thread_name_prefix', 'max_tasks_per_child', 'mp_context'):
         if k in kwargs:
             pool_kwargs[k] = kwargs.pop(k)
+    dynamic_miniters = None
     if kwargs['total'] and 'miniters' not in kwargs:
         try:
             from os import process_cpu_count as cpu_count
@@ -66,11 +67,14 @@ def _executor_map(
         rough_max = max_workers or min(32, (cpu_count() or 1) + 4)
         if kwargs['total'] > rough_max:
             kwargs['miniters'] = rough_max
+            dynamic_miniters = True
     with ensure_lock(tqdm_class, lock_name=lock_name) as lk:
         # share lock in case workers are already using `tqdm`
         with PoolExecutor(max_workers=max_workers, initializer=tqdm_class.set_lock,
                           initargs=(lk,), **pool_kwargs) as ex:
-            with tqdm_class(**kwargs) as pbar:
+            with tqdm_class(smoothing=smoothing, **kwargs) as pbar:
+                if dynamic_miniters is not None:
+                    pbar.dynamic_miniters = True
                 orisubmit = ex.submit
 
                 def patchsubmit(*args, **kwargs):
@@ -100,6 +104,8 @@ def thread_map(fn, *iterables, **tqdm_kwargs):
         Requires Python>=3.14 [default: None].
     tqdm_class  : optional
         `tqdm` class to use for bars [default: tqdm.auto.tqdm].
+    smoothing  : float, optional
+        Passed to `tqdm_class`; the [default: 0] is average (due to erratic update frequency).
     lock_name  : str, optional
         Member of `tqdm_class.get_lock()` to use [default: mp_lock].
     """
@@ -133,6 +139,8 @@ def process_map(fn, *iterables, lock_name="mp_lock", **tqdm_kwargs):
         Member of `tqdm_class.get_lock()` to use [default: mp_lock].
     tqdm_class  : optional
         `tqdm` class to use for bars [default: tqdm.auto.tqdm].
+    smoothing  : float, optional
+        Passed to `tqdm_class`; the [default: 0] is average (due to erratic update frequency).
     """
     from concurrent.futures import ProcessPoolExecutor
     if iterables and 'chunksize' not in tqdm_kwargs:

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -57,6 +57,14 @@ def _executor_map(
     for k in ('thread_name_prefix', 'max_tasks_per_child', 'mp_context'):
         if k in kwargs:
             pool_kwargs[k] = kwargs.pop(k)
+    if (
+        "miniters" not in kwargs
+        and "maxinterval" not in kwargs
+        and "mininterval" not in kwargs
+    ):  # Auto set miniters for better progress bar for parallel processes
+        total = kwargs["total"]
+        if total and total > max_workers:
+            kwargs["miniters"] = max_workers
     with ensure_lock(tqdm_class, lock_name=lock_name) as lk:
         # share lock in case workers are already using `tqdm`
         with PoolExecutor(max_workers=max_workers, initializer=tqdm_class.set_lock,

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -57,14 +57,15 @@ def _executor_map(
     for k in ('thread_name_prefix', 'max_tasks_per_child', 'mp_context'):
         if k in kwargs:
             pool_kwargs[k] = kwargs.pop(k)
-    if (
-        "miniters" not in kwargs
-        and "maxinterval" not in kwargs
-        and "mininterval" not in kwargs
-    ):  # Auto set miniters for better progress bar for parallel processes
-        total = kwargs["total"]
-        if total and total > max_workers:
-            kwargs["miniters"] = max_workers
+    if kwargs['total'] and 'miniters' not in kwargs:
+        try:
+            from os import process_cpu_count as cpu_count
+        except ImportError:
+            from os import cpu_count
+        # thread & process pools have different default workers, but we KISS here
+        rough_max = max_workers or min(32, (cpu_count() or 1) + 4)
+        if kwargs['total'] > rough_max:
+            kwargs['miniters'] = rough_max
     with ensure_lock(tqdm_class, lock_name=lock_name) as lk:
         # share lock in case workers are already using `tqdm`
         with PoolExecutor(max_workers=max_workers, initializer=tqdm_class.set_lock,


### PR DESCRIPTION
Fixes #1161 and linting error
by setting the miniters to max_workers if provided and constraints like {maxinterval,mininterval,miniters} are not provided.

Moreover

linting error:
cpu_core() might return none so linter was giving error:::  "Operator "+" not supported for None"
max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))

so it was replaced by 

max_workers = kwargs.pop("max_workers", min(32, (cpu_count() or 1) + 4))
