### PR TITLE
pandas: drop broken (Series|DataFrame)GroupBy.progress_map

### DIFF
--- a/tests/tests_pandas.py
+++ b/tests/tests_pandas.py
@@ -110,6 +110,19 @@ def test_pandas_data_frame():
                 f"\nExpected:\n100% at least 6 times\nIn:\n{our_file.read()}\n")
 
 
+def test_pandas_groupby_no_progress_map():
+    """Test pandas.DataFrame.groupby(...) has no broken .progress_map"""
+    with closing(StringIO()) as our_file:
+        tqdm.pandas(file=our_file, leave=True, ascii=True)
+
+        df = pd.DataFrame({'a': randint(0, 50, (100,)), 'b': randint(0, 50, (100,))})
+        for grouped in (df.groupby('a'), df.groupby('a')['b']):
+            if hasattr(grouped, 'map'):  # pragma: no cover
+                skip("pandas (Series|DataFrame)GroupBy now provides `map`")
+            # registering it would only raise `AttributeError` on call
+            assert not hasattr(grouped, 'progress_map')
+
+
 @mark.filterwarnings("ignore:DataFrameGroupBy.apply operated on the grouping columns")
 def test_pandas_groupby_apply():
     """Test pandas.DataFrame.groupby(...).progress_apply"""

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -931,13 +931,12 @@ class tqdm(Comparable):
         Series.progress_apply = inner_generator()
         SeriesGroupBy.progress_apply = inner_generator()
         Series.progress_map = inner_generator('map')
-        SeriesGroupBy.progress_map = inner_generator('map')
 
         DataFrame.progress_apply = inner_generator()
         DataFrameGroupBy.progress_apply = inner_generator()
         DataFrame.progress_applymap = inner_generator('applymap')
         DataFrame.progress_map = inner_generator('map')
-        DataFrameGroupBy.progress_map = inner_generator('map')
+        # no `(Series|DataFrame)GroupBy.map` to delegate to
 
         if Panel is not None:
             Panel.progress_apply = inner_generator()


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  # 4.70.0 3.11.15 (main, Mar  3 2026, 09:26:23) [GCC 13.3.0] linux
  # pandas 3.0.5
  ```

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=

`tqdm.pandas()` registered `progress_map` on `SeriesGroupBy` and on `DataFrameGroupBy`, but pandas has never provided `GroupBy.map` for those wrappers to delegate to. Calling `df.groupby(g).progress_map(func)` or `df.groupby(g)[col].progress_map(func)` therefore opened a progress bar and then raised `AttributeError`, leaving the bar behind. Checked against pandas 3.0.5 and pandas 2.2.3, neither exposes `map` on the groupby classes.

This drops the two registrations, so the attribute is simply absent rather than present and broken. `Series.progress_map`, `DataFrame.progress_map` and `DataFrame.progress_applymap` are untouched, since pandas does provide `map` and `applymap` there. The groupby entry points that do work, `progress_apply`, `progress_aggregate` and `progress_transform`, are also untouched.

A regression test is added. It fails on master with `AssertionError` on `hasattr(grouped, 'progress_map')` and passes with the change. It skips itself if a future pandas grows `GroupBy.map`, so it will not block adding the wrappers back later. The full suite passes locally, 153 passed and 8 skipped, and flake8 is clean with the project configuration.

Fixes #1803.