### PR TITLE
fix: truncate percentage to prevent premature 100% display

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -612,7 +612,13 @@ class tqdm(Comparable):
             frac = n / total
             percentage = frac * 100
 
-            l_bar += f'{percentage:3.0f}%|'
+            if n < total:
+                # Use int() to truncate rather than round, preventing
+                # the percentage from displaying 100% before completion
+                # (e.g. 99.76% would round to 100% with :3.0f)
+                l_bar += f'{int(percentage):3d}%|'
+            else:
+                l_bar += f'{percentage:3.0f}%|'
 
             if ncols == 0:
                 return l_bar[:-1] + r_bar[1:]


### PR DESCRIPTION
## Summary

- Fixes the default progress bar percentage display showing `100%` before all iterations are actually complete (e.g. `100%|███████████████████▍| 5068/5080`)
- Uses `int()` truncation instead of `:3.0f` rounding for the percentage when `n < total`, so 99.76% displays as `99%` rather than rounding up to `100%`
- When `n >= total` (task truly complete), the original `:3.0f` formatting is preserved

Closes #1640

## Test plan

- [ ] Verify `format_meter(5068, 5080, ...)` shows `99%` instead of `100%`
- [ ] Verify `format_meter(100, 100, ...)` still shows `100%` when complete
- [ ] Verify `format_meter(0, 100, ...)` shows `0%`
- [ ] Verify `format_meter(50, 100, ...)` shows `50%`
- [ ] Verify `format_meter(999, 1000, ...)` shows `99%` (edge case near completion)
- [ ] Verify `ncols=0` path also shows truncated percentage
- [ ] Verify custom `bar_format` with `{percentage}` still receives the raw float value for user formatting flexibility