### PR TITLE
fix: count process_map items when chunksize > 1

### DIFF
--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -52,6 +52,18 @@ def test_process_map():
             skip(str(err))
 
 
+def test_process_map_chunksize_progress():
+    """process_map should count items, not chunks, when chunksize > 1 (#1791)"""
+    with closing(StringIO()) as our_file:
+        a = range(101)
+        b = [i + 1 for i in a]
+        try:
+            assert process_map(incr, a, chunksize=10, file=our_file, miniters=1) == b
+        except ImportError as err:
+            skip(str(err))
+        assert '101/101' in our_file.getvalue()
+
+
 def check_lock(args):
     """Check that another interpreter cannot acquire a held tqdm lock"""
     from os.path import exists

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -154,10 +154,14 @@ def _executor_map(
                 if dynamic_miniters is not None:
                     pbar.dynamic_miniters = True
                 orisubmit = ex.submit
+                # ProcessPoolExecutor.map submits one Future per chunk, not per item.
+                from concurrent.futures import ProcessPoolExecutor
+                counts_chunks = PoolExecutor is ProcessPoolExecutor
 
                 def patchsubmit(*args, **kwargs):
                     fut = orisubmit(*args, **kwargs)
-                    fut.add_done_callback(lambda _: pbar.update())
+                    n = len(args[1]) if counts_chunks and len(args) > 1 else 1
+                    fut.add_done_callback(lambda _, n=n: pbar.update(n))
                     return fut
                 ex.submit = patchsubmit
                 return list(ex.map(


### PR DESCRIPTION
Fixes #1791

- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [x] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

`ProcessPoolExecutor.map` submits one Future per *chunk*. After #1709, `process_map` called `pbar.update()` once per Future, so `chunksize=10` on 101 items finished at **11/101** instead of 101/101.

This updates the bar by the chunk length (last chunk included). `thread_map` / `interpreter_map` still increment once per item.

```python
from tqdm.contrib.concurrent import process_map
process_map(lambda x: x, range(101), chunksize=10)
# 4.70.0: 11/101
# this PR: 101/101
```

Regression test: `test_process_map_chunksize_progress`.