### PR TITLE
fix: drop tqdm._utils re-exports removed from tqdm.utils

### DIFF
--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -1,10 +1,20 @@
+import sys
 from ast import literal_eval
 from collections import defaultdict
+from importlib import import_module
 from typing import Union  # py<3.10
 
 import pytest
 
+from tqdm.std import TqdmDeprecationWarning
 from tqdm.utils import envwrap
+
+
+def test_deprecated_utils_shim():
+    """Test tqdm._utils re-exports every name it promises"""
+    sys.modules.pop('tqdm._utils', None)
+    with pytest.warns(TqdmDeprecationWarning, match="tqdm.utils"):
+        import_module('tqdm._utils')
 
 
 def test_envwrap_deprecated(monkeypatch):

--- a/tqdm/_utils.py
+++ b/tqdm/_utils.py
@@ -3,8 +3,8 @@ from warnings import warn
 from .std import TqdmDeprecationWarning
 from .utils import (  # noqa: F401, pylint: disable=unused-import
     CUR_OS, IS_NIX, IS_WIN, RE_ANSI, Comparable, FormatReplace, SimpleTextIOWrapper,
-    _environ_cols_wrapper, _is_ascii, _is_utf, _screen_shape_linux, _screen_shape_tput,
-    _screen_shape_windows, _screen_shape_wrapper, _supports_unicode, _term_move_up, colorama)
+    _environ_cols_wrapper, _is_ascii, _is_utf, _screen_shape_wrapper, _supports_unicode,
+    _term_move_up, colorama)
 
 warn("This function will be removed in tqdm==5.0.0\n"
      "Please use `tqdm.utils.*` instead of `tqdm._utils.*`",


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [x] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  # 4.70.0 3.13.13 (tags/v3.13.13:01104ce, Apr  7 2026, 19:25:48) [MSC v.1944 64 bit (AMD64)] win32
  ```

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=

---

`import tqdm._utils` raises `ImportError` on the current release. No open issue — I searched the tracker before filing, and the nearest match, #927, is the same breakage from 2020, closed long ago.

```console
$ pip install tqdm==4.70.0 && python -c "import tqdm._utils"
ImportError: cannot import name '_screen_shape_linux' from 'tqdm.utils'

$ pip install tqdm==4.67.1 && python -c "import tqdm._utils"   # warns, then succeeds
```

### Cause

`0de6e96` ("simplify terminal size detection") replaced the platform-specific helpers with a single `os.get_terminal_size()` call and deleted `_screen_shape_linux`, `_screen_shape_tput` and `_screen_shape_windows` from `tqdm/utils.py`. The deprecated `tqdm/_utils.py` shim still re-exports all three, so the module raises on import instead of emitting its `TqdmDeprecationWarning`.

The shim says it "will be removed in tqdm==5.0.0", so it is meant to keep working through 4.x. It worked in 4.67.1, making this a regression from 4.68.0 onwards. It is not platform-specific — the deleted names are absent everywhere.

### Fix

Drop only those three names from the import list. Every other name it re-exports (`CUR_OS`, `IS_NIX`, `IS_WIN`, `RE_ANSI`, `Comparable`, `FormatReplace`, `SimpleTextIOWrapper`, `_environ_cols_wrapper`, `_is_ascii`, `_is_utf`, `_screen_shape_wrapper`, `_supports_unicode`, `_term_move_up`, `colorama`) is still exported by `tqdm.utils`, verified name by name.

This is the same shape of fix as `0229cc6` ("fix import error => deprecation"), which resolved #927 by realigning this exact import list.

I checked the sibling shims too — `tqdm._tqdm`, `tqdm._tqdm_gui`, `tqdm._tqdm_notebook`, `tqdm._tqdm_pandas`, `tqdm._main` and `tqdm._monitor` all import cleanly and are untouched here.

### Test

`tests/tests_utils.py::test_deprecated_utils_shim` imports the shim and asserts the deprecation warning. Nothing in the suite had ever imported `tqdm._utils`, which is why this class of break has now shipped twice; the test closes that gap.

It fails before this change with the `ImportError` above and passes after:

```
$ pytest tests/tests_utils.py::test_deprecated_utils_shim   # before
E   ImportError: cannot import name '_screen_shape_linux' from 'tqdm.utils'
1 failed

$ pytest tests/tests_utils.py                               # after
5 passed
```

Full suite on this branch: **150 passed, 11 skipped, 0 failed**. `flake8`, `isort --check-only` and `pyupgrade --py38-plus` are all clean on the changed files.
