### PR TITLE
Fix ZeroDivisionError in gui.py display()

### DIFF
--- a/tqdm/gui.py
+++ b/tqdm/gui.py
@@ -124,9 +124,9 @@ class tqdm_gui(std_tqdm):  # pragma: no cover
         line2 = self.line2
         hspan = getattr(self, 'hspan', None)
         # instantaneous rate
-        y = delta_it / delta_t
+        y = delta_it / delta_t if delta_t else 0
         # overall rate
-        z = n / elapsed
+        z = n / elapsed if elapsed else 0
         # update line data
         xdata.append(n * 100.0 / total if total else cur_t)
         ydata.append(y)


### PR DESCRIPTION
## Problem

`gui.py`'s `display()` can crash with `ZeroDivisionError` on the rate calculations:

```python
y = delta_it / delta_t   # delta_t can be 0
z = n / elapsed           # elapsed can be 0
```

`delta_t` is zero on the first display call (where `cur_t == last_print_t`) or when `display()` fires twice in quick succession. `elapsed` is zero when `display()` runs at the exact start time.

The parent `tqdm` class handles this in `format_meter`, but `gui.py` does its own direct arithmetic without zero-guards.

## Fix

Guard both divisions against zero: return 0 when the denominator is 0.
