### PR TITLE
Add flush argument to tqdm.write

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -6,6 +6,7 @@ import re
 import sys
 from contextlib import contextmanager
 from functools import wraps
+from unittest.mock import MagicMock, call
 from warnings import catch_warnings, simplefilter
 
 from pytest import importorskip, mark, raises, skip
@@ -1555,6 +1556,19 @@ def test_write():
     # Restore stdout and stderr
     sys.stderr = stde
     sys.stdout = stdo
+
+
+def test_write_flush():
+    """Test that tqdm.write flush argument flushes the stream"""
+    # flush=True: content written then fp.flush() called (order matters)
+    mock_file = MagicMock()
+    tqdm.write("hello", file=mock_file, flush=True)
+    assert mock_file.mock_calls == [
+        call.write("hello"), call.write("\n"), call.flush()]
+    # default (no flush arg): fp.flush() must NOT be called
+    mock_file2 = MagicMock()
+    tqdm.write("hello", file=mock_file2)
+    mock_file2.flush.assert_not_called()
 
 
 def test_len():

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -714,13 +714,15 @@ class tqdm(Comparable):
                     inst.pos = abs(instance.pos)
 
     @classmethod
-    def write(cls, s, file=None, end="\n", nolock=False):
+    def write(cls, s, file=None, end="\n", nolock=False, flush=False):
         """Print a message via tqdm (without overlap with bars)."""
         fp = file if file is not None else sys.stdout
         with cls.external_write_mode(file=file, nolock=nolock):
             # Write the message
             fp.write(s)
             fp.write(end)
+            if flush:
+                fp.flush()
 
     @classmethod
     @contextmanager


### PR DESCRIPTION
Closes #1651

## Summary

Adds a `flush=False` keyword argument to `tqdm.write()` to match the
signature of Python's built-in `print(flush=True)`.

When `flush=True`, `fp.flush()` is called after writing.

## Changes

- `tqdm/std.py` — `flush=False` added to `write()` signature; `fp.flush()` called when `True`
- `tests/tests_tqdm.py` — `test_write_flush()` added

## Test plan

- `test_write_flush` passes
- 130 passed, 7 skipped (optional deps: numpy, dask, keras, rich, tkinter)