### PR TITLE
feat(asyncio): add return_exceptions to gather wrapper

### DIFF
--- a/tests/tests_asyncio.py
+++ b/tests/tests_asyncio.py
@@ -124,12 +124,6 @@ async def double(i):
     return i * 2
 
 
-async def raise_exc(i):
-    if i == 1:
-        raise ValueError("test")
-    return i * 2
-
-
 @mark.asyncio
 async def test_gather(capsys):
     """Test asyncio gather"""
@@ -137,6 +131,12 @@ async def test_gather(capsys):
     _, err = capsys.readouterr()
     assert '30/30' in err
     assert res == list(range(0, 30 * 2, 2))
+
+
+async def raise_exc(i):
+    if i == 1:
+        raise ValueError("test")
+    return i * 2
 
 
 @mark.asyncio

--- a/tests/tests_asyncio.py
+++ b/tests/tests_asyncio.py
@@ -124,6 +124,12 @@ async def double(i):
     return i * 2
 
 
+async def raise_exc(i):
+    if i == 1:
+        raise ValueError("test")
+    return i * 2
+
+
 @mark.asyncio
 async def test_gather(capsys):
     """Test asyncio gather"""
@@ -131,3 +137,14 @@ async def test_gather(capsys):
     _, err = capsys.readouterr()
     assert '30/30' in err
     assert res == list(range(0, 30 * 2, 2))
+
+
+@mark.asyncio
+async def test_gather_exceptions(capsys):
+    """Test asyncio gather return_exceptions"""
+    res = await gather(*map(raise_exc, range(3)), return_exceptions=True)
+    _, err = capsys.readouterr()
+    assert '3/3' in err
+    assert isinstance(res[1], ValueError)
+    assert res[0] == 0
+    assert res[2] == 4

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -1,4 +1,4 @@
-"""
+ """
 Asynchronous progress bar decorator for iterators.
 Includes a default `range` iterator printing to `stderr`.
 
@@ -68,12 +68,18 @@ class tqdm_asyncio(std_tqdm):
                        total=total, **tqdm_kwargs)
 
     @classmethod
-    async def gather(cls, *fs, loop=None, timeout=None, total=None, **tqdm_kwargs):
+    async def gather(cls, *fs, loop=None, timeout=None, total=None,
+                     return_exceptions=False, **tqdm_kwargs):
         """
         Wrapper for `asyncio.gather`.
         """
         async def wrap_awaitable(i, f):
-            return i, await f
+            try:
+                return i, await f
+            except Exception as e:  # noqa: BLE001
+                if return_exceptions:
+                    return i, e
+                raise
 
         ifs = [wrap_awaitable(i, f) for i, f in enumerate(fs)]
         res = [await f for f in cls.as_completed(ifs, loop=loop, timeout=timeout,

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -1,4 +1,4 @@
- """
+"""
 Asynchronous progress bar decorator for iterators.
 Includes a default `range` iterator printing to `stderr`.
 

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -68,8 +68,8 @@ class tqdm_asyncio(std_tqdm):
                        total=total, **tqdm_kwargs)
 
     @classmethod
-    async def gather(cls, *fs, loop=None, timeout=None, total=None,
-                     return_exceptions=False, **tqdm_kwargs):
+    async def gather(cls, *fs, loop=None, timeout=None, total=None, return_exceptions=False,
+                     **tqdm_kwargs):
         """
         Wrapper for `asyncio.gather`.
         """


### PR DESCRIPTION
Related to #1286
Add support for return_exceptions param in tqdm.asyncio.gather to match asyncio.gather behaviour, update wrap_awaitable and add test.