### PR TITLE
Fix set_description_str colon handling

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1307,6 +1307,7 @@ def test_set_description():
             assert t.desc == 'Hello'
             t.set_description_str('World')
             assert t.desc == 'World'
+            assert "World: " not in our_file.getvalue()
             t.set_description()
             assert t.desc == ''
             t.set_description('Bye')

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -64,6 +64,13 @@ class TqdmMonitorWarning(TqdmWarning, RuntimeWarning):
     pass
 
 
+class _TqdmPrefix(str):
+    def __new__(cls, value, sep=True):
+        prefix = str.__new__(cls, value)
+        prefix._tqdm_sep = sep
+        return prefix
+
+
 def TRLock(*args, **kwargs):
     """threading RLock"""
     try:
@@ -578,11 +585,14 @@ class tqdm(Comparable):
         except OverflowError:
             eta_dt = datetime.max
 
+        prefix_sep = getattr(prefix, '_tqdm_sep', True)
+
         # format the stats displayed to the left and right sides of the bar
         if prefix:
             # old prefix setup work around
             bool_prefix_colon_already = (prefix[-2:] == ": ")
-            l_bar = prefix if bool_prefix_colon_already else prefix + ": "
+            l_bar = (prefix if bool_prefix_colon_already or not prefix_sep
+                     else prefix + ": ")
         else:
             l_bar = ''
 
@@ -657,7 +667,7 @@ class tqdm(Comparable):
             return disp_trim(res, ncols) if ncols else res
         else:
             # no total: no progressbar, ETA, just progress stats
-            return (f'{(prefix + ": ") if prefix else ""}'
+            return (f'{(prefix + (": " if prefix_sep else "")) if prefix else ""}'
                     f'{n_fmt}{unit} [{elapsed_str}, {rate_fmt}{postfix}]')
 
     def __new__(cls, *_, **__):
@@ -1395,7 +1405,7 @@ class tqdm(Comparable):
 
     def set_description_str(self, desc=None, refresh=True):
         """Set/modify description without ': ' appended."""
-        self.desc = desc or ''
+        self.desc = _TqdmPrefix(desc or '', sep=False)
         if refresh:
             self.refresh()
 


### PR DESCRIPTION
Fixes #1616.

`set_description_str()` is documented as updating the description without appending `": "`. The default `format_meter()` path was adding the separator again when the prefix did not already end with `": "`.

This keeps the existing behavior for `desc="..."` and `set_description()`, while preserving separator-free output from `set_description_str()` through an internal marker. The public `format_dict` keys are unchanged.

Tests:
- `pytest tests/tests_tqdm.py -q`
- `pytest tests/tests_tk.py tests/tests_notebook.py -q`
- `pytest tests/tests_rich.py -q`
- `python -m py_compile tqdm/std.py tests/tests_tqdm.py`
- `git diff --check`
