### PR TITLE
Fix concurrent maps for unsized iterables

### DIFF
--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -52,6 +52,17 @@ def test_process_map():
             skip(str(err))
 
 
+def test_thread_map_unsized():
+    """Test contrib.concurrent.thread_map with unsized iterables"""
+    with closing(StringIO()) as our_file:
+        a = range(9)
+        b = [i + 1 for i in a]
+        # no iterable reports a length
+        assert thread_map(incr, (i for i in a), file=our_file) == b
+        # only some iterables report a length
+        assert thread_map(lambda x, _: x + 1, (i for i in a), a, file=our_file) == b
+
+
 def check_lock(args):
     """Check that another interpreter cannot acquire a held tqdm lock"""
     from os.path import exists
@@ -100,7 +111,11 @@ def test_interpreter_map_lock(tmp_path):
                                             (['x', ()], False), (['x' * 1001], True),
                                             (['x' * 100, ('x',) * 1001], False),
                                             (['x' * 1001, ('x',) * 100], False),
-                                            (['x' * 1001, ('x',) * 1001], True)])
+                                            (['x' * 1001, ('x',) * 1001], True),
+                                            # unsized iterables report no length
+                                            ([map(str, 'x' * 1001)], False),
+                                            ([map(str, 'x'), map(str, 'x')], False),
+                                            (['x' * 1001, map(str, 'x')], True)])
 def test_chunksize_warning(iterables, should_warn):
     """Test contrib.concurrent.process_map chunksize warnings"""
     patch = importorskip('unittest.mock').patch

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -100,8 +100,8 @@ def _get_interpreter_init(tqdm_class, lock_queue_id):
 
 
 def _min_map_len(iterables):
-    """min(map(length_hint, iterables))"""
-    return min(n for it in iterables if (n := length_hint(it, -1)) >= 0)
+    """min(map(length_hint, iterables)), or `None` if no length is known"""
+    return min((n for it in iterables if (n := length_hint(it, -1)) >= 0), default=None)
 
 
 def _executor_map(
@@ -250,7 +250,7 @@ def process_map(fn, *iterables, lock_name="mp_lock", **tqdm_kwargs):
         # default `chunksize=1` has poor performance for large iterables
         # (most time spent dispatching items to workers).
         shortest_iterable_len = _min_map_len(iterables)
-        if shortest_iterable_len > 1000:
+        if shortest_iterable_len is not None and shortest_iterable_len > 1000:
             from warnings import warn
             warn("Iterable length %d > 1000 but `chunksize` is not set."
                  " This may seriously degrade multiprocess performance."


### PR DESCRIPTION
## Summary

Allow `thread_map()` and `process_map()` to accept iterables that do not implement `__len__` or `__length_hint__`.

## Problem and reproduction

`_min_map_len()` currently calls `min()` over only the iterables with a known length. When every input is unsized, the filtered generator is empty and `min()` raises `ValueError` before the executor starts:

```python
thread_map(abs, (value for value in [-1, -2]))
```

Return `None` when no length is known, and only perform the large-iterable `chunksize` warning check when a length is available. Mixed sized/unsized inputs continue to use the shortest known length.

## Tests

- `python -m pytest tests/tests_concurrent.py -q`
- Result: 14 passed, 2 skipped (Python 3.14-only tests)
- `git diff --check upstream/master...HEAD`
