### PR TITLE
docs(contrib): expand docstrings for DummyTqdmFile and tzip/tmap/tenumerate

### DIFF
--- a/tqdm/contrib/__init__.py
+++ b/tqdm/contrib/__init__.py
@@ -17,10 +17,26 @@ class DummyTqdmFile(ObjectWrapper):
     """Dummy file-like that will write to tqdm"""
 
     def __init__(self, wrapped):
+        """
+        Parameters
+        ----------
+        wrapped  : file-like
+            Underlying file object to write to via `tqdm.write()`.
+        """
         super().__init__(wrapped)
         self._buf = []
 
     def write(self, x, nolock=False):
+        """
+        Buffer and flush `x` to `tqdm.write()` on each newline.
+
+        Parameters
+        ----------
+        x  : str or bytes
+            Data to write.
+        nolock  : bool, optional
+            If (default: False), do not acquire the tqdm lock.
+        """
         nl = b"\n" if isinstance(x, bytes) else "\n"
         pre, sep, post = x.rpartition(nl)
         if sep:
@@ -32,6 +48,7 @@ class DummyTqdmFile(ObjectWrapper):
             self._buf.append(x)
 
     def __del__(self):
+        """Flush any remaining buffered data via `tqdm.write()`."""
         if self._buf:
             blank = type(self._buf[0])()
             try:
@@ -53,7 +70,15 @@ def tenumerate(iterable, start=0, total=None, tqdm_class=tqdm_auto, **tqdm_kwarg
 
     Parameters
     ----------
-    tqdm_class  : [default: tqdm.auto.tqdm].
+    iterable  : iterable or numpy.ndarray
+        Object to enumerate. `numpy.ndenumerate` is used when possible.
+    start  : int, optional
+        Starting index for builtin `enumerate` [default: 0].
+    total  : int, optional
+        Hint for the total number of iterations passed to `tqdm_class`.
+    tqdm_class  : optional
+        `tqdm` class used for the progress bar [default: tqdm.auto.tqdm].
+    **tqdm_kwargs  : passed to `tqdm_class`.
     """
     try:
         import numpy as np
@@ -72,7 +97,13 @@ def tzip(iter1, *iter2plus, **tqdm_kwargs):
 
     Parameters
     ----------
-    tqdm_class  : [default: tqdm.auto.tqdm].
+    iter1  : iterable
+        First iterable; the progress bar tracks this one.
+    *iter2plus  : iterable
+        Additional iterables zipped alongside `iter1` (untracked).
+    tqdm_class  : optional
+        `tqdm` class used for the progress bar [default: tqdm.auto.tqdm].
+    **tqdm_kwargs  : passed to `tqdm_class`.
     """
     kwargs = tqdm_kwargs.copy()
     tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
@@ -85,7 +116,13 @@ def tmap(function, *sequences, **tqdm_kwargs):
 
     Parameters
     ----------
-    tqdm_class  : [default: tqdm.auto.tqdm].
+    function  : callable
+        Function to apply to each element.
+    *sequences  : iterable
+        One or more iterables whose elements are passed to `function`.
+    tqdm_class  : optional
+        `tqdm` class used for the progress bar [default: tqdm.auto.tqdm].
+    **tqdm_kwargs  : passed to `tqdm_class` via `tzip`.
     """
     for i in tzip(*sequences, **tqdm_kwargs):
         yield function(*i)


### PR DESCRIPTION
## Summary

Expands documentation in `tqdm/contrib/__init__.py` — no logic changes.

- Add `Parameters` docstrings to `DummyTqdmFile.__init__` and `.write()`, and a one-line docstring to `.__del__()`
- Expand the sparse `Parameters` sections of `tenumerate`, `tzip`, and `tmap` to document all positional arguments (`iterable`, `start`, `total`, `iter1`, `*iter2plus`, `function`, `*sequences`) alongside the existing `tqdm_class` entry
- All docstring lines stay within the 76-character limit specified in CONTRIBUTING.md
- Docstring style matches the NumPy-style conventions used throughout the codebase (`VAR  : TYPE[, optional]`, `[default: ...]`)