### PR TITLE
Fix format_meter OverflowError when total is inf

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -213,6 +213,8 @@ def test_format_meter():
     assert format_meter(231, 1000, 392) == (" 23%|" + unich(0x2588) * 2 + unich(0x258e) +
                                             "       | 231/1000 [06:32<21:44,  1.70s/it]")
     assert format_meter(10000, 1000, 13) == "10000it [00:13, 769.23it/s]"
+    # total=inf behaves the same as unknown total (#651) instead of crashing
+    assert format_meter(5, float("inf"), 1) == format_meter(5, None, 1)
     assert format_meter(231, 1000, 392, ncols=56, ascii=True) == " 23%|" + '#' * 3 + '6' + (
         "            | 231/1000 [06:32<21:44,  1.70s/it]")
     assert format_meter(100000, 1000, 13, unit_scale=True,

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -213,7 +213,6 @@ def test_format_meter():
     assert format_meter(231, 1000, 392) == (" 23%|" + unich(0x2588) * 2 + unich(0x258e) +
                                             "       | 231/1000 [06:32<21:44,  1.70s/it]")
     assert format_meter(10000, 1000, 13) == "10000it [00:13, 769.23it/s]"
-    # total=inf behaves the same as unknown total (#651) instead of crashing
     assert format_meter(5, float("inf"), 1) == format_meter(5, None, 1)
     assert format_meter(231, 1000, 392, ncols=56, ascii=True) == " 23%|" + '#' * 3 + '6' + (
         "            | 231/1000 [06:32<21:44,  1.70s/it]")

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -530,10 +530,8 @@ class tqdm(Comparable):
         """
 
         # sanity check: total
-        if total == float("inf"):
-            # infinite total: behave the same as unknown total (#651)
-            total = None
-        elif total and n >= (total + 0.5):  # allow float imprecision (#849)
+        if total and (n >= (total + 0.5) or total == float("inf")):
+            # allow float imprecision (#849) or inf (#651)
             total = None
 
         # apply custom scale if necessary

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -530,7 +530,10 @@ class tqdm(Comparable):
         """
 
         # sanity check: total
-        if total and n >= (total + 0.5):  # allow float imprecision (#849)
+        if total == float("inf"):
+            # infinite total: behave the same as unknown total (#651)
+            total = None
+        elif total and n >= (total + 0.5):  # allow float imprecision (#849)
             total = None
 
         # apply custom scale if necessary


### PR DESCRIPTION
`tqdm.format_meter` crashes when `total` is `float('inf')`:

```python
>>> from tqdm.std import tqdm
>>> tqdm.format_meter(5, float('inf'), 1)
OverflowError: cannot convert float infinity to integer
```

With an infinite total the remaining time is computed as `inf`, and `format_interval(inf)` then does `int(inf)` and raises.

The `tqdm` class already handles this by treating an infinite total the same as an unknown total, and `total=float('inf')` is a documented feature. This makes the public `format_meter` static method consistent: an infinite total is treated as unknown, so it no longer crashes and returns the same output as `total=None`.

Added a regression assertion in `test_format_meter`. Existing format tests pass locally.