### PR TITLE
Fix typo 'beween' -> 'between' in README

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -459,7 +459,7 @@ Submodules
         """IPython/Jupyter Notebook widget."""
 
     class tqdm.auto.tqdm(tqdm.tqdm):
-        """Automatically chooses beween `tqdm.notebook` and `tqdm.tqdm`."""
+        """Automatically chooses between `tqdm.notebook` and `tqdm.tqdm`."""
 
     class tqdm.asyncio.tqdm(tqdm.tqdm):
       """Asynchronous version."""

--- a/README.rst
+++ b/README.rst
@@ -676,7 +676,7 @@ Submodules
         """IPython/Jupyter Notebook widget."""
 
     class tqdm.auto.tqdm(tqdm.tqdm):
-        """Automatically chooses beween `tqdm.notebook` and `tqdm.tqdm`."""
+        """Automatically chooses between `tqdm.notebook` and `tqdm.tqdm`."""
 
     class tqdm.asyncio.tqdm(tqdm.tqdm):
       """Asynchronous version."""


### PR DESCRIPTION
Fixes a small typo in the `tqdm.auto.tqdm` docstring shown in the README:

> "Automatically chooses ~~beween~~ between `tqdm.notebook` and `tqdm.tqdm`."

Updated both the source (`.meta/.readme.rst`) and the generated `README.rst` so they stay in sync. Docs-only; no code change.