### PR TITLE
Take into account `unit_divisor` for rate calculation

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -551,10 +551,11 @@ class tqdm(Comparable):
             rate = (n - initial) / elapsed
         inv_rate = 1 / rate if rate else None
         format_sizeof = tqdm.format_sizeof
-        rate_noinv_fmt = ((format_sizeof(rate) if unit_scale else f'{rate:5.2f}')
-                          if rate else '?') + unit + '/s'
+        rate_noinv_fmt = (
+            (format_sizeof(rate, divisor=unit_divisor) if unit_scale else f'{rate:5.2f}')
+            if rate else '?') + unit + '/s'
         rate_inv_fmt = (
-            (format_sizeof(inv_rate) if unit_scale else f'{inv_rate:5.2f}')
+            (format_sizeof(inv_rate, divisor=unit_divisor) if unit_scale else f'{inv_rate:5.2f}')
             if inv_rate else '?') + 's/' + unit
         rate_fmt = rate_inv_fmt if inv_rate and inv_rate > 1 else rate_noinv_fmt
 


### PR DESCRIPTION
Normally this issue would only result in a barely-noticeable error in rate calculation, but I have patched `tqdm.format_sizeof` so that `divisor == 1024` results in binary SI units being used (MiB/s, etc). Because of the inconsistent treatment of `divisor` this would otherwise result in a confusing mixed display of `4.62Mi/16.0Mi [00:03<00:08, 1.35MB/s]`.

The patch to `tqdm.format_sizeof` isn't included in this PR because I'm not sure what best to do it; since the `format_sizeof(suffix=)` argument isn't used in the codebase at all, and seems like it could *only* be used to implement the binary SI units, I would remove it entirely and instead pick suffix (really it's more of an infix) based on `divisor`; but if it is desired to keep it because of API stability concerns then I'm happy to do a different implementation.