### PR TITLE
docs: fix Codacy dashboard link in JOSS paper

### DIFF
--- a/examples/paper.md
+++ b/examples/paper.md
@@ -130,7 +130,7 @@ Web-based Jupyter interactive demonstrations are also available
 
 Unit tests are run at least weekly on cloud-based continuous integration
 [@travis], with code style and security issues checked on
-[Codacy](https://app.codacy.com/project/tqdm/tqdm/dashboard) [@code-review].
+[Codacy](https://app.codacy.com/gh/tqdm/tqdm/dashboard) [@code-review].
 Coverage is reported on [Coveralls](https://coveralls.io/github/tqdm/tqdm) and
 [Codecov](https://codecov.io/gh/tqdm/tqdm), and performance is monitored against
 regression [@asv].


### PR DESCRIPTION
## Problem

`examples/paper.md` linked to
`https://app.codacy.com/project/tqdm/tqdm/dashboard`, which returns 404.
The README already uses the working `https://app.codacy.com/gh/tqdm/tqdm/dashboard`
target.

Verified:

    GET https://app.codacy.com/project/tqdm/tqdm/dashboard -> 404
    GET https://app.codacy.com/gh/tqdm/tqdm/dashboard -> 200

## Solution

Use the same Codacy dashboard URL as README.rst.

## Verification

GET of the replacement URL returns 200.

This is a documentation-only change.
