### PR TITLE
Fix: force final refresh() in tqdm.rich to prevent incomplete visual completion (#1266)

### DIFF
--- a/tqdm/rich.py
+++ b/tqdm/rich.py
@@ -120,6 +120,14 @@ class tqdm_rich(std_tqdm):  # pragma: no cover
         if self.disable:
             return
         self.display()  # print 100%, vis #1306
+
+        # Fix for #1266: Force synchronous refresh to ensure the final 100%
+        # frame is rendered before the rich Progress thread shuts down.
+        try:
+            self._prog.refresh()
+        except Exception:
+            pass
+
         super().close()
         self._prog.__exit__(None, None, None)
 


### PR DESCRIPTION
Fixes #1266.

## Problem
As reported in #1266, when using `tqdm.rich`, the progress bar visually stops one update short of 100%, even though the underlying data iteration is completely finished.

## Root Cause
In `tqdm/rich.py`, the `close()` method calls `self.display()` to push the final 100% state to the underlying `rich.progress.Progress` object, and then immediately calls `self._prog.__exit__()`. Because `rich` uses an asynchronous background thread to render frames, the thread is killed *before* it has a chance to draw the final frame triggered by `display()`.

## Solution
This PR forces a synchronous `self._prog.refresh()` call immediately after `display()` but before `__exit__()`. This guarantees the final 100% frame is flushed to the terminal buffer before the application shuts down the rendering thread, cleanly completing the visual output exactly as expected.