### PR TITLE
fix(contrib): count chunk size for process_map progress (#1791)

### DIFF
--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -52,6 +52,43 @@ def test_process_map():
             skip(str(err))
 
 
+def test_process_map_chunksize():
+    """Test contrib.concurrent.process_map progress with chunksize > 1 (#1791)"""
+    with closing(StringIO()) as our_file:
+        a = range(101)
+        b = [i + 1 for i in a]
+        try:
+            assert process_map(incr, a, chunksize=10, max_workers=2,
+                               file=our_file) == b
+        except ImportError as err:
+            skip(str(err))
+        # each submitted future processes a whole chunk of items, so each
+        # chunk completion must advance the bar by more than one
+        assert '101/101' in our_file.getvalue()
+
+
+def test_thread_map_chunksize():
+    """Test contrib.concurrent.thread_map progress with chunksize > 1 (#1791)"""
+    with closing(StringIO()) as our_file:
+        a = list(range(17))
+        b = [i + 1 for i in a]
+        assert thread_map(incr, a, chunksize=4, file=our_file) == b
+        assert '17/17' in our_file.getvalue()
+
+
+@mark.skipif(sys.version_info < (3, 14), reason="requires Python 3.14+")
+def test_interpreter_map_chunksize(capsys):
+    """Test contrib.concurrent.interpreter_map progress with chunksize > 1 (#1791)"""
+    a = range(101)
+    b = [i + 1 for i in a]
+    try:
+        assert interpreter_map(incr, a, chunksize=10) == b
+    except ImportError as err:
+        skip(str(err))
+    _, err = capsys.readouterr()
+    assert '101/101' in err
+
+
 def check_lock(args):
     """Check that another interpreter cannot acquire a held tqdm lock"""
     from os.path import exists

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -2,6 +2,7 @@
 Thin wrappers around `concurrent.futures`.
 """
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from operator import length_hint
 
@@ -157,7 +158,14 @@ def _executor_map(
 
                 def patchsubmit(*args, **kwargs):
                     fut = orisubmit(*args, **kwargs)
-                    fut.add_done_callback(lambda _: pbar.update())
+                    if chunksize > 1 and not issubclass(PoolExecutor, ThreadPoolExecutor):
+                        # `ProcessPoolExecutor` submits one future per chunk,
+                        # so update `pbar` by the exact chunk size (#1791).
+                        # `ThreadPoolExecutor` (and subclasses) ignore
+                        # `chunksize` and submit one future per item instead.
+                        fut.add_done_callback(lambda _, n=len(args[1]): pbar.update(n))
+                    else:
+                        fut.add_done_callback(lambda _: pbar.update())
                     return fut
                 ex.submit = patchsubmit
                 return list(ex.map(


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] visual output fix
- [x] If applicable, I have mentioned the relevant/related issue(s)

Fixes #1791.

With `chunksize > 1`, `process_map` submits one future per chunk to the
worker pool, but the done callback only advanced the progress bar by one
item per future — so the bar stopped well short of the total (e.g.
`11/101` with `chunksize=10`). The callback now advances the bar by the
exact size of each submitted chunk. `ThreadPoolExecutor` (and its
subclasses) ignore `chunksize` and submit one future per item, so that
path keeps the previous one-item-per-future behaviour.

Tests added for `process_map`, `thread_map` and `interpreter_map`
(pending Python 3.14) with `chunksize > 1`.

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```
  4.67.3 3.11.15 linux

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=
