### PR TITLE
`tqdm.write` should do nothing when `sys.stdout=None`

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1959,3 +1959,13 @@ def test_contains(capsys):
     assert not out
     assert '  0%' in err
     assert '100%' not in err
+
+
+def test_write_stdout_none():
+    """Test tqdm.write does not crash when sys.stdout is None"""
+    orig_stdout = sys.stdout
+    try:
+        sys.stdout = None
+        tqdm.write("test stdout none message")
+    finally:
+        sys.stdout = orig_stdout

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -717,6 +717,8 @@ class tqdm(Comparable):
     def write(cls, s, file=None, end="\n", nolock=False):
         """Print a message via tqdm (without overlap with bars)."""
         fp = file if file is not None else sys.stdout
+        if fp is None:
+            return
         with cls.external_write_mode(file=file, nolock=nolock):
             # Write the message
             fp.write(s)
@@ -730,6 +732,9 @@ class tqdm(Comparable):
         Useful when writing to standard output stream
         """
         fp = file if file is not None else sys.stdout
+        if fp is None:
+            yield
+            return
 
         try:
             if not nolock:


### PR DESCRIPTION
Fixes #1654