### PR TITLE
Fix AttributeError on display() for disabled notebook bar (#1587)

### DIFF
--- a/tests/tests_notebook.py
+++ b/tests/tests_notebook.py
@@ -5,3 +5,10 @@ def test_notebook_disabled_description():
     """Test that set_description works for disabled tqdm_notebook"""
     with tqdm_notebook(1, disable=True) as t:
         t.set_description("description")
+
+
+def test_notebook_disabled_display():
+    """Test that display() does not raise for disabled tqdm_notebook"""
+    with tqdm_notebook(total=10, desc="Processing tasks", disable=True) as t:
+        t.display()
+        t.refresh()

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -148,6 +148,10 @@ class tqdm_notebook(std_tqdm):
         # Clear previous output (really necessary?)
         # clear_output(wait=1)
 
+        # A disabled bar has no container to update (see __init__)
+        if self.disable:
+            return
+
         if not msg and not close:
             d = self.format_dict
             # remove {bar}


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s): Fixes #1587

## Root cause

`tqdm.notebook.tqdm_notebook.__init__` early-returns when `disable=True`, **before** `self.container` (and `self.displayed`, `self.disp = self.display`) are set:

```python
super().__init__(*args, **kwargs)
if self.disable or not kwargs['gui']:
    self.disp = lambda *_, **__: None
    return
...
self.container = self.status_printer(...)   # never reached when disabled
```

`display()`, however, unconditionally does `ltext, pbar, rtext = self.container.children`. So calling `display()` directly on a disabled notebook bar raises `AttributeError: 'tqdm_notebook' object has no attribute 'container'`.

Normal iteration never hits this, because the base `tqdm.std` guards every display-driving call (`update`, `refresh`, `close`, …) with `if self.disable: return`. The crash only surfaces on a **direct** external `display()` call.

## Reproduction

```python
from tqdm.auto import tqdm  # resolves to tqdm.notebook in a notebook

pbar = tqdm(total=10, desc="Processing tasks", disable=True)
pbar.display()
```

Observed on `master` (wrong — crashes):

```
File ".../tqdm/notebook.py", line 158, in display
    ltext, pbar, rtext = self.container.children
                         ^^^^^^^^^^^^^^
AttributeError: 'tqdm_notebook' object has no attribute 'container'
```

After this fix (correct — disabled bar is a no-op):

```
# no output, no exception
```

## Fix

Add a single guard at the top of `tqdm_notebook.display()`:

```python
# A disabled bar has no container to update (see __init__)
if self.disable:
    return
```

This mirrors the existing `close()` and `reset()` methods, which already begin with `if self.disable: ...`. It is localized, does not touch `__init__`, and preserves all existing behaviour for enabled bars.

## Tests

Added a focused regression test in `tests/tests_notebook.py` alongside the existing `test_notebook_disabled_description`:

```python
def test_notebook_disabled_display():
    """Test that display() does not raise for disabled tqdm_notebook"""
    with tqdm_notebook(total=10, desc="Processing tasks", disable=True) as t:
        t.display()
        t.refresh()
```

- Fails on unmodified `master` with the exact `AttributeError` above.
- Passes with the fix.
- `tests/tests_notebook.py`, `tests/tests_tqdm.py`, `tests/tests_utils.py`, `tests/tests_itertools.py`, `tests/tests_main.py`, `tests/tests_asyncio.py`, `tests/tests_synchronisation.py`, and `tests/tests_concurrent.py` all pass locally (1 unrelated skip: numpy not installed). `isort` clean.

Disclosure: prepared with AI assistance; reviewed and verified locally.
