### PR TITLE
Fix notebook widget progress bar with numeric unit_scale

### DIFF
--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -154,7 +154,8 @@ class tqdm_notebook(std_tqdm):
             msg = self.format_meter(**d)
 
         ltext, pbar, rtext = self.container.children
-        pbar.value = self.n
+        unit_scale = 1 if self.unit_scale is True else self.unit_scale or 1
+        pbar.value = self.n * unit_scale
 
         if msg:
             msg = msg.replace(' ', '\u2007')  # fix html space padding


### PR DESCRIPTION
## Problem

When `unit_scale` is a numeric value (e.g. `1024`), the notebook widget's `max` is set to `total * unit_scale` during `__init__`:

```python
unit_scale = 1 if self.unit_scale is True else self.unit_scale or 1
total = self.total * unit_scale if self.total else self.total
self.container = self.status_printer(self.fp, total, ...)
```

But `display()` always sets `pbar.value = self.n` (the raw, unscaled counter). The progress bar widget never visually reaches completion because the value is orders of magnitude smaller than its max.

For example with `tqdm(total=1000, unit_scale=1024)`:
- Widget max = 1,024,000
- At completion: `pbar.value = 1000` → shows ~0.1%

## Fix

Apply the same `unit_scale` scaling to `pbar.value` in `display()`.
