### PR TITLE
fix: don't crash when there is no output stream

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -400,6 +400,19 @@ def test_write_bytes():
         sys.stderr = stderr
 
 
+def test_no_default_file():
+    """Test absent `sys.stderr` (e.g. `pythonw.exe`, console-less frozen app)"""
+    stderr = sys.stderr
+    try:
+        sys.stderr = None
+        with tqdm(total=3) as t:
+            assert t.disable
+            t.update(3)
+        assert list(tqdm(range(3))) == [0, 1, 2]
+    finally:
+        sys.stderr = stderr
+
+
 def test_iterate_over_csv_rows():
     """Test csv iterator"""
     # Create a test csv pseudo file

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -967,6 +967,10 @@ class tqdm(Comparable):
         """see tqdm.tqdm for arguments"""
         if file is None:
             file = sys.stderr
+            if file is None:
+                # console-less hosts (`pythonw.exe`, frozen GUI apps) have no
+                # `sys.stderr` at all, so there is nothing to display on
+                disable = True
 
         if write_bytes:
             # Despite coercing unicode into bytes, py2 sys.std* streams


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s): #1523, #1593
- [x] I have visited the [source website], and in particular read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and environment:
  ```text
  4.70.0 3.14.7 (tags/v3.14.7:823f032, Aug  5 2026, 10:51:32) [MSC v.1944 64 bit (AMD64)] win32
  ```

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=

---

A Windows process with no console has no standard handles, so CPython sets `sys.stderr` to
`None`. `__init__` defaults `file` to `sys.stderr` without rechecking it, so `self.fp` wraps
`None` and the first `refresh()` raises `AttributeError: 'NoneType' object has no attribute
'write'`. That is #1523 (PyInstaller `-w`) and #1593.

74ff992 already handled this in `write()` and `external_write_mode()` with `if fp is None:
return`. This does the same in the constructor by setting `disable`.

Checked on Windows 11 / Python 3.14.7 under a `pythonw.exe` spawned `DETACHED_PROCESS |
CREATE_NO_WINDOW` with no inherited handles, so `sys.stderr is None` is real rather than
simulated:

| | before | after |
|---|---|---|
| `tqdm(total=100); update(100)` | `AttributeError` | no exception |
| `for i in tqdm(range(3))` | `AttributeError` | iterates |

`tests_tqdm.py`: 146 passed before, 147 after. flake8 clean on both files.

One deliberate consequence: with no stream, an explicit `disable=False` is overridden. That
matches `write()`, which already no-ops in the same situation.
