### PR TITLE
docs: fix redundant word typo in tests_synchronisation.py

### DIFF
--- a/tests/tests_synchronisation.py
+++ b/tests/tests_synchronisation.py
@@ -8,7 +8,7 @@ from .tests_tqdm import StringIO, closing, importorskip, patch_lock, skip
 
 
 class Time:
-    """Fake time class class providing an offset"""
+    """Fake time class providing an offset"""
     offset = 0
 
     @classmethod

--- a/tests/tests_synchronisation.py
+++ b/tests/tests_synchronisation.py
@@ -9,7 +9,7 @@ from .tests_tqdm import StringIO, closing, importorskip, patch_lock, skip
 
 
 class Time:
-    """Fake time class class providing an offset"""
+    """Fake time class providing an offset"""
     offset = 0
 
     @classmethod


### PR DESCRIPTION
Simple documentation cleanup in the test suite. Removed a repeated "class" word in the `Time` class docstring within `tests/tests_synchronisation.py`.