### PR TITLE
docs: update star-history URL in JOSS bibliography

### DIFF
--- a/examples/paper.bib
+++ b/examples/paper.bib
@@ -113,7 +113,7 @@
  year="2019",
  author="{timqian}",
  title="Star history",
- url="https://timqian.com/star-history/#tqdm/tqdm"
+ url="https://www.star-history.com/#tqdm/tqdm"
 }
 @misc{trend-hist,
  year="2018",


### PR DESCRIPTION
## Problem
`examples/paper.bib` cites `https://timqian.com/star-history/#tqdm/tqdm`.
A GET request to that URL returns HTTP 404.

## Solution
Update the bibliography URL to `https://www.star-history.com/#tqdm/tqdm`,
which currently returns HTTP 200 and is the current host for that tool.

## Verification
GET `https://timqian.com/star-history/#tqdm/tqdm` -> 404
GET `https://www.star-history.com/#tqdm/tqdm` -> 200
