### PR TITLE
fix: process_map progress bar undercounts with chunksize > 1

### DIFF
--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -52,6 +52,22 @@ def test_process_map():
             skip(str(err))
 
 
+def test_process_map_chunksize():
+    """Test contrib.concurrent.process_map bar reaches `total` with `chunksize>1`"""
+    with closing(StringIO()) as our_file:
+        n = 101
+        a = range(n)
+        b = [i + 1 for i in a]
+        try:
+            assert process_map(incr, a, chunksize=10, file=our_file) == b
+        except ImportError as err:
+            skip(str(err))
+        our_file.seek(0)
+        out = our_file.read()
+        assert "100%|" in out
+        assert "%d/%d" % (n, n) in out
+
+
 def check_lock(args):
     """Check that another interpreter cannot acquire a held tqdm lock"""
     from os.path import exists

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -154,10 +154,21 @@ def _executor_map(
                 if dynamic_miniters is not None:
                     pbar.dynamic_miniters = True
                 orisubmit = ex.submit
+                total = kwargs.get('total')
+                submitted = [0]
 
                 def patchsubmit(*args, **kwargs):
                     fut = orisubmit(*args, **kwargs)
-                    fut.add_done_callback(lambda _: pbar.update())
+                    # `chunksize > 1` means each future represents multiple items
+                    # (e.g. `ProcessPoolExecutor.map` groups items into chunks
+                    # before submitting), so update the bar by the chunk size
+                    # rather than by `1` per completed future.
+                    if total is not None:
+                        n = min(chunksize, total - submitted[0])
+                        submitted[0] += n
+                    else:
+                        n = 1
+                    fut.add_done_callback(lambda _, n=n: pbar.update(n))
                     return fut
                 ex.submit = patchsubmit
                 return list(ex.map(


### PR DESCRIPTION
## Bug

Fixes #1791.

`process_map(fn, range(101), chunksize=10)` finishes at `11/101` instead of `101/101`.

## Root cause

`_executor_map` patches `ex.submit` to add a `done_callback` that calls `pbar.update()` (i.e. `+1`) once per completed future. That's correct when each future represents one input item (`chunksize=1`, the default, and what `ThreadPoolExecutor`/`InterpreterPoolExecutor` effectively use).

However, `ProcessPoolExecutor.map` (see `concurrent.futures.process.ProcessPoolExecutor.map`) groups the input into chunks of `chunksize` items and submits **one future per chunk** (via `_process_chunk`). So with `chunksize=10` and 101 items, only 11 futures get submitted, and the bar increments by 1 per future -> stops at `11/101` even though all 101 items were processed. This regressed in #1709 which introduced the callback-based update.

## Fix

`tqdm/contrib/concurrent.py`: track how many items are known to have been submitted so far and compute, at submit time, how many items the just-submitted future represents (`min(chunksize, total - submitted_so_far)`), then update the bar by that amount in the completion callback instead of always by `1`.

## Test plan

- Added `test_process_map_chunksize` in `tests/tests_concurrent.py`, which runs `process_map(incr, range(101), chunksize=10, file=our_file)` and asserts the final bar output reaches `101/101`.
- Verified the new test fails on current `master` (bar stops at `11/101`) and passes with the fix.
- Ran `tests/tests_concurrent.py` (11 passed, 2 skipped requiring Python 3.14) and `flake8 --max-line-length=99` on the changed files (clean).