### PR TITLE
Support async iterables with only __aiter__ in tqdm_asyncio

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,9 @@
+Support async iterables with only __aiter__ in tqdm_asyncio
+
+tqdm_asyncio only checked for __anext__ (async iterator) and __next__
+(sync iterator), but did not handle objects that only implement
+__aiter__ (async iterable). Such objects would fall through to the
+sync iter() call and fail.
+
+Added a check for __aiter__ between the __anext__ and __next__ checks,
+calling __aiter__() to get the async iterator and using its __anext__.

--- a/tests/tests_asyncio.py
+++ b/tests/tests_asyncio.py
@@ -131,3 +131,38 @@ async def test_gather(capsys):
     _, err = capsys.readouterr()
     assert '30/30' in err
     assert res == list(range(0, 30 * 2, 2))
+
+
+class AsyncIterable:
+    """An async iterable that only has __aiter__ (no __anext__)."""
+    def __init__(self, items):
+        self._items = items
+
+    def __aiter__(self):
+        return AsyncIterableIterator(self._items)
+
+
+class AsyncIterableIterator:
+    def __init__(self, items):
+        self._items = iter(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._items)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+@mark.asyncio
+async def test_async_iterable():
+    """Test asyncio with async iterable (only __aiter__, no __anext__)"""
+    with closing(StringIO()) as our_file:
+        result = []
+        async for i in tqdm(AsyncIterable(range(9)), total=9,
+                            desc="aiterable", file=our_file):
+            result.append(i)
+        assert result == list(range(9))
+        assert '9/9' in our_file.getvalue()

--- a/tests/tests_asyncio.py
+++ b/tests/tests_asyncio.py
@@ -148,3 +148,38 @@ async def test_gather_exceptions(capsys):
     assert isinstance(res[1], ValueError)
     assert res[0] == 0
     assert res[2] == 4
+
+
+class AsyncIterable:
+    """An async iterable that only has __aiter__ (no __anext__)."""
+    def __init__(self, items):
+        self._items = items
+
+    def __aiter__(self):
+        return AsyncIterableIterator(self._items)
+
+
+class AsyncIterableIterator:
+    def __init__(self, items):
+        self._items = iter(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._items)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+@mark.asyncio
+async def test_async_iterable():
+    """Test asyncio with async iterable (only __aiter__, no __anext__)"""
+    with closing(StringIO()) as our_file:
+        result = []
+        async for i in tqdm(AsyncIterable(range(9)), total=9,
+                            desc="aiterable", file=our_file):
+            result.append(i)
+        assert result == list(range(9))
+        assert '9/9' in our_file.getvalue()

--- a/tests/tests_asyncio.py
+++ b/tests/tests_asyncio.py
@@ -150,16 +150,16 @@ async def test_gather_exceptions(capsys):
     assert res[2] == 4
 
 
-class AsyncIterable:
-    """An async iterable that only has __aiter__ (no __anext__)."""
+class AIterable:
+    """Has `__aiter__` but not `__anext__`"""
     def __init__(self, items):
         self._items = items
 
     def __aiter__(self):
-        return AsyncIterableIterator(self._items)
+        return AIterator(self._items)
 
 
-class AsyncIterableIterator:
+class AIterator:
     def __init__(self, items):
         self._items = iter(items)
 
@@ -174,12 +174,11 @@ class AsyncIterableIterator:
 
 
 @mark.asyncio
-async def test_async_iterable():
+async def test_async_iterable(capsys):
     """Test asyncio with async iterable (only __aiter__, no __anext__)"""
-    with closing(StringIO()) as our_file:
-        result = []
-        async for i in tqdm(AsyncIterable(range(9)), total=9,
-                            desc="aiterable", file=our_file):
-            result.append(i)
-        assert result == list(range(9))
-        assert '9/9' in our_file.getvalue()
+    result = []
+    async for i in tqdm(AIterable(range(9)), desc="aiterable"):
+        result.append(i)
+    assert result == list(range(9))
+    _, err = capsys.readouterr()
+    assert '9it' in err

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -27,6 +27,10 @@ class tqdm_asyncio(std_tqdm):
             if hasattr(iterable, "__anext__"):
                 self.iterable_next = iterable.__anext__
                 self.iterable_awaitable = True
+            elif hasattr(iterable, "__aiter__"):
+                self.iterable_iterator = iterable.__aiter__()
+                self.iterable_next = self.iterable_iterator.__anext__
+                self.iterable_awaitable = True
             elif hasattr(iterable, "__next__"):
                 self.iterable_next = iterable.__next__
             else:


### PR DESCRIPTION
Fixes #1686.

`tqdm_asyncio.__init__` checks for `__anext__` (async iterator protocol) and `__next__` (sync iterator), but doesn't handle objects that only have `__aiter__` without `__anext__` (async iterable protocol). These objects (like `aiomultiprocess.PoolResult`) fall through to `iter()` which doesn't work on async-only iterables.

Added a check for `__aiter__` between the existing `__anext__` and `__next__` checks. When an object only has `__aiter__`, we call `__aiter__()` to get the actual async iterator, then use its `__anext__` method. This follows the same pattern as the existing `else` branch that calls `iter()` for sync iterables that only have `__iter__`.

Added a test with a custom async iterable class that only provides `__aiter__`.
