### PR TITLE
next release v4.68.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 github: [casperdcl, tqdm]
 tidelift: pypi/tqdm
+thanks_dev: u/gh/tqdm
 custom: https://tqdm.github.io/merch

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,15 +10,12 @@ jobs:
     name: ${{ matrix.TOXENV }}
     strategy:
       matrix:
-        TOXENV:
-        - check
-        - perf
-    runs-on: ubuntu-latest
+        TOXENV: [check, perf]
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
+      with: {python-version: '3.x'}
     - run: pip install -U tox
     - run: tox
       env:
@@ -33,8 +30,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.GH_TOKEN || github.token }}
     - uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
+      with: {python-version: '3.x'}
     - name: Install
       run: |
         pip install -U wheel packaging
@@ -66,11 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
+      with: {fetch-depth: 0}
     - uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
+      with: {python-version: '3.x'}
     - name: Install
       run: |
         pip install -U wheel packaging

--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -5,7 +5,7 @@ on:
   pull_request_review_comment: {types: [created]}
 jobs:
   tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions: {contents: write, pull-requests: write, issues: write}
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,11 +1,10 @@
 name: Post Release
 on:
-  release:
-    types: [published]
+  release: {types: [published]}
   workflow_dispatch:
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - name: Checkout repo
       uses: actions/checkout@v6
@@ -21,8 +20,7 @@ jobs:
         path: docs
         token: ${{ secrets.GH_TOKEN }}
     - uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
+      with: {python-version: '3.x'}
     - name: Install
       run: |
         pip install -U wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,11 @@ on:
 jobs:
   check:
     if: github.event_name != 'pull_request' || !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
+      with: {python-version: '3.x'}
     - name: set PYSHA
       run: echo "PYSHA=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
     - uses: actions/cache@v5
@@ -93,8 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
+      with: {python-version: '3.x'}
     - name: Coveralls Finished
       run: |
         pip install -U coveralls
@@ -118,8 +116,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.GH_TOKEN || github.token }}
     - uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
+      with: {python-version: '3.x'}
     - name: Install
       run: |
         sudo apt-get install -yqq pandoc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,8 @@ jobs:
     continue-on-error: ${{ matrix.os == 'windows' }}
     strategy:
       matrix:
-        os: [ubuntu]
         python: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
+        os: [ubuntu]
         include:
         - {os: macos, python: 3.13}
         - {os: windows, python: 3.13}
@@ -66,8 +66,8 @@ jobs:
         if test "py${{ matrix.python }}" = py3.7; then
           sed -i /asyncio_default_fixture_loop_scope/d pyproject.toml
         fi
-        if test "py${{ matrix.python }}-${{ matrix.os }}" = py3.11-ubuntu; then
-          export TOXENV="py311-tf,py311-tf-keras"  # full
+        if test "py${{ matrix.python }}-${{ matrix.os }}" = py3.13-ubuntu; then
+          export TOXENV="py313-tf,py313-tf-keras"  # full
         fi
         if test "${{ matrix.os }}" != ubuntu; then
           tox -e py${PYVER/./}                     # basic
@@ -123,7 +123,7 @@ jobs:
         pip install -r .meta/requirements-build.txt
         make build .dockerignore Dockerfile snapcraft.yaml
     - id: dist
-      uses: casperdcl/deploy-pypi@v2
+      uses: casperdcl/deploy-pypi@v3
       with:
         gpg_key: ${{ secrets.GPG_KEY }}
         upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
@@ -158,7 +158,7 @@ jobs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_TOKEN }}
     - name: Docker build push
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}
         tags: ${{ steps.collect_assets.outputs.docker_tags }}
@@ -166,7 +166,7 @@ jobs:
         username: ${{ secrets.DOCKER_USR }}
         no_push: ${{ steps.collect_assets.outputs.docker_tags == '' }}
     - name: Docker push GitHub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}/tqdm
         tags: ${{ steps.collect_assets.outputs.docker_tags }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,36 +4,6 @@ on:
   pull_request:
   schedule: [{cron: '2 1 * * 6'}]  # M H d m w (Sat 1:02)
 jobs:
-  check:
-    if: github.event_name != 'pull_request' || !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association)
-    runs-on: ubuntu-slim
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
-      with: {python-version: '3.x'}
-    - name: set PYSHA
-      run: echo "PYSHA=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-    - uses: actions/cache@v5
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PYSHA }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - name: dependencies
-      run: pip install -U pre-commit
-    - uses: reviewdog/action-setup@v1
-    - if: github.event_name == 'push' || github.event_name == 'pull_request'
-      name: comment
-      run: |
-        if test "$EVENT" = pull_request; then
-          REPORTER=github-pr-review
-        else
-          REPORTER=github-check
-        fi
-        pre-commit run -a todo | reviewdog -efm="%f:%l: %m" -name=TODO -tee -reporter=$REPORTER -filter-mode nofilter
-        pre-commit run -a flake8 | reviewdog -f=pep8 -name=flake8 -tee -reporter=$REPORTER -filter-mode nofilter
-      env:
-        REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        EVENT: ${{ github.event_name }}
-    - run: pre-commit run -a --show-diff-on-failure
   test:
     if: github.event_name != 'pull_request' || !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association)
     name: py${{ matrix.python }}-${{ matrix.os }}
@@ -106,7 +76,7 @@ jobs:
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
   deploy:
-    needs: [check, test]
+    needs: test
     runs-on: ubuntu-latest
     environment: pypi
     permissions: {contents: write, id-token: write, packages: write}

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -353,7 +353,7 @@ Documentation
     class tqdm():
       """{DOC_tqdm}"""
 
-      @envwrap("TQDM_")  # override defaults via env vars
+      @envwrap("tqdm")  # override defaults via env vars
       def __init__(self, iterable=None, desc=None, total=None, leave=True,
                    file=None, ncols=None, mininterval=0.1,
                    maxinterval=10.0, miniters=None, ascii=None, disable=False,

--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -1238,7 +1238,7 @@ Citation information: |DOI|
 .. |Branch-Coverage-Status| image:: https://codecov.io/gh/tqdm/tqdm/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/tqdm/tqdm
 .. |Codacy-Grade| image:: https://app.codacy.com/project/badge/Grade/3f965571598f44549c7818f29cdcf177
-   :target: https://www.codacy.com/gh/tqdm/tqdm/dashboard
+   :target: https://app.codacy.com/gh/tqdm/tqdm/dashboard
 .. |CII Best Practices| image:: https://bestpractices.coreinfrastructure.org/projects/3264/badge
    :target: https://bestpractices.coreinfrastructure.org/projects/3264
 .. |GitHub-Status| image:: https://img.shields.io/github/tag/tqdm/tqdm.svg?maxAge=86400&logo=github&logoColor=white

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,11 +56,11 @@ repos:
   - id: pyupgrade
     args: [--py37-plus]
 - repo: https://github.com/PyCQA/isort
-  rev: 7.0.0
+  rev: 9.0.0a3
   hooks:
   - id: isort
 - repo: https://github.com/kynan/nbstripout
-  rev: 0.9.0
+  rev: 0.9.1
   hooks:
   - id: nbstripout
     args: [--keep-count, --keep-output]

--- a/.prospector.yml
+++ b/.prospector.yml
@@ -1,0 +1,13 @@
+pydocstyle:
+  disable:
+    - D105
+    - D202
+    - D203
+    - D204
+    - D205
+    - D212 # TODO: pick one
+    - D213 # TODO: pick one
+    - D403
+    - D415
+    - D416
+    - F401

--- a/README.rst
+++ b/README.rst
@@ -357,7 +357,7 @@ Documentation
       progressbar every time a value is requested.
       """
 
-      @envwrap("TQDM_")  # override defaults via env vars
+      @envwrap("tqdm")  # override defaults via env vars
       def __init__(self, iterable=None, desc=None, total=None, leave=True,
                    file=None, ncols=None, mininterval=0.1,
                    maxinterval=10.0, miniters=None, ascii=None, disable=False,

--- a/README.rst
+++ b/README.rst
@@ -1455,7 +1455,7 @@ Citation information: |DOI|
 .. |Branch-Coverage-Status| image:: https://codecov.io/gh/tqdm/tqdm/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/tqdm/tqdm
 .. |Codacy-Grade| image:: https://app.codacy.com/project/badge/Grade/3f965571598f44549c7818f29cdcf177
-   :target: https://www.codacy.com/gh/tqdm/tqdm/dashboard
+   :target: https://app.codacy.com/gh/tqdm/tqdm/dashboard
 .. |CII Best Practices| image:: https://bestpractices.coreinfrastructure.org/projects/3264/badge
    :target: https://bestpractices.coreinfrastructure.org/projects/3264
 .. |GitHub-Status| image:: https://img.shields.io/github/tag/tqdm/tqdm.svg?maxAge=86400&logo=github&logoColor=white

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,25 +4,14 @@
     "project_url": "https://github.com/tqdm/tqdm/",
     "repo": ".",
     "environment_type": "virtualenv",
-    "build_command": ["PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} ."],
     "show_commit_url": "https://github.com/tqdm/tqdm/commit/",
-    // "pythons": ["3.7", "3.13"],
-    // "conda_channels": ["conda-forge", "defaults"],
     "matrix": {
-        "alive-progress": [""],
-        "progressbar2": [""],
-        "rich": [""],
+        "req": {
+            "alive-progress": [""],
+            "progressbar2": [""],
+            "rich": [""]
+        }
     },
-    // "exclude": [
-    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
-    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
-    // ],
-    // "include": [
-    //     // additional env for python2.7
-    //     {"python": "2.7", "numpy": "1.8"},
-    //     // additional env if run on windows+conda
-    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
-    // ],
     "benchmark_dir": "benchmarks",
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -12,12 +12,12 @@ class Comparison:
         except ImportError:
             from time import clock
             self.time = clock
-        self.iterable = range(int(length))
+        self.iterable = range(1, 1 + int(length))
 
     def run(self, cls):
         pbar = cls(self.iterable)
         t0 = self.time()
-        [0 for _ in pbar]  # pylint: disable=pointless-statement
+        all(pbar)  # pylint: disable=pointless-statement
         t1 = self.time()
         return t1 - t0
 

--- a/environment.yml
+++ b/environment.yml
@@ -15,12 +15,12 @@ dependencies:
 # test env managers
 - pre-commit
 - tox
-- asv
+- asv >=0.5
 # tests (native)
 - pytest
 - pytest-cov
 - pytest-timeout
-- pytest-asyncio>=0.24
+- pytest-asyncio >=0.24
 - coverage
 # extras
 - dask               # dask

--- a/examples/tqdm_wget.py
+++ b/examples/tqdm_wget.py
@@ -63,7 +63,7 @@ def my_hook(t):
     return update_to
 
 
-class TqdmUpTo(tqdm):
+class TqdmUpTo(tqdm):  # pylint: disable=inconsistent-mro
     """Alternative Class-based version of the above.
 
     Provides `update_to(n)` which uses `tqdm.update(delta_n)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,9 @@ dependencies = ['colorama; platform_system == "Windows"', 'importlib_metadata; p
 
 [project.optional-dependencies]
 dev = ["pytest>=6", "pytest-cov", "pytest-timeout", "pytest-asyncio>=0.24", "nbval"]
-discord = ["requests"]
-slack = ["slack-sdk"]
-telegram = ["requests"]
+discord = ["requests", "envwrap"]
+slack = ["slack-sdk", "envwrap"]
+telegram = ["requests", "envwrap"]
 notebook = ["ipywidgets>=6"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,14 +123,11 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.run]
 branch = true
-include = ["tqdm/*"]
 omit = [
     "tqdm/contrib/bells.py",
     "tqdm/contrib/slack.py",
     "tqdm/contrib/discord.py",
     "tqdm/contrib/telegram.py",
     "tqdm/contrib/utils_worker.py"]
-relative_files = true
-disable_warnings = ["include-ignored"]
 [tool.coverage.report]
 show_missing = true

--- a/tests/tests_itertools.py
+++ b/tests/tests_itertools.py
@@ -3,23 +3,115 @@ Tests for `tqdm.contrib.itertools`.
 """
 import itertools as it
 
-from tqdm.contrib.itertools import product
+import pytest
 
-from .tests_tqdm import StringIO, closing
-
-
-class NoLenIter:
-    def __init__(self, iterable):
-        self._it = iterable
-
-    def __iter__(self):
-        yield from self._it
+from tqdm.contrib import itertools as tit
 
 
-def test_product():
+def no_len(iterable):
+    yield from iterable
+
+
+def test_chain(capsys):
+    """Test contrib.itertools.chain"""
+    a = range(9)
+    assert list(tit.chain(a, a)) == list(it.chain(a, a))
+    assert "18/18" in capsys.readouterr().err
+
+    assert list(tit.chain(a, no_len(a))) == list(it.chain(a, no_len(a)))
+    res = capsys.readouterr().err
+    assert "18it" in res
+    assert "18/18" not in res
+
+    assert list(tit.chain(a, no_len(a), total=18)) == list(it.chain(a, no_len(a)))
+    assert "18/18" in capsys.readouterr().err
+
+
+def test_product(capsys):
     """Test contrib.itertools.product"""
-    with closing(StringIO()) as our_file:
-        a = range(9)
-        assert list(product(a, a[::-1], file=our_file)) == list(it.product(a, a[::-1]))
+    a = range(9)
+    assert list(tit.product(a, a)) == list(it.product(a, a))
+    assert "81/81" in capsys.readouterr().err
 
-        assert list(product(a, NoLenIter(a), file=our_file)) == list(it.product(a, NoLenIter(a)))
+    assert list(tit.product(a, no_len(a))) == list(it.product(a, no_len(a)))
+    res = capsys.readouterr().err
+    assert "81it" in res
+    assert "81/81" not in res
+
+    assert list(tit.product(a, no_len(a), total=81)) == list(it.product(a, no_len(a)))
+    assert "81/81" in capsys.readouterr().err
+
+
+def test_permutations(capsys):
+    """Test contrib.itertools.permutations"""
+    a = range(5)
+    assert list(tit.permutations(a)) == list(it.permutations(a))
+    assert "120/120" in capsys.readouterr().err
+
+    assert list(tit.permutations(a, 10)) == list(it.permutations(a, 10)) == []
+    capsys.readouterr()
+
+    assert list(tit.permutations(no_len(a))) == list(it.permutations(no_len(a)))
+    res = capsys.readouterr().err
+    assert "120it" in res
+    assert "120/120" not in res
+
+    assert list(tit.permutations(no_len(a), total=120)) == list(it.permutations(no_len(a)))
+    assert "120/120" in capsys.readouterr().err
+
+
+def test_combinations(capsys):
+    """Test contrib.itertools.combinations"""
+    a = range(9)
+    assert list(tit.combinations(a, 3)) == list(it.combinations(a, 3))
+    assert "84/84" in capsys.readouterr().err
+
+    assert list(tit.combinations(a, 10)) == list(it.combinations(a, 10)) == []
+    capsys.readouterr()
+
+    assert list(tit.combinations(no_len(a), 3)) == list(it.combinations(no_len(a), 3))
+    res = capsys.readouterr().err
+    assert "84it" in res
+    assert "84/84" not in res
+
+    assert list(tit.combinations(no_len(a), 3, total=84)) == list(it.combinations(no_len(a), 3))
+    assert "84/84" in capsys.readouterr().err
+
+
+def test_combinations_with_replacement(capsys):
+    """Test contrib.itertools.combinations_with_replacement"""
+    a = range(9)
+    assert list(tit.combinations_with_replacement(a, 3)) == list(
+        it.combinations_with_replacement(a, 3))
+    assert "165/165" in capsys.readouterr().err
+
+    assert list(tit.combinations_with_replacement(no_len(a), 3)) == list(
+        it.combinations_with_replacement(no_len(a), 3))
+    res = capsys.readouterr().err
+    assert "165it" in res
+    assert "165/165" not in res
+
+    assert list(tit.combinations_with_replacement(no_len(a), 3, total=165)) == list(
+        it.combinations_with_replacement(no_len(a), 3))
+    assert "165/165" in capsys.readouterr().err
+
+    a = range(5)
+    assert list(tit.combinations_with_replacement(a, 6)) == list(
+        it.combinations_with_replacement(a, 6))
+    assert "210/210" in capsys.readouterr().err
+
+
+@pytest.mark.skipif(not hasattr(it, 'batched'), reason="NotFound: itertools.batched")
+def test_batched(capsys):
+    """Test contrib.itertools.batched"""
+    a = range(10)
+    assert list(tit.batched(a, 3)) == list(it.batched(a, 3))
+    assert "12/12" in capsys.readouterr().err
+
+    assert list(tit.batched(no_len(a), 3)) == list(it.batched(no_len(a), 3))
+    res = capsys.readouterr().err
+    assert "12it" in res
+    assert "12/12" not in res
+
+    assert list(tit.batched(no_len(a), 3, total=12)) == list(it.batched(no_len(a), 3))
+    assert "12/12" in capsys.readouterr().err

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -62,7 +62,7 @@ def test_main_import():
     sys.argv = ['', '--desc', 'Test CLI import',
                 '--ascii', 'True', '--unit_scale', 'True']
     try:
-        import tqdm.__main__  # NOQA, pylint: disable=unused-variable
+        import tqdm.__main__  # noqa: F401, pylint: disable=unused-import
     finally:
         sys.stdin, sys.argv = _SYS
 

--- a/tests/tests_perf.py
+++ b/tests/tests_perf.py
@@ -58,7 +58,7 @@ def relative_timer():
     yield lambda: elapser()
     spent = elapser()
 
-    def elapser():  # NOQA
+    def elapser():  # pylint: disable=function-redefined
         return spent
 
 

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -37,7 +37,7 @@ else:
 nt_and_no_colorama = False
 if os.name == 'nt':
     try:
-        import colorama  # NOQA
+        import colorama  # noqa: F401, pylint: disable=unused-import
     except ImportError:
         nt_and_no_colorama = True
 

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -2,16 +2,33 @@ from ast import literal_eval
 from collections import defaultdict
 from typing import Union  # py<3.10
 
+import pytest
+
 from tqdm.utils import envwrap
 
 
-def test_envwrap(monkeypatch):
+def test_envwrap_deprecated(monkeypatch):
     """Test @envwrap (basic)"""
     monkeypatch.setenv('FUNC_A', "42")
     monkeypatch.setenv('FUNC_TyPe_HiNt', "1337")
     monkeypatch.setenv('FUNC_Unused', "x")
 
-    @envwrap("FUNC_")
+    with pytest.warns(DeprecationWarning, match="Trailing underscore in `name` is automatic"):
+        @envwrap("FUNC_")
+        def func(a=1, b=2, type_hint: int = None):
+            return a, b, type_hint
+
+    assert (42, 2, 1337) == func()
+    assert (99, 2, 1337) == func(a=99)
+
+
+def test_envwrap(monkeypatch):
+    """Test @envwrap (basic)"""
+    monkeypatch.setenv('NAME_FUNC_A', "42")
+    monkeypatch.setenv('NAME_TyPe_HiNt', "1337")
+    monkeypatch.setenv('NAME_unused', "x")
+
+    @envwrap("name", "func")
     def func(a=1, b=2, type_hint: int = None):
         return a, b, type_hint
 
@@ -23,7 +40,7 @@ def test_envwrap_types(monkeypatch):
     """Test @envwrap(types)"""
     monkeypatch.setenv('FUNC_notype', "3.14159")
 
-    @envwrap("FUNC_", types=defaultdict(lambda: literal_eval))
+    @envwrap("func", types=defaultdict(lambda: literal_eval))
     def func(notype=None):
         return notype
 
@@ -32,7 +49,7 @@ def test_envwrap_types(monkeypatch):
     monkeypatch.setenv('FUNC_number', "1")
     monkeypatch.setenv('FUNC_string', "1")
 
-    @envwrap("FUNC_", types={'number': int})
+    @envwrap("func", types={'number': int})
     def nofallback(number=None, string=None):
         return number, string
 
@@ -44,7 +61,7 @@ def test_envwrap_annotations(monkeypatch):
     monkeypatch.setenv('FUNC_number', "1.1")
     monkeypatch.setenv('FUNC_string', "1.1")
 
-    @envwrap("FUNC_")
+    @envwrap("func")
     def annotated(number: Union[int, float] = None, string: int = None):
         return number, string
 

--- a/tox.ini
+++ b/tox.ini
@@ -52,8 +52,8 @@ deps=
     tf: tensorflow!=2.5.0
     keras: keras
 commands=
-    pytest --cov=tqdm --cov-report= -W=ignore tests_notebook.ipynb --nbval --nbval-current-env --nbval-sanitize-with=.meta/nbval.ini
-    pytest --cov=tqdm --cov-report=xml --cov-report=term --cov-append -k "not perf"
+    pytest --cov=tqdm --cov-report= --cov-append -k "not perf"
+    pytest --cov=tqdm --cov-report=xml --cov-report=term -W=ignore tests_notebook.ipynb --nbval --nbval-current-env --nbval-sanitize-with=.meta/nbval.ini
     {[core]commands}
 allowlist_externals=codacy
 

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -1,7 +1,7 @@
 from warnings import warn
 
 from .std import TqdmDeprecationWarning
-from .utils import (  # NOQA, pylint: disable=unused-import
+from .utils import (  # noqa: F401, pylint: disable=unused-import
     CUR_OS, IS_NIX, IS_WIN, RE_ANSI, Comparable, FormatReplace, SimpleTextIOWrapper,
     _environ_cols_wrapper, _is_ascii, _is_utf, _screen_shape_linux, _screen_shape_tput,
     _screen_shape_windows, _screen_shape_wrapper, _supports_unicode, _term_move_up, colorama)

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -131,8 +131,6 @@ class tqdm_discord(tqdm_auto):
         if fmt.get('bar_format', None):
             fmt['bar_format'] = fmt['bar_format'].replace(
                 '<bar/>', '{bar:10u}').replace('{bar}', '{bar:10u}')
-        else:
-            fmt['bar_format'] = '{l_bar}{bar:10u}{r_bar}'
         self.dio.write(self.format_meter(**fmt))
 
     def clear(self, *args, **kwargs):

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -40,7 +40,7 @@ class DiscordIO(MonoWorker):
     @property
     def message_id(self):
         if hasattr(self, '_message_id'):
-            return self._message_id
+            return self._message_id  # pylint: disable=access-member-before-definition
         try:
             req = self.session.post(
                 f'{self.API}/channels/{self.channel_id}/messages',
@@ -93,7 +93,7 @@ class DiscordIO(MonoWorker):
             return future
 
 
-class tqdm_discord(tqdm_auto):
+class tqdm_discord(tqdm_auto):  # pylint: disable=inconsistent-mro
     """
     Standard `tqdm.auto.tqdm` but also sends updates to a Discord Bot.
     May take a few seconds to create (`__init__`).
@@ -124,7 +124,7 @@ class tqdm_discord(tqdm_auto):
             self.dio = DiscordIO(token, channel_id)
         super().__init__(*args, **kwargs)
 
-    def display(self, **kwargs):
+    def display(self, **kwargs):  # pylint: disable=arguments-differ
         super().display(**kwargs)
         fmt = self.format_dict
         if fmt.get('bar_format', None):

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -8,7 +8,6 @@ Usage:
 
 ![screenshot](https://tqdm.github.io/img/screenshot-discord.png)
 """
-from os import getenv
 from warnings import warn
 
 from requests import Session
@@ -16,6 +15,7 @@ from requests.utils import default_user_agent
 
 from ..auto import tqdm as tqdm_auto
 from ..std import TqdmWarning
+from ..utils import envwrap
 from ..version import __version__
 from .utils_worker import MonoWorker
 
@@ -107,7 +107,8 @@ class tqdm_discord(tqdm_auto):
     >>> for i in tqdm(iterable, token='{token}', channel_id='{channel_id}'):
     ...     ...
     """
-    def __init__(self, *args, **kwargs):
+    @envwrap("tqdm", "discord", is_method=True)
+    def __init__(self, *args, token=None, channel_id=None, **kwargs):
         """
         Parameters
         ----------
@@ -120,9 +121,7 @@ class tqdm_discord(tqdm_auto):
         """
         if not kwargs.get('disable'):
             kwargs = kwargs.copy()
-            self.dio = DiscordIO(
-                kwargs.pop('token', getenv('TQDM_DISCORD_TOKEN')),
-                kwargs.pop('channel_id', getenv('TQDM_DISCORD_CHANNEL_ID')))
+            self.dio = DiscordIO(token, channel_id)
         super().__init__(*args, **kwargs)
 
     def display(self, **kwargs):

--- a/tqdm/contrib/itertools.py
+++ b/tqdm/contrib/itertools.py
@@ -6,30 +6,96 @@ import itertools
 from ..auto import tqdm as tqdm_auto
 
 __author__ = {"github.com/": ["casperdcl"]}
-__all__ = ['product']
+__all__ = [
+    'chain', 'product', 'permutations', 'combinations', 'combinations_with_replacement', 'batched']
 
 
-def product(*iterables, **tqdm_kwargs):
-    """
-    Equivalent of `itertools.product`.
+def chain(*iterables, total=None, tqdm_class=tqdm_auto, **kwargs):
+    """Equivalent of `itertools.chain`."""
+    if total is None:
+        try:
+            total = sum(map(len, iterables))
+        except (TypeError, AttributeError):
+            pass
+    return tqdm_class(itertools.chain(*iterables), total=total, **kwargs)
 
-    Parameters
-    ----------
-    tqdm_class  : [default: tqdm.auto.tqdm].
-    """
-    kwargs = tqdm_kwargs.copy()
-    tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
-    try:
-        lens = list(map(len, iterables))
-    except TypeError:
-        total = None
-    else:
-        total = 1
-        for i in lens:
-            total *= i
-        kwargs.setdefault("total", total)
-    with tqdm_class(**kwargs) as t:
-        it = itertools.product(*iterables)
-        for i in it:
-            yield i
-            t.update()
+
+def product(*iterables, repeat=1, total=None, tqdm_class=tqdm_auto, **kwargs):
+    """Equivalent of `itertools.product`."""
+    if total is None:
+        try:
+            lens = list(map(len, iterables))
+        except (TypeError, AttributeError):
+            pass
+        else:  # py>=3.8: math.prod(lens) ** repeat
+            total = 1
+            for i in lens:
+                total *= i
+            total **= repeat
+    for i in tqdm_class(itertools.product(*iterables, repeat=repeat), total=total, **kwargs):
+        yield i
+
+
+def permutations(iterable, r=None, total=None, tqdm_class=tqdm_auto, **kwargs):
+    """Equivalent of `itertools.permutations`."""
+    if total is None:
+        try:
+            n = len(iterable)
+        except (TypeError, AttributeError):
+            pass
+        else:
+            r = n if r is None else r
+            if r > n:
+                total = 0
+            else:  # py>=3.8: math.perm(n, r)
+                total = 1
+                for i in range(n, n-r, -1):
+                    total *= i
+    return tqdm_class(itertools.permutations(iterable, r), total=total, **kwargs)
+
+
+def combinations(iterable, r, total=None, tqdm_class=tqdm_auto, **kwargs):
+    """Equivalent of `itertools.combinations`."""
+    if total is None:
+        try:
+            n = len(iterable)
+        except (TypeError, AttributeError):
+            pass
+        else:
+            if r > n:
+                total = 0
+            else:  # py>=3.8: math.comb(n, r)
+                total = 1
+                for i in range(n, n-r, -1):
+                    total *= i
+                for i in range(1, r+1):
+                    total //= i
+    return tqdm_class(itertools.combinations(iterable, r), total=total, **kwargs)
+
+
+def combinations_with_replacement(iterable, r, total=None, tqdm_class=tqdm_auto, **kwargs):
+    """Equivalent of `itertools.combinations_with_replacement`."""
+    if total is None:
+        try:
+            n = len(iterable)
+        except (TypeError, AttributeError):
+            pass
+        else:
+            total = 1
+            for i in range(n+r-1, n-1, -1):
+                total *= i
+            for i in range(1, r+1):
+                total //= i
+    return tqdm_class(itertools.combinations_with_replacement(iterable, r), total=total, **kwargs)
+
+
+def batched(iterable, n, total=None, tqdm_class=tqdm_auto, **kwargs):
+    """Equivalent of `itertools.batched`."""
+    if total is None:
+        try:
+            total = len(iterable)
+        except (TypeError, AttributeError):
+            pass
+    return tqdm_class(itertools.batched(iterable, n), unit_scale=n,
+                      total=(total+n-1) // n if total is not None else None,
+                      **kwargs)

--- a/tqdm/contrib/slack.py
+++ b/tqdm/contrib/slack.py
@@ -96,7 +96,7 @@ class tqdm_slack(tqdm_auto):
         if fmt.get('bar_format', None):
             fmt['bar_format'] = fmt['bar_format'].replace(
                 '<bar/>', '`{bar:10}`').replace('{bar}', '`{bar:10u}`')
-        else:
+        elif self.total:
             fmt['bar_format'] = '{l_bar}`{bar:10}`{r_bar}'
         if fmt['ascii'] is False:
             fmt['ascii'] = [":black_square:", ":small_blue_diamond:", ":large_blue_diamond:",

--- a/tqdm/contrib/slack.py
+++ b/tqdm/contrib/slack.py
@@ -56,7 +56,7 @@ class SlackIO(MonoWorker):
             return future
 
 
-class tqdm_slack(tqdm_auto):
+class tqdm_slack(tqdm_auto):  # pylint: disable=inconsistent-mro
     """
     Standard `tqdm.auto.tqdm` but also sends updates to a Slack app.
     May take a few seconds to create (`__init__`).
@@ -89,7 +89,7 @@ class tqdm_slack(tqdm_auto):
             kwargs['mininterval'] = max(1.5, kwargs.get('mininterval', 1.5))
         super().__init__(*args, **kwargs)
 
-    def display(self, **kwargs):
+    def display(self, **kwargs):  # pylint: disable=arguments-differ
         super().display(**kwargs)
         fmt = self.format_dict
         if fmt.get('bar_format', None):

--- a/tqdm/contrib/slack.py
+++ b/tqdm/contrib/slack.py
@@ -9,7 +9,6 @@ Usage:
 ![screenshot](https://tqdm.github.io/img/screenshot-slack.png)
 """
 import logging
-from os import getenv
 
 try:
     from slack_sdk import WebClient
@@ -17,6 +16,7 @@ except ImportError:
     raise ImportError("Please `pip install slack-sdk`")
 
 from ..auto import tqdm as tqdm_auto
+from ..utils import envwrap
 from .utils_worker import MonoWorker
 
 __author__ = {"github.com/": ["0x2b3bfa0", "casperdcl"]}
@@ -68,7 +68,8 @@ class tqdm_slack(tqdm_auto):
     >>> for i in tqdm(iterable, token='{token}', channel='{channel}'):
     ...     ...
     """
-    def __init__(self, *args, **kwargs):
+    @envwrap("tqdm", "slack", is_method=True)
+    def __init__(self, *args, token=None, channel=None, **kwargs):
         """
         Parameters
         ----------
@@ -84,9 +85,7 @@ class tqdm_slack(tqdm_auto):
         if not kwargs.get('disable'):
             kwargs = kwargs.copy()
             logging.getLogger("HTTPClient").setLevel(logging.WARNING)
-            self.sio = SlackIO(
-                kwargs.pop('token', getenv("TQDM_SLACK_TOKEN")),
-                kwargs.pop('channel', getenv("TQDM_SLACK_CHANNEL")))
+            self.sio = SlackIO(token, channel)
             kwargs['mininterval'] = max(1.5, kwargs.get('mininterval', 1.5))
         super().__init__(*args, **kwargs)
 

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -128,8 +128,6 @@ class tqdm_telegram(tqdm_auto):
         if fmt.get('bar_format', None):
             fmt['bar_format'] = fmt['bar_format'].replace(
                 '<bar/>', '{bar:10u}').replace('{bar}', '{bar:10u}')
-        else:
-            fmt['bar_format'] = '{l_bar}{bar:10u}{r_bar}'
         self.tgio.write(self.format_meter(**fmt))
 
     def clear(self, *args, **kwargs):

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -8,13 +8,13 @@ Usage:
 
 ![screenshot](https://tqdm.github.io/img/screenshot-telegram.gif)
 """
-from os import getenv
 from warnings import warn
 
 from requests import Session
 
 from ..auto import tqdm as tqdm_auto
 from ..std import TqdmWarning
+from ..utils import envwrap
 from .utils_worker import MonoWorker
 
 __author__ = {"github.com/": ["casperdcl"]}
@@ -104,7 +104,8 @@ class tqdm_telegram(tqdm_auto):
     >>> for i in tqdm(iterable, token='{token}', chat_id='{chat_id}'):
     ...     ...
     """
-    def __init__(self, *args, **kwargs):
+    @envwrap("tqdm", "telegram", is_method=True)
+    def __init__(self, *args, token=None, chat_id=None, **kwargs):
         """
         Parameters
         ----------
@@ -117,9 +118,7 @@ class tqdm_telegram(tqdm_auto):
         """
         if not kwargs.get('disable'):
             kwargs = kwargs.copy()
-            self.tgio = TelegramIO(
-                kwargs.pop('token', getenv('TQDM_TELEGRAM_TOKEN')),
-                kwargs.pop('chat_id', getenv('TQDM_TELEGRAM_CHAT_ID')))
+            self.tgio = TelegramIO(token, chat_id)
         super().__init__(*args, **kwargs)
 
     def display(self, **kwargs):

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -37,7 +37,7 @@ class TelegramIO(MonoWorker):
     @property
     def message_id(self):
         if hasattr(self, '_message_id'):
-            return self._message_id
+            return self._message_id  # pylint: disable=access-member-before-definition
         try:
             req = self.session.post(
                 f'{self.API}{self.token}/sendMessage',
@@ -88,7 +88,7 @@ class TelegramIO(MonoWorker):
             return future
 
 
-class tqdm_telegram(tqdm_auto):
+class tqdm_telegram(tqdm_auto):  # pylint: disable=inconsistent-mro
     """
     Standard `tqdm.auto.tqdm` but also sends updates to a Telegram Bot.
     May take a few seconds to create (`__init__`).
@@ -121,7 +121,7 @@ class tqdm_telegram(tqdm_auto):
             self.tgio = TelegramIO(token, chat_id)
         super().__init__(*args, **kwargs)
 
-    def display(self, **kwargs):
+    def display(self, **kwargs):  # pylint: disable=arguments-differ
         super().display(**kwargs)
         fmt = self.format_dict
         if fmt.get('bar_format', None):

--- a/tqdm/keras.py
+++ b/tqdm/keras.py
@@ -23,7 +23,8 @@ class TqdmCallback(keras.callbacks.Callback):
             if logs:
                 if pop:
                     logs = copy(logs)
-                    [logs.pop(i, 0) for i in pop]
+                    for i in pop:
+                        logs.pop(i, 0)
                 bar.set_postfix(logs, refresh=False)
             bar.update(n)
 

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -20,7 +20,7 @@ if True:  # pragma: no cover
     # import IPython/Jupyter base widget and display utilities
     IPY = 0
     try:  # IPython 4.x
-        import ipywidgets
+        import ipywidgets  # noqa: F401, pylint: disable=unused-import
         IPY = 4
     except ImportError:  # IPython 3.x / 2.x
         IPY = 32
@@ -29,7 +29,7 @@ if True:  # pragma: no cover
             warnings.filterwarnings(
                 'ignore', message=".*The `IPython.html` package has been deprecated.*")
             try:
-                import IPython.html.widgets as ipywidgets  # NOQA: F401
+                import IPython.html.widgets as ipywidgets  # noqa: F401
             except ImportError:
                 pass
 

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -949,8 +949,8 @@ class tqdm(Comparable):
             _Rolling_and_Expanding.progress_apply = inner_generator()
 
     # override defaults via env vars
-    @envwrap("TQDM_", is_method=True, types={'total': float, 'ncols': int, 'miniters': float,
-                                             'position': int, 'nrows': int})
+    @envwrap("tqdm", is_method=True, types={'total': float, 'ncols': int, 'miniters': float,
+                                            'position': int, 'nrows': int})
     def __init__(self, iterable=None, desc=None, total=None, leave=True, file=None,
                  ncols=None, mininterval=0.1, maxinterval=10.0, miniters=None,
                  ascii=None, disable=False, unit='it', unit_scale=False,

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -51,17 +51,15 @@ class TqdmWarning(Warning):
 
 class TqdmExperimentalWarning(TqdmWarning, FutureWarning):
     """beta feature, unstable API and behaviour"""
-    pass
 
 
 class TqdmDeprecationWarning(TqdmWarning, DeprecationWarning):
+    """may be removed in a future release"""
     # not suppressed if raised
-    pass
 
 
 class TqdmMonitorWarning(TqdmWarning, RuntimeWarning):
     """tqdm monitor errors which do not affect external functionality"""
-    pass
 
 
 def TRLock(*args, **kwargs):
@@ -462,8 +460,9 @@ class tqdm(Comparable):
         return print_status
 
     @staticmethod
-    def format_meter(n, total, elapsed, ncols=None, prefix='', ascii=False, unit='it',
-                     unit_scale=False, rate=None, bar_format=None, postfix=None,
+    def format_meter(n, total, elapsed, ncols=None, prefix='',
+                     ascii=False,  # pylint: disable=redefined-builtin
+                     unit='it', unit_scale=False, rate=None, bar_format=None, postfix=None,
                      unit_divisor=1000, initial=0, colour=None, **extra_kwargs):
         """
         Return a string-based progress bar given some parameters
@@ -953,10 +952,10 @@ class tqdm(Comparable):
                                             'position': int, 'nrows': int})
     def __init__(self, iterable=None, desc=None, total=None, leave=True, file=None,
                  ncols=None, mininterval=0.1, maxinterval=10.0, miniters=None,
-                 ascii=None, disable=False, unit='it', unit_scale=False,
-                 dynamic_ncols=False, smoothing=0.3, bar_format=None, initial=0,
-                 position=None, postfix=None, unit_divisor=1000, write_bytes=False,
-                 lock_args=None, nrows=None, colour=None, delay=0.0, gui=False,
+                 ascii=False,  # pylint: disable=redefined-builtin
+                 disable=False, unit='it', unit_scale=False, dynamic_ncols=False, smoothing=0.3,
+                 bar_format=None, initial=0, position=None, postfix=None, unit_divisor=1000,
+                 write_bytes=False, lock_args=None, nrows=None, colour=None, delay=0.0, gui=False,
                  **kwargs):
         """see tqdm.tqdm for arguments"""
         if file is None:
@@ -1130,7 +1129,8 @@ class tqdm(Comparable):
 
     def __contains__(self, item):
         contains = getattr(self.iterable, '__contains__', None)
-        return contains(item) if contains is not None else item in self.__iter__()
+        return (contains(item) if contains is not None  # pylint: disable=not-callable
+                else item in self.__iter__())
 
     def __enter__(self):
         return self
@@ -1499,7 +1499,8 @@ class tqdm(Comparable):
 
     @classmethod
     @contextmanager
-    def wrapattr(cls, stream, method, total=None, bytes=True, **tqdm_kwargs):
+    def wrapattr(cls, stream, method, total=None, bytes=True,  # pylint: disable=redefined-builtin
+                 **tqdm_kwargs):
         """
         stream  : file-like object.
         method  : str, "read" or "write". The result of `read()` and

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -31,7 +31,7 @@ else:
         colorama.init()
 
 try:
-    from envwrap import envwrap
+    from envwrap import envwrap  # pylint: disable=unused-import
 except ModuleNotFoundError:
     def envwrap(name, app="", types=None, is_method=False):
         """

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -284,69 +284,16 @@ def _screen_shape_wrapper():  # pragma: no cover
     Return a function which returns console dimensions (width, height).
     Supported: linux, osx, windows, cygwin.
     """
-    _screen_shape = None
-    if IS_WIN:
-        _screen_shape = _screen_shape_windows
-        if _screen_shape is None:
-            _screen_shape = _screen_shape_tput
-    if IS_NIX:
-        _screen_shape = _screen_shape_linux
-    return _screen_shape
+    from os import get_terminal_size
 
-
-def _screen_shape_windows(fp):  # pragma: no cover
-    try:
-        import struct
-        from ctypes import create_string_buffer, windll
-        from sys import stdin, stdout
-
-        io_handle = -12  # assume stderr
-        if fp == stdin:
-            io_handle = -10
-        elif fp == stdout:
-            io_handle = -11
-
-        h = windll.kernel32.GetStdHandle(io_handle)
-        csbi = create_string_buffer(22)
-        res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
-        if res:
-            (_bufx, _bufy, _curx, _cury, _wattr, left, top, right, bottom,
-             _maxx, _maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
-            return right - left, bottom - top  # +1
-    except Exception:  # nosec
-        pass
-    return None, None
-
-
-def _screen_shape_tput(*_):  # pragma: no cover
-    """cygwin xterm (windows)"""
-    try:
-        import shlex
-        from subprocess import check_call  # nosec
-        return [int(check_call(shlex.split('tput ' + i))) - 1
-                for i in ('cols', 'lines')]
-    except Exception:  # nosec
-        pass
-    return None, None
-
-
-def _screen_shape_linux(fp):  # pragma: no cover
-
-    try:
-        from array import array
-        from fcntl import ioctl
-        from termios import TIOCGWINSZ
-    except ImportError:
-        return None, None
-    else:
+    def inner(fp):
         try:
-            rows, cols = array('h', ioctl(fp, TIOCGWINSZ, '\0' * 8))[:2]
-            return cols, rows
+            cols, lines = get_terminal_size(getattr(fp, 'fileno', lambda: None)())
+            return cols - 1, lines - 1
         except Exception:
-            try:
-                return [int(os.environ[i]) - 1 for i in ("COLUMNS", "LINES")]
-            except (KeyError, ValueError):
-                return None, None
+            return None, None
+
+    return inner
 
 
 def _environ_cols_wrapper():  # pragma: no cover

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -30,73 +30,52 @@ else:
     except TypeError:
         colorama.init()
 
+try:
+    from envwrap import envwrap
+except ModuleNotFoundError:
+    def envwrap(name, app="", types=None, is_method=False):
+        """
+        Basic (env-var-only) version of `envwrap <https://github.com/tqdm/envwrap>`_.
+        Install ``envwrap`` for config file support.
+        """
+        if types is None:
+            types = {}
+        if name[-1] == "_":
+            name = name[:-1]
+            warn("Trailing underscore in `name` is automatic", DeprecationWarning, stacklevel=2)
+        prefixes = (name, f"{name}_{app}") if app else (name,)
+        env_overrides = {}
+        for prefix in prefixes:
+            prefix = prefix.upper() + "_"
+            i = len(prefix)
+            env_overrides.update(
+                (k[i:].lower(), v) for k, v in os.environ.items() if k.startswith(prefix))
+        part = partialmethod if is_method else partial
 
-def envwrap(prefix, types=None, is_method=False):
-    """
-    Override parameter defaults via `os.environ[prefix + param_name]`.
-    Maps UPPER_CASE env vars map to lower_case param names.
-    camelCase isn't supported (because Windows ignores case).
-
-    Precedence (highest first):
-
-    - call (`foo(a=3)`)
-    - environ (`FOO_A=2`)
-    - signature (`def foo(a=1)`)
-
-    Parameters
-    ----------
-    prefix  : str
-        Env var prefix, e.g. "FOO_"
-    types  : dict, optional
-        Fallback mappings `{'param_name': type, ...}` if types cannot be
-        inferred from function signature.
-        Consider using `types=collections.defaultdict(lambda: ast.literal_eval)`.
-    is_method  : bool, optional
-        Whether to use `functools.partialmethod`. If (default: False) use `functools.partial`.
-
-    Examples
-    --------
-    ```
-    $ cat foo.py
-    from tqdm.utils import envwrap
-    @envwrap("FOO_")
-    def test(a=1, b=2, c=3):
-        print(f"received: a={a}, b={b}, c={c}")
-
-    $ FOO_A=42 FOO_C=1337 python -c 'import foo; foo.test(c=99)'
-    received: a=42, b=2, c=99
-    ```
-    """
-    if types is None:
-        types = {}
-    i = len(prefix)
-    env_overrides = {k[i:].lower(): v for k, v in os.environ.items() if k.startswith(prefix)}
-    part = partialmethod if is_method else partial
-
-    def wrap(func):
-        params = signature(func).parameters
-        # ignore unknown env vars
-        overrides = {k: v for k, v in env_overrides.items() if k in params}
-        # infer overrides' `type`s
-        for k in overrides:
-            param = params[k]
-            if param.annotation is not param.empty:  # typehints
-                for typ in getattr(param.annotation, '__args__', (param.annotation,)):
-                    try:
-                        overrides[k] = typ(overrides[k])
-                    except Exception:
+        def wrap(func):
+            params = signature(func).parameters
+            # ignore unknown env vars
+            overrides = {k: v for k, v in env_overrides.items() if k in params}
+            # infer overrides' `type`s
+            for k in overrides:
+                param = params[k]
+                if param.annotation is not param.empty:  # typehints
+                    for typ in getattr(param.annotation, '__args__', (param.annotation,)):
+                        try:
+                            overrides[k] = typ(overrides[k])
+                        except Exception:
+                            pass
+                        else:
+                            break
+                elif param.default is not None:  # type of default value
+                    overrides[k] = type(param.default)(overrides[k])
+                else:
+                    try:  # `types` fallback
+                        overrides[k] = types[k](overrides[k])
+                    except KeyError:  # keep unconverted (`str`)
                         pass
-                    else:
-                        break
-            elif param.default is not None:  # type of default value
-                overrides[k] = type(param.default)(overrides[k])
-            else:
-                try:  # `types` fallback
-                    overrides[k] = types[k](overrides[k])
-                except KeyError:  # keep unconverted (`str`)
-                    pass
-        return part(func, **overrides)
-    return wrap
+            return part(func, **overrides)
+        return wrap
 
 
 class FormatReplace:


### PR DESCRIPTION
- `utils`: simplify terminal size detection
- `contrib`
  + `itertools`
    * add `chain`, `permutations`, `combinations`, `combinations_with_replacement`, `batched`
    * add `product(repeat=1)` keyword argument (replaces/closes #1428)
  + fix `discord`, `telegram` error handling
  + fix `discord`, `slack`, `telegram` format for `total=None`
- soft-deprecate `tqdm.utils.envwrap` -> [`envwrap`](https://github.com/tqdm/envwrap)
- benchmarks: fix `asv`
- misc framework updates
  + CI: use ubuntu-slim
  + CI: migrate manual job to `pre-commit.ci`
  + misc linting
  + drop redundant config
  + bump workflow actions, pre-commit hooks
