### PR TITLE
Apply disp_trim to all format_meter return paths (#1658)

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -275,6 +275,21 @@ def test_format_meter():
                         bar_format=r'{l_bar}{bar}') == " 20%|" + unich(0x258d) + " "
     assert format_meter(20, 100, 12, ncols=6, rate=8.1,
                         bar_format=r'{bar}|test') == unich(0x258f) + "|test"
+    # ncols must trim bar_format outputs that lack a `{bar}` (issue #1658)
+    long_desc = "x" * 50
+    # total known, custom bar_format without `{bar}`
+    assert format_meter(1, 100, 12, ncols=10,
+                        bar_format="{desc}", prefix=long_desc) == "x" * 10
+    # no total, custom bar_format without `{bar}`
+    assert format_meter(1, None, 12, ncols=10,
+                        bar_format="{desc}", prefix=long_desc) == "x" * 10
+    # no total, no bar_format (default stats line)
+    assert len(format_meter(1, None, 12, ncols=10)) == 10
+    # ncols=0 and ncols=None must not trim these paths
+    assert format_meter(1, 100, 12, ncols=None,
+                        bar_format="{desc}", prefix=long_desc) == long_desc
+    assert format_meter(1, None, 12, ncols=0,
+                        bar_format="{desc}", prefix=long_desc) == long_desc
 
 
 def test_ansi_escape_codes():

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -629,7 +629,8 @@ class tqdm(Comparable):
             full_bar = FormatReplace()
             nobar = bar_format.format(bar=full_bar, **format_dict)
             if not full_bar.format_called:
-                return nobar  # no `{bar}`; nothing else to do
+                # no `{bar}`; nothing else to do but honour ncols
+                return disp_trim(nobar, ncols) if ncols else nobar
 
             # Formatting progress bar space available for bar's display
             full_bar = Bar(frac,
@@ -648,7 +649,7 @@ class tqdm(Comparable):
             full_bar = FormatReplace()
             nobar = bar_format.format(bar=full_bar, **format_dict)
             if not full_bar.format_called:
-                return nobar
+                return disp_trim(nobar, ncols) if ncols else nobar
             full_bar = Bar(0,
                            max(1, ncols - disp_len(nobar)) if ncols else 10,
                            charset=Bar.BLANK, colour=colour)
@@ -656,8 +657,9 @@ class tqdm(Comparable):
             return disp_trim(res, ncols) if ncols else res
         else:
             # no total: no bar & ETA, just progress stats
-            return (f'{(prefix + ": ") if prefix else ""}'
-                    f'{n_fmt}{unit} [{elapsed_str}, {rate_fmt}{postfix}]')
+            res = (f'{(prefix + ": ") if prefix else ""}'
+                   f'{n_fmt}{unit} [{elapsed_str}, {rate_fmt}{postfix}]')
+            return disp_trim(res, ncols) if ncols else res
 
     def __new__(cls, *_, **__):
         instance = object.__new__(cls)


### PR DESCRIPTION
Fixes #1658.

## Bug
`tqdm.std.format_meter` has six `return` paths but only two applied `disp_trim(res, ncols)`. Three others returned untrimmed strings, so `ncols` / `dynamic_ncols` were ignored for a custom `bar_format` without a `{bar}` placeholder (e.g. `bar_format="{desc}"` with `set_description_str`) and for the no-total default stats line. Untrimmed output wider than the terminal overflows and wraps.

## Fix
Wrap those three paths in `disp_trim` using the codebase's existing `disp_trim(x, ncols) if ncols else x` guard, so the `ncols=0` ("no bar" sentinel) and `ncols=None` ("unknown width") cases keep their prior behavior. The intentional `ncols==0` early-return is left untrimmed.

## Verification
- `tqdm(bar_format="{desc}", ncols=20)` with a 60-char description now yields `disp_len == 20` (overflowed before).
- Regression asserts added to `test_format_meter` — fail on pre-fix code, pass with the fix.
- Full suite: **137 passed, 6 skipped** (skips are optional deps). Matches the fix the issue author proposed.
