### PR TITLE
Fix notebook leave=False close on break

### DIFF
--- a/tests/tests_notebook.py
+++ b/tests/tests_notebook.py
@@ -5,3 +5,14 @@ def test_notebook_disabled_description():
     """Test that set_description works for disabled tqdm_notebook"""
     with tqdm_notebook(1, disable=True) as t:
         t.set_description("description")
+
+
+def test_notebook_leave_false_closes_incomplete_bar():
+    """Test that leave=False hides a manually closed incomplete bar"""
+    t = tqdm_notebook(range(3), leave=False, display=False)
+    for _ in t:
+        t.close()
+        break
+
+    assert t.container.children[1].bar_style != 'danger'
+    assert t.container.layout.visibility == 'hidden'

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -250,6 +250,8 @@ class tqdm_notebook(std_tqdm):
         try:
             it = super().__iter__()
             yield from it
+        except GeneratorExit:
+            raise
         # NB: except ... [ as ...] breaks IPython async KeyboardInterrupt
         except:  # NOQA
             self.disp(bar_style='danger')
@@ -276,7 +278,10 @@ class tqdm_notebook(std_tqdm):
         # Try to detect if there was an error or KeyboardInterrupt
         # in manual mode: if n < total, things probably got wrong
         if self.total and self.n < self.total:
-            self.disp(bar_style='danger', check_delay=False)
+            if self.leave:
+                self.disp(bar_style='danger', check_delay=False)
+            else:
+                self.disp(close=True, check_delay=False)
         else:
             if self.leave:
                 self.disp(bar_style='success', check_delay=False)


### PR DESCRIPTION
Fixes #1382

- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [x] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the source website, and in particular read the known issues
- [x] I have searched through the issue tracker for duplicates
- [x] I have mentioned version numbers, operating system and environment, where applicable:
  `tqdm 4.70.0, Python 3.13.14, Windows`

## Reproduction

On current `master`, this leaves an incomplete notebook bar styled as `danger` instead of hiding it, despite `leave=False` and an explicit `close()`:

```python
from tqdm.notebook import tqdm
bar = tqdm(range(3), leave=False, display=False)
for _ in bar:
    bar.close()
    break
print(bar.container.children[1].bar_style, bar.container.layout.visibility)
# master: danger, None
```

## Root cause

`tqdm_notebook.__iter__` caught `GeneratorExit` from normal generator closure on `break` in its broad exception handler and marked the widget as `danger`. `close()` also always treated incomplete notebook bars as errors, ignoring `leave=False` for manual early close.

## Fix

Let `GeneratorExit` propagate without setting the danger style, and make incomplete `close()` hide the widget when `leave=False` while preserving the existing danger display for `leave=True` and actual exceptions.

## Compatibility

The change is limited to notebook widget close/display behavior. It does not affect the std tqdm hot loop or terminal tqdm behavior.

## Validation

- `python -m pytest tests\\tests_notebook.py -q` -> 2 passed
- `python -m flake8 tqdm\\notebook.py tests\\tests_notebook.py` -> passed
- `python -m pytest` (with Git `usr\\bin` on PATH for `ls`) -> 163 passed, 5 skipped
- Regression check: with the `tqdm/notebook.py` fix reverted, `tests\\tests_notebook.py::test_notebook_leave_false_closes_incomplete_bar` fails with `AssertionError: assert 'danger' != 'danger'`.