### PR TITLE
improve `autonotebook` support

### DIFF
--- a/.meta/mksnap.py
+++ b/.meta/mksnap.py
@@ -59,7 +59,7 @@ apps:
   tqdm:
     command: bin/tqdm
     completer: completion.sh
-""".format(version=tqdm.__version__)  # nosec
+""".format(version=tqdm.__version__.split('.d')[0])  # nosec
 
 if __name__ == "__main__":
     (Path(__file__).resolve().parent.parent / 'snapcraft.yaml').write_text(

--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -6,13 +6,22 @@ Usage:
 >>> for i in trange(10):
 ...     ...
 """
+import os
 import sys
 from warnings import warn
 
 try:
-    get_ipython = sys.modules['IPython'].get_ipython
-    if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover
-        raise ImportError("console")
+    if 'ipykernel.zmqshell' in sys.modules:
+        if any(i == 'QT_API' or i.startswith('SPYDER') for i in os.environ):
+            raise ImportError("console")  # jupyter-qtconsole/spyder
+        ipy = sys.modules['IPython'].get_ipython().__class__.__name__.lower()
+        if 'qt' in ipy or 'spyder' in ipy:
+            raise ImportError("console")  # older jupyter-qtconsole/spyder
+        # jupyter-notebook/jupyterlab/vscode/binder/colab
+    elif 'IPython.utils._process_emscripten' in sys.modules:
+        pass  # jupyterlite (pyodide)/jupyterlite-xeus
+    else:
+        raise ImportError("console")  # ipython/jupyter-console
     from .notebook import WARN_NOIPYW, IProgress
     if IProgress is None:
         from .std import TqdmWarning

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -267,10 +267,9 @@ def _screen_shape_wrapper():  # pragma: no cover
     Return a function which returns console dimensions (width, height).
     Supported: linux, osx, windows, cygwin.
     """
-    from os import get_terminal_size
-
     def inner(fp):
         try:
+            from os import get_terminal_size
             cols, lines = get_terminal_size(getattr(fp, 'fileno', lambda: None)())
             return cols - 1, lines - 1
         except Exception:


### PR DESCRIPTION
- `utils`: delay `os.get_terminal_size` (follow-up to #1760)
- `autonotebook`: support QtConsole, Spyder, JupyterLite
  + fixes #1283
  + fixes #1098
  + replaces/closes #1628
  + replaces/closes #1559
  + fixes #512
- fix snap build (drop date from version str)