### PR TITLE
Fix reset() in the tk, notebook and rich subclasses

### DIFF
--- a/tests/tests_notebook.py
+++ b/tests/tests_notebook.py
@@ -1,7 +1,21 @@
 from tqdm.notebook import tqdm as tqdm_notebook
 
+from .tests_tqdm import importorskip
+
 
 def test_notebook_disabled_description():
     """Test that set_description works for disabled tqdm_notebook"""
     with tqdm_notebook(1, disable=True) as t:
         t.set_description("description")
+
+
+def test_notebook_reset_inf_total():
+    """Test that reset(total=inf) gives an info style bar, as in __init__"""
+    importorskip('ipywidgets')
+    with tqdm_notebook(total=10) as t:
+        t.reset(total=float("inf"))
+        assert t.total is None
+        _, pbar, _ = t.container.children
+        assert pbar.max == 1
+        assert pbar.bar_style == 'info'
+        assert pbar.layout.width == "20px"

--- a/tests/tests_rich.py
+++ b/tests/tests_rich.py
@@ -15,6 +15,24 @@ def test_rich_no_total(capsys):
     assert '5/?' in out
 
 
+@mark.filterwarnings("ignore:rich is experimental/alpha:"
+                     "tqdm.std.TqdmExperimentalWarning")
+def test_rich_reset():
+    """Test `tqdm.rich` reset(), including `total=inf` meaning unknown"""
+    rich = importorskip('tqdm.rich')
+    with rich.tqdm(total=10, desc="desc") as pbar:
+        pbar.update(5)
+        pbar.reset(total=20)
+        task = pbar._prog.tasks[0]
+        assert (pbar.total, task.total, task.completed) == (20, 20, 0)
+
+        pbar.reset(total=float("inf"))
+        task = pbar._prog.tasks[0]
+        assert pbar.total is None
+        assert task.total is None  # indeterminate, as in `__init__`
+        assert task.description == "desc"
+
+
 def test_rich_fraction_column_no_total():
     """Test `FractionColumn` renders a `?` placeholder when total is unknown"""
     rich = importorskip('tqdm.rich')

--- a/tests/tests_tk.py
+++ b/tests/tests_tk.py
@@ -1,7 +1,25 @@
 """Test `tqdm.tk`."""
-from .tests_tqdm import importorskip
+import os
+import sys
+
+from .tests_tqdm import importorskip, mark, skip
 
 
 def test_tk_import():
     """Test `tqdm.tk` import"""
     importorskip('tqdm.tk')
+
+
+@mark.filterwarnings("ignore:GUI is experimental/alpha:"
+                     "tqdm.std.TqdmExperimentalWarning")
+def test_tk_reset_inf_total():
+    """Test `tqdm.tk` `reset(total=inf)` gives an indeterminate bar"""
+    tk = importorskip('tqdm.tk')
+    if sys.platform.startswith("linux") and not os.environ.get("DISPLAY"):
+        skip("no DISPLAY")
+
+    with tk.tqdm(total=10) as t:
+        t.reset(total=float("inf"))
+        assert t.total is None
+        assert t._tk_pbar['maximum'] == 100
+        assert str(t._tk_pbar['mode']) == "indeterminate"

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -301,9 +301,15 @@ class tqdm_notebook(std_tqdm):
         _, pbar, _ = self.container.children
         pbar.bar_style = ''
         if total is not None:
-            pbar.max = total
-            if not self.total and self.ncols is None:  # no longer unknown total
-                pbar.layout.width = None  # reset width
+            if self._norm_total(total) is None:  # unknown total: info style bar
+                pbar.max = 1
+                pbar.bar_style = 'info'
+                if self.ncols is None:
+                    pbar.layout.width = "20px"
+            else:
+                pbar.max = total
+                if not self.total and self.ncols is None:  # no longer unknown total
+                    pbar.layout.width = None  # reset width
         return super().reset(total=total)
 
 

--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -139,9 +139,14 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
         ----------
         total  : int or float, optional. Total to use for the new bar.
         """
-        if hasattr(self, '_prog'):
-            self._prog.reset(total=total)
         super().reset(total=total)
+        if hasattr(self, '_prog'):
+            if self.total is None:
+                # `rich` cannot un-set a total, so replace the task as in `__init__`
+                self._prog.remove_task(self._task_id)
+                self._task_id = self._prog.add_task(self.desc or "", **self.format_dict)
+            else:
+                self._prog.reset(self._task_id, total=self.total)
 
 
 def trrange(*args, **kwargs):

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -984,8 +984,7 @@ class tqdm(Comparable):
                 total = len(iterable)
             except (TypeError, AttributeError):
                 total = None
-        if total == float("inf"):
-            total = None  # same as unknown
+        total = self._norm_total(total)
 
         if disable:
             self.iterable = iterable
@@ -1365,6 +1364,11 @@ class tqdm(Comparable):
         self.start_t += cur_t - self.last_print_t
         self.last_print_t = cur_t
 
+    @staticmethod
+    def _norm_total(total):
+        """`float("inf")` behaves the same as unknown (#651)."""
+        return None if total == float("inf") else total
+
     def reset(self, total=None):
         """
         Resets to 0 iterations for repeated use.
@@ -1377,7 +1381,7 @@ class tqdm(Comparable):
         """
         self.n = 0
         if total is not None:
-            self.total = None if total == float("inf") else total
+            self.total = self._norm_total(total)
         if self.disable:
             return
         self.last_print_n = 0

--- a/tqdm/tk.py
+++ b/tqdm/tk.py
@@ -168,7 +168,7 @@ class tqdm_tk(std_tqdm):  # pragma: no cover
         total  : int or float, optional. Total to use for the new bar.
         """
         if hasattr(self, '_tk_pbar'):
-            if total is None:
+            if self._norm_total(total) is None:
                 self._tk_pbar.configure(maximum=100, mode="indeterminate")
             else:
                 self._tk_pbar.configure(maximum=total, mode="determinate")


### PR DESCRIPTION
Follow-up to #1783 — you suggested checking the subclasses, and there were two problems.

`tqdm.rich.tqdm.reset()` called rich's `Progress.reset(total=...)` without a `task_id`, so it raised `TypeError` for any total, `inf` or not.

`tk`, `notebook` and `rich` also configured their widget from the raw `total`, so `reset(total=inf)` gave `maximum=inf` + determinate mode (tk), `pbar.max=inf` (notebook) and a determinate task (rich), while `self.total` became `None`. `__init__(total=inf)` gives an indeterminate/info bar, so `reset` now ends up in the same state.

The `inf`-means-unknown rule is now a single `_norm_total()` in `std`, used by `__init__`/`reset` and the subclasses. For rich, `Progress.reset()`/`update()` can't un-set a total, so the task is replaced the way `__init__` creates it.

Each test fails on master and passes with the change; full suite 156 passed / 7 skipped vs 153 / 7 before.
