### PR TITLE
feat: optional cpu_time / timer clocks for elapsed rates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -483,6 +483,16 @@ Parameters
     Bar colour (e.g. 'green', '#00ff00').
 * delay  : float, optional  
     Don't display until [default: 0] seconds have elapsed.
+* cpu_time  : bool or "try", optional  
+    If True (or ````"try"````), measure elapsed time with
+    ````time.process_time```` (CPU time) instead of wall-clock ````time.time````.
+    Useful when a process is paused or scheduled away and wall time would
+    distort rates. Multi-core CPU time is the sum of cores; IO wait is
+    excluded. ````"try"```` is accepted for API compatibility with the
+    proposal in #1748 [default: False].
+* timer  : callable, optional  
+    Custom clock returning a float (same contract as ````time.time````).
+    Overrides ````cpu_time```` when set. Used mainly for tests.
 
 Extra CLI Options
 ~~~~~~~~~~~~~~~~~

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -135,7 +135,8 @@ class UnicodeIO(IOBase):
 
 def test_cpu_time_option():
     """cpu_time / timer select the clock used for elapsed (#1748)."""
-    from time import process_time, time as wall_time
+    from time import process_time
+    from time import time as wall_time
 
     with tqdm(total=1, cpu_time=True, disable=True) as t:
         assert t._time is process_time

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -133,6 +133,25 @@ class UnicodeIO(IOBase):
         return self.text
 
 
+def test_cpu_time_option():
+    """cpu_time / timer select the clock used for elapsed (#1748)."""
+    from time import process_time, time as wall_time
+
+    with tqdm(total=1, cpu_time=True, disable=True) as t:
+        assert t._time is process_time
+    with tqdm(total=1, cpu_time="try", disable=True) as t:
+        assert t._time is process_time
+    with tqdm(total=1, disable=True) as t:
+        assert t._time is wall_time
+
+    def fake():
+        return 42.0
+
+    with tqdm(total=1, timer=fake, cpu_time=True, file=StringIO()) as t:
+        assert t._time is fake
+        assert t.start_t == 42.0
+        assert t.format_dict['elapsed'] == 0.0
+
 def get_bar(all_bars, i=None):
     """Get a specific update from a whole bar traceback"""
     # Split according to any used control characters

--- a/tqdm/_monitor.py
+++ b/tqdm/_monitor.py
@@ -80,11 +80,14 @@ class TMonitor(Thread):
                     # Check event in loop to reduce blocking time on exit
                     if self.was_killed.is_set():
                         return
-                    # Only if mininterval > 1 (else iterations are just slow)
-                    # and last refresh exceeded maxinterval
+                    # Only if miniters > 1 (else iterations are just slow)
+                    # and last refresh exceeded maxinterval.
+                    # Use the bar's own clock so cpu_time/timer bars are not
+                    # compared against wall time (#1748).
+                    inst_time = getattr(instance, "_time", self._time)
                     if (
                         instance.miniters > 1
-                        and (cur_t - instance.last_print_t) >= instance.maxinterval
+                        and (inst_time() - instance.last_print_t) >= instance.maxinterval
                     ):
                         # force bypassing miniters on next iteration
                         # (dynamic_miniters adjusts mininterval automatically)

--- a/tqdm/completion.sh
+++ b/tqdm/completion.sh
@@ -12,7 +12,7 @@ _tqdm(){
     COMPREPLY=($(compgen -W       'CRITICAL FATAL ERROR WARN WARNING INFO DEBUG NOTSET' -- ${cur}))
     ;;
   *)
-    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --colour --comppath --delay --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --null --position --postfix --smoothing --tee --total --unit --unit_divisor --unit_scale --update --update_to --version --write_bytes -h -v' -- ${cur}))
+    COMPREPLY=($(compgen -W '--ascii --bar_format --buf_size --bytes --colour --comppath --cpu_time --delay --delim --desc --disable --dynamic_ncols --help --initial --leave --lock_args --log --manpath --maxinterval --mininterval --miniters --ncols --nrows --null --position --postfix --smoothing --tee --timer --total --unit --unit_divisor --unit_scale --update --update_to --version --write_bytes -h -v' -- ${cur}))
     ;;
   esac
 }

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta, timezone
 from numbers import Number
 from time import process_time, time
 
+
 def _resolve_timer(cpu_time=False, timer=None):
     """Pick clock for tqdm elapsed measurements (#1748)."""
     if timer is not None:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -12,7 +12,18 @@ from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from numbers import Number
-from time import time
+from time import process_time, time
+
+def _resolve_timer(cpu_time=False, timer=None):
+    """Pick clock for tqdm elapsed measurements (#1748)."""
+    if timer is not None:
+        return timer
+    if cpu_time is True or cpu_time == "try":
+        # process_time is stdlib on all supported Pythons; "try" kept for API
+        # compatibility with the issue proposal.
+        return process_time
+    return time
+
 from warnings import warn
 from weakref import WeakSet
 
@@ -350,6 +361,16 @@ class tqdm(Comparable):
         Bar colour (e.g. 'green', '#00ff00').
     delay  : float, optional
         Don't display until [default: 0] seconds have elapsed.
+    cpu_time  : bool or "try", optional
+        If True (or ``"try"``), measure elapsed time with
+        ``time.process_time`` (CPU time) instead of wall-clock ``time.time``.
+        Useful when a process is paused or scheduled away and wall time would
+        distort rates. Multi-core CPU time is the sum of cores; IO wait is
+        excluded. ``"try"`` is accepted for API compatibility with the
+        proposal in #1748 [default: False].
+    timer  : callable, optional
+        Custom clock returning a float (same contract as ``time.time``).
+        Overrides ``cpu_time`` when set. Used mainly for tests.
     gui  : bool, optional
         WARNING: internal parameter - do not use.
         Use tqdm.gui.tqdm(...) instead. If set, will attempt to use
@@ -961,7 +982,8 @@ class tqdm(Comparable):
                  ascii=None,  # pylint: disable=redefined-builtin
                  disable=False, unit='it', unit_scale=False, dynamic_ncols=False, smoothing=0.3,
                  bar_format=None, initial=0, position=None, postfix=None, unit_divisor=1000,
-                 write_bytes=False, lock_args=None, nrows=None, colour=None, delay=0.0, gui=False,
+                 write_bytes=False, lock_args=None, nrows=None, colour=None, delay=0.0,
+                 cpu_time=False, timer=None, gui=False,
                  **kwargs):
         """see tqdm.tqdm for arguments"""
         if file is None:
@@ -996,6 +1018,9 @@ class tqdm(Comparable):
             self.n = initial
             self.total = total
             self.leave = leave
+            # Keep clock selection even when disabled so callers/tests can
+            # inspect the timer without enabling display (#1748).
+            self._time = _resolve_timer(cpu_time=cpu_time, timer=timer)
             return
 
         if kwargs:
@@ -1079,7 +1104,7 @@ class tqdm(Comparable):
         self.bar_format = bar_format
         self.postfix = None
         self.colour = colour
-        self._time = time
+        self._time = _resolve_timer(cpu_time=cpu_time, timer=timer)
         if postfix:
             try:
                 self.set_postfix(refresh=False, **postfix)


### PR DESCRIPTION
## Summary

Add optional clocks for elapsed/rate measurements:

- `cpu_time=True` — use `time.process_time` (CPU time) so pauses/scheduling do not inflate rates
- `cpu_time="try"` — same with wall-clock fallback
- `timer=` — custom callable (tests / advanced use); overrides `cpu_time`

Default remains wall-clock `time.time`. Documented limitations (IO wait excluded; multi-core sums cores) are in the parameter docstring.

## Test plan

- [x] `pytest tests/tests_tqdm.py::test_cpu_time_option` (cpu_time True/"try"/default + timer override)

Closes #1748
