### PR TITLE
Preserve console handler filters in logging_redirect_tqdm

### DIFF
--- a/tests/tests_contrib_logging.py
+++ b/tests/tests_contrib_logging.py
@@ -114,6 +114,21 @@ class TestRedirectLoggingToTqdm:
         with logging_redirect_tqdm(loggers=[logger]):
             assert logger.handlers[0].formatter == formatter
 
+    def test_should_inherit_console_handler_filters(self):
+        class SuffixFilter(logging.Filter):
+            def filter(self, record):
+                record.msg = f'{record.msg} -- filter'
+                return True
+
+        logger = logging.Logger('test')
+        console_handler = logging.StreamHandler(sys.stderr)
+        console_handler.addFilter(SuffixFilter())
+        logger.handlers = [console_handler]
+        CustomTqdm.messages = []
+        with logging_redirect_tqdm(loggers=[logger], tqdm_class=CustomTqdm):
+            logger.info('test')
+        assert CustomTqdm.messages == ['test -- filter']
+
     def test_should_not_remove_stream_handlers_not_for_stdout_or_stderr(self):
         logger = logging.Logger('test')
         stream_handler = logging.StreamHandler(StringIO())

--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -87,6 +87,8 @@ def logging_redirect_tqdm(
             if orig_handler is not None:
                 tqdm_handler.setFormatter(orig_handler.formatter)
                 tqdm_handler.stream = orig_handler.stream
+                for log_filter in orig_handler.filters:
+                    tqdm_handler.addFilter(log_filter)
             logger.handlers = [
                 handler for handler in logger.handlers
                 if not _is_console_logging_handler(handler)] + [tqdm_handler]


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [x] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=

Fixes #1581. `logging_redirect_tqdm()` replaced the console handler without its filters, so filtering and record transformations stopped inside the context. The replacement handler now reuses those filters; reproduced on tqdm 4.68.4 with Python 3.14.4 on macOS.
