### PR TITLE
add `tqdm.concurrent.intepreter_map`

### DIFF
--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -13,6 +13,34 @@ def incr(x):
     return x + 1
 
 
+def check_lock(args):
+    """Check that another interpreter cannot acquire a held tqdm lock."""
+    from os.path import exists
+    from time import sleep
+
+    from tqdm.auto import tqdm
+
+    held, checked, result, role = args
+    lock = tqdm.get_lock()
+    if role == 'holder':
+        with lock, lock:  # also check that the lock is reentrant
+            with open(held, 'w'):
+                pass
+            while not exists(checked):
+                sleep(0.01)
+    else:
+        while not exists(held):
+            sleep(0.01)
+        acquired = lock.acquire(False)
+        if acquired:
+            lock.release()
+        with open(result, 'w') as result_file:
+            result_file.write(str(acquired))
+        with open(checked, 'w'):
+            pass
+    return role
+
+
 def test_thread_map():
     """Test contrib.concurrent.thread_map"""
     with closing(StringIO()) as our_file:
@@ -46,6 +74,21 @@ def test_interpreter_map():
         a = range(9)
         b = [i + 1 for i in a]
         assert interpreter_map(incr, a, file=our_file) == b
+
+
+def test_interpreter_map_lock(tmp_path):
+    """Test interpreter workers share tqdm's write lock"""
+    try:
+        from concurrent.futures import InterpreterPoolExecutor  # NOQA: F401
+    except ImportError as err:
+        skip(str(err))
+    held = str(tmp_path / 'held')
+    checked = str(tmp_path / 'checked')
+    result = tmp_path / 'result'
+    roles = ['holder', 'contender']
+    args = [(held, checked, str(result), role) for role in roles]
+    assert interpreter_map(check_lock, args, max_workers=2, disable=True) == roles
+    assert result.read_text() == 'False'
 
 
 @mark.parametrize("iterables,should_warn", [([], False), (['x'], False), ([()], False),

--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -3,7 +3,7 @@ Tests for `tqdm.contrib.concurrent`.
 """
 from pytest import warns
 
-from tqdm.contrib.concurrent import process_map, thread_map
+from tqdm.contrib.concurrent import interpreter_map, process_map, thread_map
 
 from .tests_tqdm import StringIO, TqdmWarning, closing, importorskip, mark, skip
 
@@ -34,6 +34,18 @@ def test_process_map():
             assert process_map(incr, a, file=our_file) == b
         except ImportError as err:
             skip(str(err))
+
+
+def test_interpreter_map():
+    """Test contrib.concurrent.interpreter_map"""
+    try:
+        from concurrent.futures import InterpreterPoolExecutor  # NOQA: F401
+    except ImportError as err:
+        skip(str(err))
+    with closing(StringIO()) as our_file:
+        a = range(9)
+        b = [i + 1 for i in a]
+        assert interpreter_map(incr, a, file=our_file) == b
 
 
 @mark.parametrize("iterables,should_warn", [([], False), (['x'], False), ([()], False),

--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -1,6 +1,8 @@
 """
 Tests for `tqdm.contrib.concurrent`.
 """
+import sys
+
 from pytest import warns
 
 from tqdm.contrib.concurrent import interpreter_map, process_map, thread_map
@@ -66,10 +68,8 @@ def test_process_map():
 
 def test_interpreter_map():
     """Test contrib.concurrent.interpreter_map"""
-    try:
-        from concurrent.futures import InterpreterPoolExecutor  # NOQA: F401
-    except ImportError as err:
-        skip(str(err))
+    if sys.version_info < (3, 14):
+        skip("requires Python 3.14+")
     with closing(StringIO()) as our_file:
         a = range(9)
         b = [i + 1 for i in a]
@@ -78,10 +78,8 @@ def test_interpreter_map():
 
 def test_interpreter_map_lock(tmp_path):
     """Test interpreter workers share tqdm's write lock"""
-    try:
-        from concurrent.futures import InterpreterPoolExecutor  # NOQA: F401
-    except ImportError as err:
-        skip(str(err))
+    if sys.version_info < (3, 14):
+        skip("requires Python 3.14+")
     held = str(tmp_path / 'held')
     checked = str(tmp_path / 'checked')
     result = tmp_path / 'result'

--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -23,6 +23,7 @@ def check_lock(args):
     from tqdm.auto import tqdm
 
     held, checked, result, role = args
+    assert tqdm.monitor_interval == 0
     lock = tqdm.get_lock()
     if role == 'holder':
         with lock, lock:  # also check that the lock is reentrant

--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -15,8 +15,45 @@ def incr(x):
     return x + 1
 
 
+def test_thread_map():
+    """Test contrib.concurrent.thread_map"""
+    with closing(StringIO()) as our_file:
+        a = range(9)
+        b = [i + 1 for i in a]
+        try:
+            assert thread_map(lambda x: x + 1, a, file=our_file) == b
+        except ImportError as err:
+            skip(str(err))
+        assert thread_map(incr, a, file=our_file) == b
+
+
+@mark.skipif(sys.version_info < (3, 14), reason="requires Python 3.14+")
+def test_interpreter_map(capsys):
+    """Test contrib.concurrent.interpreter_map"""
+    a = range(9)
+    b = [i + 1 for i in a]
+    try:
+        assert interpreter_map(incr, a) == b
+    except ImportError as err:
+        skip(str(err))
+    out, err = capsys.readouterr()
+    assert not out
+    assert '9/9' in err
+
+
+def test_process_map():
+    """Test contrib.concurrent.process_map"""
+    with closing(StringIO()) as our_file:
+        a = range(9)
+        b = [i + 1 for i in a]
+        try:
+            assert process_map(incr, a, file=our_file) == b
+        except ImportError as err:
+            skip(str(err))
+
+
 def check_lock(args):
-    """Check that another interpreter cannot acquire a held tqdm lock."""
+    """Check that another interpreter cannot acquire a held tqdm lock"""
     from os.path import exists
     from time import sleep
 
@@ -44,49 +81,18 @@ def check_lock(args):
     return role
 
 
-def test_thread_map():
-    """Test contrib.concurrent.thread_map"""
-    with closing(StringIO()) as our_file:
-        a = range(9)
-        b = [i + 1 for i in a]
-        try:
-            assert thread_map(lambda x: x + 1, a, file=our_file) == b
-        except ImportError as err:
-            skip(str(err))
-        assert thread_map(incr, a, file=our_file) == b
-
-
-def test_process_map():
-    """Test contrib.concurrent.process_map"""
-    with closing(StringIO()) as our_file:
-        a = range(9)
-        b = [i + 1 for i in a]
-        try:
-            assert process_map(incr, a, file=our_file) == b
-        except ImportError as err:
-            skip(str(err))
-
-
-def test_interpreter_map():
-    """Test contrib.concurrent.interpreter_map"""
-    if sys.version_info < (3, 14):
-        skip("requires Python 3.14+")
-    with closing(StringIO()) as our_file:
-        a = range(9)
-        b = [i + 1 for i in a]
-        assert interpreter_map(incr, a, file=our_file) == b
-
-
+@mark.skipif(sys.version_info < (3, 14), reason="requires Python 3.14+")
 def test_interpreter_map_lock(tmp_path):
     """Test interpreter workers share tqdm's write lock"""
-    if sys.version_info < (3, 14):
-        skip("requires Python 3.14+")
     held = str(tmp_path / 'held')
     checked = str(tmp_path / 'checked')
     result = tmp_path / 'result'
     roles = ['holder', 'contender']
     args = [(held, checked, str(result), role) for role in roles]
-    assert interpreter_map(check_lock, args, max_workers=2, disable=True) == roles
+    try:
+        assert interpreter_map(check_lock, args, max_workers=2, disable=True) == roles
+    except ImportError as err:
+        skip(str(err))
     assert result.read_text() == 'False'
 
 

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -93,6 +93,7 @@ def _get_interpreter_init(tqdm_class, lock_queue_id):
         f"tqdm_class = import_module({tqdm_class.__module__!r})\n"
         f"for name in {tqdm_class.__qualname__.split('.')!r}:\n"
         "    tqdm_class = getattr(tqdm_class, name)\n"
+        "tqdm_class.monitor_interval = 0\n"
         f"tqdm_class.set_lock(_InterpreterLock(interpreters.Queue({lock_queue_id!r})))")
     return exec, (code,)
 

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -4,9 +4,6 @@ Thin wrappers around `concurrent.futures`.
 import sys
 from contextlib import contextmanager
 from operator import length_hint
-from queue import Empty
-from threading import RLock, get_ident
-from time import monotonic
 
 from ..auto import tqdm as tqdm_auto
 from ..std import TqdmWarning
@@ -17,15 +14,19 @@ __all__ = ['thread_map', 'process_map', 'interpreter_map']
 
 class _InterpreterLock:
     """Reentrant lock backed by a cross-interpreter queue."""
+    from threading import get_ident
+    from time import monotonic as _time
 
     def __init__(self, queue):
+        from threading import RLock
         self._queue = queue
         self._lock = RLock()
         self._owner = None
         self._depth = 0
 
     def acquire(self, blocking=True, timeout=-1):
-        start = monotonic()
+        from queue import Empty
+        start = self._time()
         if timeout == -1:
             acquired = self._lock.acquire(blocking)
         else:
@@ -41,17 +42,17 @@ class _InterpreterLock:
             elif timeout == -1:
                 self._queue.get()
             else:
-                remaining = max(0, timeout - (monotonic() - start))
+                remaining = max(0, timeout - (self._time() - start))
                 self._queue.get(timeout=remaining)
         except Empty:
             self._lock.release()
             return False
-        self._owner = get_ident()
+        self._owner = self.get_ident()
         self._depth = 1
         return True
 
     def release(self):
-        if self._owner != get_ident():
+        if self._owner != self.get_ident():
             raise RuntimeError("cannot release un-acquired lock")
         self._depth -= 1
         if not self._depth:

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -3,6 +3,9 @@ Thin wrappers around `concurrent.futures`.
 """
 from contextlib import contextmanager
 from operator import length_hint
+from queue import Empty
+from threading import RLock, get_ident
+from time import monotonic
 
 from ..auto import tqdm as tqdm_auto
 from ..std import TqdmWarning
@@ -11,11 +14,64 @@ __author__ = {"github.com/": ["casperdcl"]}
 __all__ = ['thread_map', 'process_map', 'interpreter_map']
 
 
+class _InterpreterLock:
+    """Reentrant lock backed by a cross-interpreter queue."""
+
+    def __init__(self, queue):
+        self._queue = queue
+        self._lock = RLock()
+        self._owner = None
+        self._depth = 0
+
+    def acquire(self, blocking=True, timeout=-1):
+        start = monotonic()
+        if timeout == -1:
+            acquired = self._lock.acquire(blocking)
+        else:
+            acquired = self._lock.acquire(blocking, timeout)
+        if not acquired:
+            return False
+        if self._depth:
+            self._depth += 1
+            return True
+        try:
+            if not blocking:
+                self._queue.get_nowait()
+            elif timeout == -1:
+                self._queue.get()
+            else:
+                remaining = max(0, timeout - (monotonic() - start))
+                self._queue.get(timeout=remaining)
+        except Empty:
+            self._lock.release()
+            return False
+        self._owner = get_ident()
+        self._depth = 1
+        return True
+
+    def release(self):
+        if self._owner != get_ident():
+            raise RuntimeError("cannot release un-acquired lock")
+        self._depth -= 1
+        if not self._depth:
+            self._owner = None
+            self._queue.put(None)
+        self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc):
+        self.release()
+
+
 @contextmanager
-def ensure_lock(tqdm_class, lock_name=""):
+def ensure_lock(tqdm_class, lock_name="", lock=None):
     """get (create if necessary) and then restore `tqdm_class`'s lock"""
     old_lock = getattr(tqdm_class, '_lock', None)  # don't create a new lock
-    lock = old_lock or tqdm_class.get_lock()  # maybe create a new lock
+    if lock is None:
+        lock = old_lock or tqdm_class.get_lock()  # maybe create a new lock
     lock = getattr(lock, lock_name, lock)  # maybe subtype
     tqdm_class.set_lock(lock)
     yield lock
@@ -25,6 +81,12 @@ def ensure_lock(tqdm_class, lock_name=""):
         tqdm_class.set_lock(old_lock)
 
 
+def _set_interpreter_lock(tqdm_class, lock_queue_id):
+    """Install an interpreter-local lock backed by a shared queue."""
+    from concurrent import interpreters
+    tqdm_class.set_lock(_InterpreterLock(interpreters.Queue(lock_queue_id)))
+
+
 def _min_map_len(iterables):
     """min(map(length_hint, iterables))"""
     return min(n for it in iterables if (n := length_hint(it, -1)) >= 0)
@@ -32,7 +94,8 @@ def _min_map_len(iterables):
 
 def _executor_map(
     PoolExecutor, fn, *iterables, max_workers=None, timeout=None, chunksize=1, lock_name="",
-    tqdm_class=tqdm_auto, smoothing=0.0, _share_lock=True, **tqdm_kwargs
+    tqdm_class=tqdm_auto, smoothing=0.0, _lock=None, _initializer=None, _initargs=None,
+    **tqdm_kwargs
 ):
     """
     Implementation of `thread_map`, `process_map` and `interpreter_map`.
@@ -68,11 +131,13 @@ def _executor_map(
         if kwargs['total'] > rough_max:
             kwargs['miniters'] = rough_max
             dynamic_miniters = True
-    with ensure_lock(tqdm_class, lock_name=lock_name) as lk:
-        if _share_lock:
-            # share lock in case workers are already using `tqdm`
-            pool_kwargs.update(initializer=tqdm_class.set_lock, initargs=(lk,))
-        with PoolExecutor(max_workers=max_workers, **pool_kwargs) as ex:
+    with ensure_lock(tqdm_class, lock_name=lock_name, lock=_lock) as lk:
+        # share lock in case workers are already using `tqdm`
+        if _initializer is None:
+            _initializer = tqdm_class.set_lock
+            _initargs = (lk,)
+        with PoolExecutor(max_workers=max_workers, initializer=_initializer, initargs=_initargs,
+                          **pool_kwargs) as ex:
             with tqdm_class(smoothing=smoothing, **kwargs) as pbar:
                 if dynamic_miniters is not None:
                     pbar.dynamic_miniters = True
@@ -126,10 +191,16 @@ def interpreter_map(fn, *iterables, **tqdm_kwargs):
     Notes
     -----
     `fn`, its arguments, and its return values must be pickleable.
+    Worker progress bars using the same `tqdm_class` share a cross-interpreter write lock.
     """
+    from concurrent import interpreters
     from concurrent.futures import InterpreterPoolExecutor
-    return _executor_map(InterpreterPoolExecutor, fn, *iterables, _share_lock=False,
-                         **tqdm_kwargs)
+    lock_queue = interpreters.create_queue()
+    lock_queue.put(None)
+    tqdm_class = tqdm_kwargs.get("tqdm_class", tqdm_auto)
+    return _executor_map(
+        InterpreterPoolExecutor, fn, *iterables, _lock=_InterpreterLock(lock_queue),
+        _initializer=_set_interpreter_lock, _initargs=(tqdm_class, lock_queue.id), **tqdm_kwargs)
 
 
 def process_map(fn, *iterables, lock_name="mp_lock", **tqdm_kwargs):

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -8,7 +8,7 @@ from ..auto import tqdm as tqdm_auto
 from ..std import TqdmWarning
 
 __author__ = {"github.com/": ["casperdcl"]}
-__all__ = ['thread_map', 'process_map']
+__all__ = ['thread_map', 'process_map', 'interpreter_map']
 
 
 @contextmanager
@@ -32,10 +32,10 @@ def _min_map_len(iterables):
 
 def _executor_map(
     PoolExecutor, fn, *iterables, max_workers=None, timeout=None, chunksize=1, lock_name="",
-    tqdm_class=tqdm_auto, smoothing=0.0, **tqdm_kwargs
+    tqdm_class=tqdm_auto, smoothing=0.0, _share_lock=True, **tqdm_kwargs
 ):
     """
-    Implementation of `thread_map` and `process_map`.
+    Implementation of `thread_map`, `process_map` and `interpreter_map`.
 
     Parameters
     ----------
@@ -69,9 +69,10 @@ def _executor_map(
             kwargs['miniters'] = rough_max
             dynamic_miniters = True
     with ensure_lock(tqdm_class, lock_name=lock_name) as lk:
-        # share lock in case workers are already using `tqdm`
-        with PoolExecutor(max_workers=max_workers, initializer=tqdm_class.set_lock,
-                          initargs=(lk,), **pool_kwargs) as ex:
+        if _share_lock:
+            # share lock in case workers are already using `tqdm`
+            pool_kwargs.update(initializer=tqdm_class.set_lock, initargs=(lk,))
+        with PoolExecutor(max_workers=max_workers, **pool_kwargs) as ex:
             with tqdm_class(smoothing=smoothing, **kwargs) as pbar:
                 if dynamic_miniters is not None:
                     pbar.dynamic_miniters = True
@@ -107,10 +108,28 @@ def thread_map(fn, *iterables, **tqdm_kwargs):
     smoothing  : float, optional
         Passed to `tqdm_class`; the [default: 0] is average (due to erratic update frequency).
     lock_name  : str, optional
-        Member of `tqdm_class.get_lock()` to use [default: mp_lock].
+        Member of `tqdm_class.get_lock()` to use [default: ''].
     """
     from concurrent.futures import ThreadPoolExecutor
     return _executor_map(ThreadPoolExecutor, fn, *iterables, **tqdm_kwargs)
+
+
+def interpreter_map(fn, *iterables, **tqdm_kwargs):
+    """
+    Equivalent of `list(map(fn, *iterables))`
+    driven by `concurrent.futures.InterpreterPoolExecutor` (Python 3.14+).
+
+    Parameters
+    ----------
+    Same as `thread_map`.
+
+    Notes
+    -----
+    `fn`, its arguments, and its return values must be pickleable.
+    """
+    from concurrent.futures import InterpreterPoolExecutor
+    return _executor_map(InterpreterPoolExecutor, fn, *iterables, _share_lock=False,
+                         **tqdm_kwargs)
 
 
 def process_map(fn, *iterables, lock_name="mp_lock", **tqdm_kwargs):

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -1,6 +1,7 @@
 """
 Thin wrappers around `concurrent.futures`.
 """
+import sys
 from contextlib import contextmanager
 from operator import length_hint
 from queue import Empty
@@ -81,10 +82,19 @@ def ensure_lock(tqdm_class, lock_name="", lock=None):
         tqdm_class.set_lock(old_lock)
 
 
-def _set_interpreter_lock(tqdm_class, lock_queue_id):
-    """Install an interpreter-local lock backed by a shared queue."""
-    from concurrent import interpreters
-    tqdm_class.set_lock(_InterpreterLock(interpreters.Queue(lock_queue_id)))
+def _get_interpreter_init(tqdm_class, lock_queue_id):
+    """Return an initializer which bootstraps the parent import path and lock."""
+    code = (
+        "import sys\n"
+        f"sys.path[:] = {sys.path!r}\n"
+        "from concurrent import interpreters\n"
+        "from importlib import import_module\n"
+        "from tqdm.contrib.concurrent import _InterpreterLock\n"
+        f"tqdm_class = import_module({tqdm_class.__module__!r})\n"
+        f"for name in {tqdm_class.__qualname__.split('.')!r}:\n"
+        "    tqdm_class = getattr(tqdm_class, name)\n"
+        f"tqdm_class.set_lock(_InterpreterLock(interpreters.Queue({lock_queue_id!r})))")
+    return exec, (code,)
 
 
 def _min_map_len(iterables):
@@ -198,9 +208,10 @@ def interpreter_map(fn, *iterables, **tqdm_kwargs):
     lock_queue = interpreters.create_queue()
     lock_queue.put(None)
     tqdm_class = tqdm_kwargs.get("tqdm_class", tqdm_auto)
+    initializer, initargs = _get_interpreter_init(tqdm_class, lock_queue.id)
     return _executor_map(
         InterpreterPoolExecutor, fn, *iterables, _lock=_InterpreterLock(lock_queue),
-        _initializer=_set_interpreter_lock, _initargs=(tqdm_class, lock_queue.id), **tqdm_kwargs)
+        _initializer=initializer, _initargs=initargs, **tqdm_kwargs)
 
 
 def process_map(fn, *iterables, lock_name="mp_lock", **tqdm_kwargs):


### PR DESCRIPTION
Python 3.14 adds an [InterpreterPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.InterpreterPoolExecutor) - this PR adds `interpreter_map` that uses it. The `InterpreterPoolExecutor` import is lazy so that `tqdm.concurrent.futures` can still be imported in older Python versions.

