### PR TITLE
[codex] Parse boolean env overrides correctly

### DIFF
--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -53,7 +53,7 @@ def test_envwrap_types(monkeypatch):
     def nofallback(number=None, string=None):
         return number, string
 
-    assert 1, "1" == nofallback()
+    assert (1, "1") == nofallback()
 
 
 def test_envwrap_annotations(monkeypatch):
@@ -65,4 +65,18 @@ def test_envwrap_annotations(monkeypatch):
     def annotated(number: Union[int, float] = None, string: int = None):
         return number, string
 
-    assert 1.1, "1.1" == annotated()
+    assert (1.1, "1.1") == annotated()
+
+
+def test_envwrap_bool(monkeypatch):
+    """Test @envwrap with bool values"""
+    monkeypatch.setenv('FUNC_default_true', "False")
+    monkeypatch.setenv('FUNC_default_false', "1")
+    monkeypatch.setenv('FUNC_annotated', "0")
+    monkeypatch.setenv('FUNC_fallback', "yes")
+
+    @envwrap("func", types={'fallback': bool})
+    def func(default_true=True, default_false=False, annotated: bool = None, fallback=None):
+        return default_true, default_false, annotated, fallback
+
+    assert (False, True, False, True) == func()

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -26,11 +26,11 @@ def cast(val, typ):
 
     # sys.stderr.write('\ndebug | `val:type`: `' + val + ':' + typ + '`.\n')
     if typ == 'bool':
-        if (val == 'True') or (val == ''):
+        if val.strip().lower() in ('true', 'yes', 'on', '1', 'y', 't', ''):
             return True
-        if val == 'False':
+        if val.strip().lower() in ('false', 'no', 'off', '0', 'n', 'f'):
             return False
-        raise TqdmTypeError(val + ' : ' + typ)
+        raise TqdmTypeError(f"{typ}: {val}")
     if typ == 'chr':
         if len(val) == 1:
             return val.encode()

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -17,6 +17,17 @@ IS_WIN = any(CUR_OS.startswith(i) for i in ['win32', 'cygwin'])
 IS_NIX = any(CUR_OS.startswith(i) for i in ['aix', 'linux', 'darwin', 'freebsd'])
 RE_ANSI = re.compile(r"\x1b\[[;\d]*[A-Za-z]")
 
+
+def _environ_cast(value, typ):
+    if typ is bool:
+        value = value.strip().lower()
+        if value in {'1', 'true', 't', 'yes', 'y', 'on'}:
+            return True
+        if value in {'0', 'false', 'f', 'no', 'n', 'off', ''}:
+            return False
+    return typ(value)
+
+
 try:
     if IS_WIN:
         import colorama
@@ -60,16 +71,16 @@ def envwrap(name, app="", types=None, is_method=False):
             if param.annotation is not param.empty:  # typehints
                 for typ in getattr(param.annotation, '__args__', (param.annotation,)):
                     try:
-                        overrides[k] = typ(overrides[k])
+                        overrides[k] = _environ_cast(overrides[k], typ)
                     except Exception:  # nosec B110
                         pass
                     else:
                         break
             elif param.default is not None:  # type of default value
-                overrides[k] = type(param.default)(overrides[k])
+                overrides[k] = _environ_cast(overrides[k], type(param.default))
             else:
                 try:  # `types` fallback
-                    overrides[k] = types[k](overrides[k])
+                    overrides[k] = _environ_cast(overrides[k], types[k])
                 except KeyError:  # keep unconverted (`str`)
                     pass
         return part(func, **overrides)

--- a/tqdm/utils.py
+++ b/tqdm/utils.py
@@ -18,13 +18,14 @@ IS_NIX = any(CUR_OS.startswith(i) for i in ['aix', 'linux', 'darwin', 'freebsd']
 RE_ANSI = re.compile(r"\x1b\[[;\d]*[A-Za-z]")
 
 
-def _environ_cast(value, typ):
+def cast(value, typ):
     if typ is bool:
-        value = value.strip().lower()
-        if value in {'1', 'true', 't', 'yes', 'y', 'on'}:
+        val = value.strip().lower()
+        if val in ('true', 'yes', 'on', '1', 'y', 't'):
             return True
-        if value in {'0', 'false', 'f', 'no', 'n', 'off', ''}:
+        if val in ('false', 'no', 'off', '0', 'n', 'f', ''):
             return False
+        raise TypeError(f"{typ}: {val}")
     return typ(value)
 
 
@@ -71,16 +72,16 @@ def envwrap(name, app="", types=None, is_method=False):
             if param.annotation is not param.empty:  # typehints
                 for typ in getattr(param.annotation, '__args__', (param.annotation,)):
                     try:
-                        overrides[k] = _environ_cast(overrides[k], typ)
+                        overrides[k] = cast(overrides[k], typ)
                     except Exception:  # nosec B110
                         pass
                     else:
                         break
             elif param.default is not None:  # type of default value
-                overrides[k] = _environ_cast(overrides[k], type(param.default))
+                overrides[k] = cast(overrides[k], type(param.default))
             else:
                 try:  # `types` fallback
-                    overrides[k] = _environ_cast(overrides[k], types[k])
+                    overrides[k] = cast(overrides[k], types[k])
                 except KeyError:  # keep unconverted (`str`)
                     pass
         return part(func, **overrides)


### PR DESCRIPTION
## Summary
- Teach the local envwrap fallback to parse common false and true boolean strings.

## Validation
- targeted pytest tests and compileall passed.

## Notes
- Opened as a draft PR for maintainer review.
