### PR TITLE
Defer `tqdm.auto` imports in callbacks and contrib helpers

### DIFF
--- a/tqdm/contrib/__init__.py
+++ b/tqdm/contrib/__init__.py
@@ -5,7 +5,6 @@ Subpackages contain potentially unstable extensions.
 """
 from warnings import warn
 
-from ..auto import tqdm as tqdm_auto
 from ..std import TqdmDeprecationWarning, tqdm
 from ..utils import ObjectWrapper
 
@@ -47,7 +46,7 @@ def builtin_iterable(func):
     return func
 
 
-def tenumerate(iterable, start=0, total=None, tqdm_class=tqdm_auto, **tqdm_kwargs):
+def tenumerate(iterable, start=0, total=None, tqdm_class=None, **tqdm_kwargs):
     """
     Equivalent of `numpy.ndenumerate` or builtin `enumerate`.
 
@@ -55,6 +54,8 @@ def tenumerate(iterable, start=0, total=None, tqdm_class=tqdm_auto, **tqdm_kwarg
     ----------
     tqdm_class  : [default: tqdm.auto.tqdm].
     """
+    if tqdm_class is None:
+        from ..auto import tqdm as tqdm_class
     try:
         import numpy as np
     except ImportError:
@@ -75,7 +76,9 @@ def tzip(iter1, *iter2plus, **tqdm_kwargs):
     tqdm_class  : [default: tqdm.auto.tqdm].
     """
     kwargs = tqdm_kwargs.copy()
-    tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
+    tqdm_class = kwargs.pop("tqdm_class", None)
+    if tqdm_class is None:
+        from ..auto import tqdm as tqdm_class
     yield from zip(tqdm_class(iter1, **kwargs), *iter2plus)
 
 

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from operator import length_hint
 from os import cpu_count
 
-from ..auto import tqdm as tqdm_auto
 from ..std import TqdmWarning
 
 __author__ = {"github.com/": ["casperdcl"]}
@@ -40,7 +39,9 @@ def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
     kwargs = tqdm_kwargs.copy()
     if "total" not in kwargs:
         kwargs["total"] = length_hint(iterables[0])
-    tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
+    tqdm_class = kwargs.pop("tqdm_class", None)
+    if tqdm_class is None:
+        from ..auto import tqdm as tqdm_class
     max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))
     chunksize = kwargs.pop("chunksize", 1)
     lock_name = kwargs.pop("lock_name", "")

--- a/tqdm/contrib/itertools.py
+++ b/tqdm/contrib/itertools.py
@@ -3,8 +3,6 @@ Thin wrappers around `itertools`.
 """
 import itertools
 
-from ..auto import tqdm as tqdm_auto
-
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['product']
 
@@ -18,7 +16,9 @@ def product(*iterables, **tqdm_kwargs):
     tqdm_class  : [default: tqdm.auto.tqdm].
     """
     kwargs = tqdm_kwargs.copy()
-    tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
+    tqdm_class = kwargs.pop("tqdm_class", None)
+    if tqdm_class is None:
+        from ..auto import tqdm as tqdm_class
     try:
         lens = list(map(len, iterables))
     except TypeError:

--- a/tqdm/contrib/itertools.py
+++ b/tqdm/contrib/itertools.py
@@ -4,15 +4,15 @@ Thin wrappers around `itertools`.
 import itertools
 import math
 
-from ..auto import tqdm as tqdm_auto
-
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = [
     'chain', 'product', 'permutations', 'combinations', 'combinations_with_replacement', 'batched']
 
 
-def chain(*iterables, total=None, tqdm_class=tqdm_auto, **kwargs):
+def chain(*iterables, total=None, tqdm_class=None, **kwargs):
     """Equivalent of `itertools.chain`."""
+    if tqdm_class is None:
+        from ..auto import tqdm as tqdm_class
     if total is None:
         try:
             total = sum(map(len, iterables))
@@ -21,8 +21,10 @@ def chain(*iterables, total=None, tqdm_class=tqdm_auto, **kwargs):
     return tqdm_class(itertools.chain(*iterables), total=total, **kwargs)
 
 
-def product(*iterables, repeat=1, total=None, tqdm_class=tqdm_auto, **kwargs):
+def product(*iterables, repeat=1, total=None, tqdm_class=None, **kwargs):
     """Equivalent of `itertools.product`."""
+    if tqdm_class is None:
+        from ..auto import tqdm as tqdm_class
     if total is None:
         try:
             lens = list(map(len, iterables))
@@ -33,8 +35,10 @@ def product(*iterables, repeat=1, total=None, tqdm_class=tqdm_auto, **kwargs):
     yield from tqdm_class(itertools.product(*iterables, repeat=repeat), total=total, **kwargs)
 
 
-def permutations(iterable, r=None, total=None, tqdm_class=tqdm_auto, **kwargs):
+def permutations(iterable, r=None, total=None, tqdm_class=None, **kwargs):
     """Equivalent of `itertools.permutations`."""
+    if tqdm_class is None:
+        from ..auto import tqdm as tqdm_class
     if total is None:
         try:
             n = len(iterable)
@@ -49,8 +53,10 @@ def permutations(iterable, r=None, total=None, tqdm_class=tqdm_auto, **kwargs):
     return tqdm_class(itertools.permutations(iterable, r), total=total, **kwargs)
 
 
-def combinations(iterable, r, total=None, tqdm_class=tqdm_auto, **kwargs):
+def combinations(iterable, r, total=None, tqdm_class=None, **kwargs):
     """Equivalent of `itertools.combinations`."""
+    if tqdm_class is None:
+        from ..auto import tqdm as tqdm_class
     if total is None:
         try:
             n = len(iterable)
@@ -64,8 +70,10 @@ def combinations(iterable, r, total=None, tqdm_class=tqdm_auto, **kwargs):
     return tqdm_class(itertools.combinations(iterable, r), total=total, **kwargs)
 
 
-def combinations_with_replacement(iterable, r, total=None, tqdm_class=tqdm_auto, **kwargs):
+def combinations_with_replacement(iterable, r, total=None, tqdm_class=None, **kwargs):
     """Equivalent of `itertools.combinations_with_replacement`."""
+    if tqdm_class is None:
+        from ..auto import tqdm as tqdm_class
     if total is None:
         try:
             n = len(iterable)
@@ -80,8 +88,10 @@ def combinations_with_replacement(iterable, r, total=None, tqdm_class=tqdm_auto,
     return tqdm_class(itertools.combinations_with_replacement(iterable, r), total=total, **kwargs)
 
 
-def batched(iterable, n, total=None, tqdm_class=tqdm_auto, **kwargs):
+def batched(iterable, n, total=None, tqdm_class=None, **kwargs):
     """Equivalent of `itertools.batched`."""
+    if tqdm_class is None:
+        from ..auto import tqdm as tqdm_class
     if total is None:
         try:
             total = len(iterable)

--- a/tqdm/dask.py
+++ b/tqdm/dask.py
@@ -2,15 +2,13 @@ from functools import partial
 
 from dask.callbacks import Callback
 
-from .auto import tqdm as tqdm_auto
-
 __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['TqdmCallback']
 
 
 class TqdmCallback(Callback):
     """Dask callback for task progress."""
-    def __init__(self, start=None, pretask=None, tqdm_class=tqdm_auto,
+    def __init__(self, start=None, pretask=None, tqdm_class=None,
                  **tqdm_kwargs):
         """
         Parameters
@@ -21,6 +19,8 @@ class TqdmCallback(Callback):
             Any other arguments used for all bars.
         """
         super().__init__(start=start, pretask=pretask)
+        if tqdm_class is None:
+            from .auto import tqdm as tqdm_class
         if tqdm_kwargs:
             tqdm_class = partial(tqdm_class, **tqdm_kwargs)
         self.tqdm_class = tqdm_class

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -1,8 +1,6 @@
 from copy import copy
 from functools import partial
 
-from .auto import tqdm as tqdm_auto
-
 try:
     import keras
 except (ImportError, AttributeError) as e:
@@ -30,7 +28,7 @@ class TqdmCallback(keras.callbacks.Callback):
         return callback
 
     def __init__(self, epochs=None, data_size=None, batch_size=None, verbose=1,
-                 tqdm_class=tqdm_auto, **tqdm_kwargs):
+                 tqdm_class=None, **tqdm_kwargs):
         """
         Parameters
         ----------
@@ -48,6 +46,8 @@ class TqdmCallback(keras.callbacks.Callback):
         tqdm_kwargs  : optional
             Any other arguments used for all bars.
         """
+        if tqdm_class is None:
+            from .auto import tqdm as tqdm_class
         if tqdm_kwargs:
             tqdm_class = partial(tqdm_class, **tqdm_kwargs)
         self.tqdm_class = tqdm_class

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -1,8 +1,6 @@
 from copy import copy
 from functools import partial
 
-from .auto import tqdm as tqdm_auto
-
 try:
     import keras
 except (ImportError, AttributeError) as e:
@@ -31,7 +29,7 @@ class TqdmCallback(keras.callbacks.Callback):
         return callback
 
     def __init__(self, epochs=None, data_size=None, batch_size=None, verbose=1,
-                 tqdm_class=tqdm_auto, **tqdm_kwargs):
+                 tqdm_class=None, **tqdm_kwargs):
         """
         Parameters
         ----------
@@ -49,6 +47,8 @@ class TqdmCallback(keras.callbacks.Callback):
         tqdm_kwargs  : optional
             Any other arguments used for all bars.
         """
+        if tqdm_class is None:
+            from .auto import tqdm as tqdm_class
         if tqdm_kwargs:
             tqdm_class = partial(tqdm_class, **tqdm_kwargs)
         self.tqdm_class = tqdm_class


### PR DESCRIPTION
Many modules import `tqdm.auto` automatically even when callers supply their own `tqdm_class`, which can be expensive in some use cases.

This PR defers `tqdm.auto` imports until runtime in places where it is only needed as a default `tqdm_class`.