### PR TITLE
fix: support Marimo notebook carriage return handling

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -21,6 +21,7 @@ except ImportError:
 
 from io import IOBase  # to support unicode strings
 from io import BytesIO
+from unittest import mock
 
 
 class DeprecationError(Exception):
@@ -1969,3 +1970,25 @@ def test_write_stdout_none():
         tqdm.write("test stdout none message")
     finally:
         sys.stdout = orig_stdout
+
+
+def test_marimo_std_newline():
+    """Test std.tqdm uses \\n instead of \\r when marimo is detected"""
+    with mock.patch.dict(sys.modules, {'marimo': mock.MagicMock()}):
+        with closing(StringIO()) as our_file:
+            for _ in tqdm(range(3), file=our_file, ncols=80):
+                pass
+            out = our_file.getvalue()
+            # Should use \n as delimiter, not \r
+            assert '\r\n' not in out  # no \r followed by \n
+            assert out.startswith('\n')  # starts with \n
+
+
+def test_autonotebook_marimo_detection():
+    """Test autonotebook detects marimo module without crashing"""
+    with mock.patch.dict(sys.modules, {'marimo': mock.MagicMock()}):
+        from tqdm import autonotebook
+        tn = autonotebook.tqdm
+        # In test env without ipywidgets, it falls back to std.tqdm
+        from tqdm.std import tqdm as std_tqdm
+        assert tn == std_tqdm

--- a/tqdm/autonotebook.py
+++ b/tqdm/autonotebook.py
@@ -20,6 +20,8 @@ try:
         # jupyter-notebook/jupyterlab/vscode/binder/colab
     elif 'IPython.utils._process_emscripten' in sys.modules:
         pass  # jupyterlite (pyodide)/jupyterlite-xeus
+    elif 'marimo' in sys.modules:
+        pass  # marimo → use notebook tqdm (ipywidgets-compatible)
     else:
         raise ImportError("console")  # ipython/jupyter-console
     from .notebook import WARN_NOIPYW, IProgress

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -454,7 +454,9 @@ class tqdm(Comparable):
 
         def print_status(s):
             len_s = disp_len(s)
-            fp_write('\r' + s + (' ' * max(last_len[0] - len_s, 0)))
+            # Marimo doesn't handle \r; use \n instead so each update gets its own line
+            delim = '\n' if 'marimo' in sys.modules else '\r'
+            fp_write(delim + s + (' ' * max(last_len[0] - len_s, 0)))
             last_len[0] = len_s
 
         return print_status


### PR DESCRIPTION
- Detect Marimo in autonotebook.py and route to notebook tqdm (ipywidgets)
- Fallback fix in std.py status_printer: use \n instead of \r in Marimo to avoid garbled progress bar output

Closes #1728