### PR TITLE
fix(packaging): exclude images/ from wheel build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,10 +16,17 @@ jobs:
     - uses: actions/checkout@v7
     - uses: actions/setup-python@v6
       with: {python-version: '3.x'}
-    - run: pip install 'tox>=4'
+    - run: pip install 'tox>=4' build
     - run: tox
       env:
         TOXENV: ${{ matrix.TOXENV }}
+    - name: wheel size < 100kB
+      run: |
+        # millions of daily downloads so can't afford package bloat
+        python -m build -w
+        s=$(du -sb dist/*.whl | cut -f1)
+        echo wheel size: $s
+        (( $s < 102400 ))
   asvfull:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || github.event_name == 'schedule'
     name: Benchmark (Full)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 
 [tool.setuptools.packages.find]
-exclude = ["benchmarks", "examples", "tests", "wiki", "docs", "feedstock"]
+where = ["."]
+include = ["tqdm"]
 
 [project.urls]
 homepage = "https://tqdm.github.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 
 [tool.setuptools.packages.find]
-where = ["."]
-include = ["tqdm"]
+include = ["tqdm", "tqdm.*"]
 
 [project.urls]
 homepage = "https://tqdm.github.io"


### PR DESCRIPTION
The published wheel ships the repo's root-level `images/` directory
(`images/logo.gif`, `images/tqdm.gif` assets) as an
installed top-level package alongside `tqdm`:

This broke in version 4.68.4, introduced by the
migration of packaging config to `pyproject.toml`. 

```
$ unzip -l tqdm-4.68.4-py3-none-any.whl | grep images
38894  images/logo.gif
592063  images/tqdm.gif
```

Switches from an exclude-list to an include-allowlist scoped to tqdm only. Wheel size drops from 660.2 KB to 77.5 KB (-88.3%, 582.7 KB saved).
