### PR TITLE
Fix AttributeError in close() when __init__ fails before last_print_t is set

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1270,8 +1270,6 @@ class tqdm(Comparable):
 
     def close(self):
         """Cleanup and (if leave=False) close the progress bar."""
-        # guard against partially-initialised instances (e.g. __init__ failed,
-        # or __del__ triggered by GC before init completed). See GH #1668.
         if getattr(self, 'disable', True):
             return
 
@@ -1283,7 +1281,6 @@ class tqdm(Comparable):
         self._decr_instances(self)
 
         if not hasattr(self, 'last_print_t'):
-            # __init__ did not reach the time-counter initialisation
             return
         if self.last_print_t < self.start_t + self.delay:
             # haven't ever displayed; nothing to clear

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -1270,7 +1270,9 @@ class tqdm(Comparable):
 
     def close(self):
         """Cleanup and (if leave=False) close the progress bar."""
-        if self.disable:
+        # guard against partially-initialised instances (e.g. __init__ failed,
+        # or __del__ triggered by GC before init completed). See GH #1668.
+        if getattr(self, 'disable', True):
             return
 
         # Prevent multiple closures
@@ -1280,6 +1282,9 @@ class tqdm(Comparable):
         pos = abs(self.pos)
         self._decr_instances(self)
 
+        if not hasattr(self, 'last_print_t'):
+            # __init__ did not reach the time-counter initialisation
+            return
         if self.last_print_t < self.start_t + self.delay:
             # haven't ever displayed; nothing to clear
             return


### PR DESCRIPTION
Fixes #1668 (also relates to #1537, #261).

## Problem

When `tqdm.__init__` fails partway through (e.g. `self.refresh()` at the end of `__init__` raises an I/O error) and the object is subsequently garbage-collected, `__del__` calls `self.close()`, which accesses `self.last_print_t` — an attribute set only at the very end of `__init__`. If `__init__` did not reach that point, `close()` raises:

```
AttributeError: 'tqdm_asyncio' object has no attribute 'last_print_t'
```

This is especially visible with `tqdm_asyncio` (which inherits `close()` from `tqdm.std.tqdm`) when the asyncio event loop or file handle is in an unexpected state during construction.

## Fix

Add two defensive guards in `close()`:

1. Replace `if self.disable:` with `if getattr(self, 'disable', True):` — handles the case where `__init__` failed so early that `disable` was never set. Defaults to `True` (treat as already-closed → return).

2. Add `if not hasattr(self, 'last_print_t'): return` before the `self.last_print_t < ...` comparison — handles the case where `__init__` progressed past the `disable` assignment but failed before the time-counter initialisation.

Both guards are pure safety-nets with **zero behaviour change on the happy path** (fully-initialised instances always have both attributes). The `hasattr` pattern is already used in `display()` (line 1496: `if not hasattr(self, "sp")`), so this is consistent with existing conventions.

## Testing

- Reproduced the original crash with a mock object simulating partial `__init__`.
- Verified the patched `close()` handles partial init, very-early init failure, and the normal happy path without regression.
- `python -m py_compile tqdm/std.py` passes.