### PR TITLE
tests: skip test_pipes when ls is unavailable

### DIFF
--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -32,6 +32,7 @@ def norm(bytestr):
 
 
 @mark.slow
+@mark.skipif(IS_WIN, reason="no ls on windows")
 def test_pipes():
     """Test command line pipes"""
     ls_out = subprocess.check_output(['ls'])  # nosec

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -1,5 +1,6 @@
 """Test CLI usage."""
 import logging
+import shutil
 import subprocess  # nosec
 import sys
 from functools import wraps
@@ -32,7 +33,7 @@ def norm(bytestr):
 
 
 @mark.slow
-@mark.skipif(IS_WIN, reason="no ls on windows")
+@mark.skipif(shutil.which("ls") is None, reason="requires ls on PATH")
 def test_pipes():
     """Test command line pipes"""
     ls_out = subprocess.check_output(['ls'])  # nosec


### PR DESCRIPTION
`tests/tests_main.py::test_pipes` runs `subprocess.check_output(['ls'])`. On a Windows
host that does not have `ls` on `PATH` this raises
`FileNotFoundError: [WinError 2] The system cannot find the file specified`, so the test
errors instead of being skipped.

This skips it only when `ls` is genuinely unavailable:

```python
 @mark.slow
+@mark.skipif(shutil.which("ls") is None, reason="requires ls on PATH")
 def test_pipes():
```

**Why a capability probe rather than `skipif(IS_WIN, ...)`.** I initially used `IS_WIN`,
matching the two neighbouring tests, and that was wrong. The `py3.14-windows` job provides
`ls` via Git for Windows, and `test_pipes` currently passes there — I confirmed it in the
job log for run `30261748434`:

```
tests/tests_main.py::test_pipes PASSED                                   [ 35%]
================ 157 passed, 3 skipped, 7 deselected in 6.57s =================
```

So gating on the platform would have silently removed real Windows coverage. Probing the
command keeps the test running everywhere `ls` exists — including CI — and skips only on
hosts that actually lack it. `IS_WIN` is still used by `test_manpath` and `test_comppath`,
so the import is unchanged.

Verified locally (Windows 11, Python 3.13, no `ls` on `PATH`):

```
# skips where ls is missing
SKIPPED [1] tests/tests_main.py:35: requires ls on PATH
5 passed, 3 skipped

# and does NOT skip when ls is present: with a stub ls on PATH,
# shutil.which("ls") resolves and the test is collected and executed
which(ls) with stub = ...\stubbin\ls.BAT   ->  test runs, not skipped

# whole suite
158 passed, 9 skipped in 37.73s     (was: 1 failed, 158 passed, 8 skipped)
```

`flake8` is clean on the file using the repo's own `[tool.flake8]` config
(`max_line_length = 99`).

- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
    + test-suite fix — no library behaviour changes, so none of the four fit.
- [x] If applicable, I have mentioned the relevant/related issue(s)
    + No existing issue found; I searched for `test_pipes` and for Windows test failures.
      #1238 is a separate Linux packaging problem.

Less important but also useful:

- [x] I have visited the [source website], and in particular read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  # 4.70.0
  # 3.13.13 (main, Apr 14 2026, 14:30:19) [MSC v.1944 64 bit (AMD64)]
  # win32
  ```

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=
