### PR TITLE
Expose remaining and remaining_s in format_dict

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1074,6 +1074,23 @@ def test_custom_format():
         assert "00:00 in total" in our_file.getvalue()
 
 
+def test_format_dict_remaining():
+    """`format_dict` exposes `remaining` and `remaining_s` (#1685)."""
+    with closing(StringIO()) as our_file:
+        with tqdm(total=10, file=our_file) as t:
+            t.update(4)
+            fd = t.format_dict
+            assert 'remaining' in fd
+            assert 'remaining_s' in fd
+            assert isinstance(fd['remaining_s'], (int, float))
+            if fd['rate']:
+                assert fd['remaining_s'] == (fd['total'] - fd['n']) / fd['rate']
+                assert fd['remaining'] == tqdm.format_interval(fd['remaining_s'])
+            else:
+                assert fd['remaining_s'] == 0
+                assert fd['remaining'] == '?'
+
+
 def test_eta(capsys):
     """Test eta bar_format"""
     from datetime import datetime as dt

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1451,12 +1451,16 @@ class tqdm(Comparable):
                 'n': self.n, 'total': self.total, 'elapsed': 0, 'unit': 'it'})
         if self.dynamic_ncols:
             self.ncols, self.nrows = self.dynamic_ncols(self.fp)
+        rate = self._ema_dn() / self._ema_dt() if self._ema_dt() else None
+        remaining = (self.total - self.n) / rate if rate and self.total else 0
         return {
             'n': self.n, 'total': self.total,
             'elapsed': self._time() - self.start_t if hasattr(self, 'start_t') else 0,
             'ncols': self.ncols, 'nrows': self.nrows, 'prefix': self.desc,
             'ascii': self.ascii, 'unit': self.unit, 'unit_scale': self.unit_scale,
-            'rate': self._ema_dn() / self._ema_dt() if self._ema_dt() else None,
+            'rate': rate,
+            'remaining': self.format_interval(remaining) if rate else '?',
+            'remaining_s': remaining,
             'bar_format': self.bar_format, 'postfix': self.postfix,
             'unit_divisor': self.unit_divisor, 'initial': self.initial,
             'colour': self.colour}


### PR DESCRIPTION
## Summary
Closes #1685.

`format_meter` already computes the ETA — both `remaining` (a formatted string) and `remaining_s` (seconds) — but the public `format_dict` property does not expose them, so users who want the ETA have to recompute it from `total`/`n`/`rate` themselves.

This adds `remaining` and `remaining_s` to `format_dict`, derived exactly the same way `format_meter` derives them:

```python
rate = self._ema_dn() / self._ema_dt() if self._ema_dt() else None
remaining = (self.total - self.n) / rate if rate and self.total else 0
...
'remaining': self.format_interval(remaining) if rate else '?',
'remaining_s': remaining,
```

When the rate is unknown (no elapsed data / no total) it falls back to `'?'` / `0`, matching `format_meter`'s behavior.

## Tests
Added `test_format_dict_remaining` to `tests/tests_tqdm.py` asserting both keys are present and that `remaining_s == (total - n) / rate` and `remaining == format_interval(remaining_s)` when a rate is available.

Verified locally: full `tests/tests_tqdm.py` passes (71 passed); `flake8` clean at the project's max-line-length (99).