### PR TITLE
pandas: fix DataFrame.progress_map total (elementwise)

### DIFF
--- a/tests/tests_pandas.py
+++ b/tests/tests_pandas.py
@@ -78,11 +78,11 @@ def test_pandas_data_frame():
             return x + 1
 
         if hasattr(df, 'map'):  # pandas>=2.1.0
-            # map
+            # map (elementwise, so expect `df.size` iterations)
             res1 = df.progress_map(task_func)
             res2 = df.map(task_func)
             assert res1.equals(res2)
-            assert '200/200' in our_file.getvalue()
+            assert '20000/20000' in our_file.getvalue()
         else:
             # applymap
             res1 = df.progress_applymap(task_func)

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -868,7 +868,9 @@ class tqdm(Comparable):
                 # Precompute total iterations
                 total = tqdm_kwargs.pop("total", getattr(df, 'ngroups', None))
                 if total is None:  # not grouped
-                    if df_function == 'applymap':
+                    if df_function in ('applymap', 'map'):
+                        # elementwise: `Series.map`, `DataFrame.map` (pandas>=2.1.0)
+                        # and its predecessor `DataFrame.applymap`
                         total = df.size
                     elif isinstance(df, Series):
                         total = len(df)


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [x] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s): fixes #1798

Less important but also useful:

- [x] I have visited the [source website], and in particular read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and environment, where applicable:
```text
tqdm 4.70.0, pandas 3.0.5, Python 3.11.14, darwin
```

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=

`DataFrame.progress_map` computed `total` as the number of columns (`df.size // df.shape[axis]`), but pandas' `DataFrame.map` is elementwise (the pandas>=2.1 rename of `applymap`), so the bar reached 100% after 1/ncols of the work and froze. Treat `'map'` like `'applymap'` (`total = df.size`); for `Series.map` this is unchanged (`Series.size == len`). The `test_pandas_data_frame` assertion is updated from `200/200` to `20000/20000`, matching the `applymap` branch of the same test.

Disclosure: this contribution was prepared with AI assistance (Claude); I have reviewed, run, and verified all changes myself.