### PR TITLE
rich: fix TypeError on iterables without a length

### DIFF
--- a/tests/tests_rich.py
+++ b/tests/tests_rich.py
@@ -1,27 +1,18 @@
 """Test `tqdm.rich`."""
-from contextlib import closing
-from io import StringIO
-
-from pytest import mark
-
-from .tests_tqdm import importorskip
-
-
-def test_rich_import():
-    """Test `tqdm.rich` import"""
-    importorskip('tqdm.rich')
+from pytest import importorskip, mark
 
 
 @mark.filterwarnings("ignore:rich is experimental/alpha:"
                      "tqdm.std.TqdmExperimentalWarning")
-def test_rich_no_total():
+def test_rich_no_total(capsys):
     """Test `tqdm.rich` on an iterable without a length, e.g. a generator"""
     rich = importorskip('tqdm.rich')
-    with closing(StringIO()) as our_file:
-        # a generator has no __len__, so the rich task total stays None
-        with rich.tqdm((i for i in range(5)), file=our_file) as pbar:
-            for _ in pbar:
-                pass
+    with rich.tqdm(i for i in range(5)) as pbar:
+        for _ in pbar:
+            pass
+    out, err = capsys.readouterr()
+    assert not err
+    assert '5/?' in out
 
 
 def test_rich_fraction_column_no_total():

--- a/tests/tests_rich.py
+++ b/tests/tests_rich.py
@@ -1,7 +1,41 @@
 """Test `tqdm.rich`."""
+from contextlib import closing
+from io import StringIO
+
+from pytest import mark
+
 from .tests_tqdm import importorskip
 
 
 def test_rich_import():
     """Test `tqdm.rich` import"""
     importorskip('tqdm.rich')
+
+
+@mark.filterwarnings("ignore:rich is experimental/alpha:"
+                     "tqdm.std.TqdmExperimentalWarning")
+def test_rich_no_total():
+    """Test `tqdm.rich` on an iterable without a length, e.g. a generator"""
+    rich = importorskip('tqdm.rich')
+    with closing(StringIO()) as our_file:
+        # a generator has no __len__, so the rich task total stays None
+        with rich.tqdm((i for i in range(5)), file=our_file) as pbar:
+            for _ in pbar:
+                pass
+
+
+def test_rich_fraction_column_no_total():
+    """Test `FractionColumn` renders a `?` placeholder when total is unknown"""
+    rich = importorskip('tqdm.rich')
+
+    class Task:
+        completed = 5
+        total = None
+
+    assert rich.FractionColumn().render(Task()).plain == "5/? "
+
+    class SizedTask:
+        completed = 3
+        total = 10
+
+    assert rich.FractionColumn().render(SizedTask()).plain == "3/10 "

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -28,18 +28,21 @@ class FractionColumn(ProgressColumn):
     def render(self, task):
         """Calculate common unit for completed and total."""
         completed = int(task.completed)
-        total = int(task.total)
+        # total is None when the iterable has no length (e.g. a generator)
+        total = int(task.total) if task.total is not None else None
+        base = total if total is not None else completed
         if self.unit_scale:
             unit, suffix = filesize.pick_unit_and_suffix(
-                total,
+                base,
                 ["", "K", "M", "G", "T", "P", "E", "Z", "Y"],
                 self.unit_divisor,
             )
         else:
-            unit, suffix = filesize.pick_unit_and_suffix(total, [""], 1)
+            unit, suffix = filesize.pick_unit_and_suffix(base, [""], 1)
         precision = 0 if unit == 1 else 1
+        total_str = f"{total/unit:,.{precision}f}" if total is not None else "?"
         return Text(
-            f"{completed/unit:,.{precision}f}/{total/unit:,.{precision}f} {suffix}",
+            f"{completed/unit:,.{precision}f}/{total_str} {suffix}",
             style="progress.download")
 
 
@@ -124,7 +127,7 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
         pass
 
     def display(self, *_, **__):
-        if not hasattr(self, '_prog'):
+        if not hasattr(self, '_task_id'):
             return
         self._prog.update(self._task_id, completed=self.n, description=self.desc)
 


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s): #1391, #1674

## Bug

`tqdm.rich` crashes on any iterable that has no length:

```python
from tqdm.rich import tqdm

for _ in tqdm(enumerate(range(5))):   # or a generator, Path.glob(...), etc.
    pass
```

```
File "tqdm/rich.py", line 31, in render
    total = int(task.total)
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

rich sets a task's `total` to `None` when the wrapped iterable has no `__len__`, but `FractionColumn.render` called `int(task.total)` unconditionally, so the loop dies before the first render. Reported in #1391.

The failure inside `__init__` also leaves the bar half-built (`_prog` set, `_task_id` not), so the subsequent `__del__` -> `close()` -> `display()` raised a second, confusing `AttributeError: 'tqdm_rich' object has no attribute '_task_id'` (#1674) that masked the real error.

## Fix

- `FractionColumn.render`: when `total` is `None`, use the `completed` count for unit selection and print the total as `?`, mirroring rich's own `DownloadColumn`. Sized iterables render exactly as before.
- `display()`: guard on `_task_id` rather than `_prog`, so an interrupted `__init__` cannot cause a secondary `AttributeError` during cleanup.

## Verification

- `tqdm.rich.tqdm(enumerate(range(5)))` now completes without error; `FractionColumn` renders `5/?` for an unknown total and `1.5/? K` with `unit_scale=True`.
- A known total is unchanged: `FractionColumn().render(task)` still yields `3/10` for `completed=3, total=10`.
- Added regression tests to `tests/tests_rich.py` (fail on the current code, pass with the fix).
- `flake8` clean; full suite green locally (`tests_rich.py` 3 passed, `tests_tqdm.py` 70 passed / 1 skipped for missing numpy).
