### PR TITLE
Fix __reversed__ to actually iterate in reverse order

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1943,8 +1943,7 @@ def test_closed():
 
 def test_reversed(capsys):
     """Test reversed()"""
-    for _ in reversed(tqdm(range(9))):
-        pass
+    assert list(reversed(tqdm(range(9)))) == list(reversed(range(9)))
     out, err = capsys.readouterr()
     assert not out
     assert '  0%' in err

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1124,9 +1124,11 @@ class tqdm(Comparable):
             raise TypeError("'tqdm' object is not reversible")
         else:
             self.iterable = reversed(self.iterable)
-            return self.__iter__()
-        finally:
-            self.iterable = orig
+            try:
+                for obj in self.__iter__():
+                    yield obj
+            finally:
+                self.iterable = orig
 
     def __contains__(self, item):
         contains = getattr(self.iterable, '__contains__', None)

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1130,11 +1130,9 @@ class tqdm(Comparable):
             raise TypeError("'tqdm' object is not reversible")
         else:
             self.iterable = reversed(self.iterable)
-            try:
-                for obj in self.__iter__():
-                    yield obj
-            finally:
-                self.iterable = orig
+            yield from self.__iter__()
+        finally:
+            self.iterable = orig
 
     def __contains__(self, item):
         contains = getattr(self.iterable, '__contains__', None)

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1130,9 +1130,11 @@ class tqdm(Comparable):
             raise TypeError("'tqdm' object is not reversible")
         else:
             self.iterable = reversed(self.iterable)
-            return self.__iter__()
-        finally:
-            self.iterable = orig
+            try:
+                for obj in self.__iter__():
+                    yield obj
+            finally:
+                self.iterable = orig
 
     def __contains__(self, item):
         contains = getattr(self.iterable, '__contains__', None)


### PR DESCRIPTION
## Problem

`__reversed__` never actually iterates in reverse. The `finally` block restores `self.iterable` before the generator created by `__iter__()` starts running.

The issue is that `__iter__` is a generator function — `return self.__iter__()` creates a generator object but doesn't execute its body. Python's `finally` block runs immediately after the `return`, restoring `self.iterable = orig`. When the caller later iterates the returned generator, `__iter__` reads the already-restored original (forward) iterable.

```python
>>> list(reversed(tqdm([1, 2, 3])))
[1, 2, 3]   # should be [3, 2, 1]
```

## Fix

Make `__reversed__` itself a generator function that delegates to `__iter__` via `yield from`, so the `finally` clause only runs after the generator is exhausted or garbage-collected.
