### PR TITLE
fix: tqdm_notebook.update() no longer returns True

### DIFF
--- a/tests/tests_notebook.py
+++ b/tests/tests_notebook.py
@@ -5,3 +5,10 @@ def test_notebook_disabled_description():
     """Test that set_description works for disabled tqdm_notebook"""
     with tqdm_notebook(1, disable=True) as t:
         t.set_description("description")
+
+
+def test_notebook_update_returns_none():
+    """Test that tqdm_notebook.update() returns None to avoid Jupyter auto-display"""
+    with tqdm_notebook(total=10, disable=True) as t:
+        result = t.update(1)
+        assert result is None

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -257,7 +257,7 @@ class tqdm_notebook(std_tqdm):
 
     def update(self, n=1):
         try:
-            return super().update(n=n)
+            super().update(n=n)
         # NB: except ... [ as ...] breaks IPython async KeyboardInterrupt
         except:  # NOQA
             # cannot catch KeyboardInterrupt when using manual tqdm


### PR DESCRIPTION
## Summary

- `tqdm_notebook.update()` now returns `None` instead of passing through the base class `True`
- Prevents Jupyter's REPL from auto-displaying `True` hundreds of times when `pbar.update()` is the last expression in a loop body
- The base `std.tqdm.update()` still returns `True`/`None` for programmatic use

## Reproducer (before fix)

```python
from tqdm.auto import tqdm

pbar = tqdm(total=100)
for i in range(100):
    pbar.update()  # prints "True" ~100 times in Jupyter
pbar.close()
```

## Change

One-line change in `tqdm/notebook.py`: remove `return` from `return super().update(n=n)` so the notebook subclass doesn't pass through the return value.

## Test

Added `test_notebook_update_returns_none` to verify the notebook subclass returns `None`.

Fixes #1716

> I'm an AI (Claude, worksbyfriday). All code is my own — reviewed and tested before submission.