### PR TITLE
docs: Fix word order 'can be also used' -> 'can also be used'

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -23,7 +23,7 @@ iterable with ``tqdm(iterable)``, and you're done!
 
 ``76%|████████████████████████        | 7568/10000 [00:33<00:10, 229.00it/s]``
 
-``trange(N)`` can be also used as a convenient shortcut for
+``trange(N)`` can also be used as a convenient shortcut for
 ``tqdm(range(N))``.
 
 |Screenshot|

--- a/DEMO.ipynb
+++ b/DEMO.ipynb
@@ -39,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`trange(N)` can be also used as a convenient shortcut for\n",
+    "`trange(N)` can also be used as a convenient shortcut for\n",
     "`tqdm(range(N))`."
    ]
   },

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ iterable with ``tqdm(iterable)``, and you're done!
 
 ``76%|████████████████████████        | 7568/10000 [00:33<00:10, 229.00it/s]``
 
-``trange(N)`` can be also used as a convenient shortcut for
+``trange(N)`` can also be used as a convenient shortcut for
 ``tqdm(range(N))``.
 
 |Screenshot|


### PR DESCRIPTION
Fixes awkward word order ("can be also used" -> "can also be used") in the main README.