### PR TITLE
Fix TMonitor deadlock at interpreter shutdown

### DIFF
--- a/tests/tests_synchronisation.py
+++ b/tests/tests_synchronisation.py
@@ -210,18 +210,9 @@ def test_threadpool():
 
 def test_monitor_atexit_does_not_deadlock_on_stuck_get_lock():
     """Regression: atexit shutdown must not deadlock on stuck get_lock."""
-    # Scenario: another holder of the shared write lock (a forked child
-    # that died abnormally, a profiler-instrumented thread that hasn't
-    # released, etc.) prevents the monitor's
-    # ``with self.tqdm_cls.get_lock():`` block from acquiring the lock.
-    # The monitor thread is past its ``was_killed.wait()`` call, so simply
-    # setting ``was_killed`` does not unblock the lock acquire — only
-    # releasing the lock would. If interpreter shutdown then waits for the
-    # monitor thread to join (as the original ``atexit.register(self.exit)``
-    # did via ``self.join()``), the interpreter hangs forever.
-    # Capture the function TMonitor.__init__ passes to atexit.register
-    # without actually registering it (we don't want test residue at
-    # interpreter shutdown).
+    # Scenario: another lock holder (in a dead fork) blocks the monitor's
+    # `self.tqdm_cls.get_lock()`.
+    # The monitor thread's `was_killed.wait()` is insufficient to unblock.
     captured = []
     real_register = atexit.register
 
@@ -231,10 +222,12 @@ def test_monitor_atexit_does_not_deadlock_on_stuck_get_lock():
 
     monitor_in_acquire = Event()
 
-    # RLock wrapper that signals on the first non-setup-thread ``acquire``.
-    # Used to detect (via ``Event.wait``) that the monitor thread reached
-    # the blocking ``acquire`` call without sleeping/polling.
     class SignallingLock:
+        """
+        RLock wrapper signalling on first non-setup-thread ``acquire``.
+        Used to detect (via ``Event.wait``) that the monitor thread reached
+        the blocking ``acquire`` call without sleeping/polling.
+        """
         def __init__(self):
             self._inner = RLock()
             self._setup_thread = current_thread()

--- a/tests/tests_synchronisation.py
+++ b/tests/tests_synchronisation.py
@@ -1,5 +1,6 @@
+import atexit
 from functools import wraps
-from threading import Event
+from threading import Event, RLock, Thread, current_thread
 from time import sleep, time
 
 from tqdm import TMonitor, tqdm, trange
@@ -205,3 +206,92 @@ def test_threadpool():
     with ThreadPoolExecutor(8) as pool:
         res = list(tqdm(pool.map(incr_bar, range(100)), disable=True))
     assert sum(res) == sum(range(1, 101))
+
+
+def test_monitor_atexit_does_not_deadlock_on_stuck_get_lock():
+    """Regression: atexit shutdown must not deadlock on stuck get_lock."""
+    # Scenario: another holder of the shared write lock (a forked child
+    # that died abnormally, a profiler-instrumented thread that hasn't
+    # released, etc.) prevents the monitor's
+    # ``with self.tqdm_cls.get_lock():`` block from acquiring the lock.
+    # The monitor thread is past its ``was_killed.wait()`` call, so simply
+    # setting ``was_killed`` does not unblock the lock acquire — only
+    # releasing the lock would. If interpreter shutdown then waits for the
+    # monitor thread to join (as the original ``atexit.register(self.exit)``
+    # did via ``self.join()``), the interpreter hangs forever.
+    # Capture the function TMonitor.__init__ passes to atexit.register
+    # without actually registering it (we don't want test residue at
+    # interpreter shutdown).
+    captured = []
+    real_register = atexit.register
+
+    def capture(fn, *a, **k):
+        captured.append((fn, a, k))
+        return fn
+
+    monitor_in_acquire = Event()
+
+    # RLock wrapper that signals on the first non-setup-thread ``acquire``.
+    # Used to detect (via ``Event.wait``) that the monitor thread reached
+    # the blocking ``acquire`` call without sleeping/polling.
+    class SignallingLock:
+        def __init__(self):
+            self._inner = RLock()
+            self._setup_thread = current_thread()
+
+        def acquire(self, *a, **k):
+            if current_thread() is not self._setup_thread:
+                monitor_in_acquire.set()
+            return self._inner.acquire(*a, **k)
+
+        def release(self):
+            return self._inner.release()
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, *exc):
+            self.release()
+
+    blocking_lock = SignallingLock()
+    blocking_lock.acquire()  # held by setup thread; SignallingLock skips signal
+    monitor = None
+    try:
+        class StuckTqdm:
+            _instances = set()
+
+            @classmethod
+            def get_lock(cls):
+                return blocking_lock
+
+        atexit.register = capture
+        try:
+            monitor = TMonitor(StuckTqdm, 0.001)  # tiny sleep_interval
+        finally:
+            atexit.register = real_register
+
+        # Wait deterministically for the monitor thread to reach the
+        # blocking ``self.tqdm_cls.get_lock().acquire()`` call.
+        assert monitor_in_acquire.wait(timeout=2.0), (
+            "monitor did not reach tqdm_cls.get_lock().acquire() within 2s"
+        )
+        assert captured, "TMonitor.__init__ should have registered an atexit handler"
+
+        # Invoke the captured handler on a daemon helper thread so the
+        # test runner is not blocked if the assertion fails.
+        fn, args, kwargs = captured[0]
+        helper = Thread(target=fn, args=args, kwargs=kwargs, daemon=True)
+        helper.start()
+        helper.join(timeout=2.0)
+        assert not helper.is_alive(), (
+            "atexit handler did not return within 2s — it appears to be "
+            "joining a monitor thread blocked on tqdm_cls.get_lock(). "
+            "Daemon thread should not be joined from atexit."
+        )
+    finally:
+        # Release the blocking lock so the monitor thread can finish.
+        blocking_lock.release()
+        if monitor is not None:
+            monitor.was_killed.set()
+            monitor.join(timeout=2.0)

--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -35,20 +35,14 @@ class TMonitor(Thread):
         self.sleep_interval = sleep_interval
         self._time = self._test.get("time", time)
         self.was_killed = self._test.get("Event", Event)()
-        # Register a non-joining shutdown signal. Joining at interpreter exit
-        # can deadlock if the monitor thread is blocked acquiring
-        # tqdm_cls.get_lock() (the lock is composite; mp_lock can be left held
-        # by a forked child that died, or contended by another monitor under
-        # heavy instrumentation). The thread is daemon, so the interpreter
-        # reaps it on shutdown without needing a join.
         atexit.register(self._atexit_signal)
         self.start()
 
     def _atexit_signal(self):
         """
-        Shutdown signal for ``atexit``: set the kill event, no join.
-
-        See ``atexit.register(...)`` in ``__init__`` for the rationale.
+        Non-joining shutdown signal.
+        Avoids deadlocks at interpreter exit from other threads, dead forks, etc.
+        This daemon thread is auto-reaped on shutdown without needing a join.
         """
         self.was_killed.set()
 

--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -35,8 +35,22 @@ class TMonitor(Thread):
         self.sleep_interval = sleep_interval
         self._time = self._test.get("time", time)
         self.was_killed = self._test.get("Event", Event)()
-        atexit.register(self.exit)
+        # Register a non-joining shutdown signal. Joining at interpreter exit
+        # can deadlock if the monitor thread is blocked acquiring
+        # tqdm_cls.get_lock() (the lock is composite; mp_lock can be left held
+        # by a forked child that died, or contended by another monitor under
+        # heavy instrumentation). The thread is daemon, so the interpreter
+        # reaps it on shutdown without needing a join.
+        atexit.register(self._atexit_signal)
         self.start()
+
+    def _atexit_signal(self):
+        """
+        Shutdown signal for ``atexit``: set the kill event, no join.
+
+        See ``atexit.register(...)`` in ``__init__`` for the rationale.
+        """
+        self.was_killed.set()
 
     def exit(self):
         self.was_killed.set()


### PR DESCRIPTION
## Summary

`TMonitor.__init__` registers `self.exit` via `atexit`, and `exit` calls `self.join()` on the daemon monitor thread. If, at interpreter shutdown, the monitor thread is blocked inside

```python
with self.tqdm_cls.get_lock():
```

— for example because `mp_lock` (the multiprocessing component of `TqdmDefaultWriteLock`) was left held by a forked child that died abnormally, or contended by another monitor under heavy instrumentation — then setting `was_killed` does **not** unblock the acquire, and the join waits forever. The interpreter hangs.

## Reproducer (also added as a regression test)

Two monitor threads both blocked at `tqdm/std.py:117` (the `lock.acquire(*a, **k)` in `TqdmDefaultWriteLock.acquire`), each trying to take the same `RLock`; the main thread sits in `TMonitor.exit` → `self.join()`, waiting on one of those threads. `py-spy` excerpt from a hung interpreter:

```
Thread MainThread (idle):
    _wait_for_tstate_lock (threading.py:1169)
    join (threading.py:1149)
    exit (tqdm/_monitor.py:47)
Thread-3 (idle):
    acquire (tqdm/std.py:117)
    __enter__ (tqdm/std.py:124)
    run (tqdm/_monitor.py:69)
Thread-163 (idle):
    acquire (tqdm/std.py:117)
    __enter__ (tqdm/std.py:124)
    run (tqdm/_monitor.py:69)
```

I encountered this consistently when running tqdm's test suite under [RightTyper](https://github.com/RightTyper/RightTyper) instrumentation, which slows test execution enough to expose the race. The new test `test_monitor_atexit_does_not_deadlock_on_stuck_get_lock` reproduces it deterministically without needing instrumentation: it parks the lock from a setup thread, lets the monitor block on it, then asserts the captured atexit handler returns within 2s.

## Fix

Split the shutdown path:

- A new `_atexit_signal()` method (registered with `atexit`) only sets `was_killed` and returns. The thread is daemon, so the interpreter reaps it on shutdown without an explicit join — the join was always redundant for the atexit path.
- `exit()` (called explicitly from test teardown, where joining is desirable) is unchanged.

## Test plan

- [x] Added regression test that deterministically reproduces the deadlock with a signalling lock; verified it fails on master (2s timeout) and passes on the fix (~0.02s).
- [x] Full `pytest tests/` passes: 148 passed, 3 skipped (147 previously + the new test).
- [x] No public API changes; `exit()` semantics for the explicit test-teardown path are unchanged.