### PR TITLE
fix(concurrent): handle all-unsized iterables in _min_map_len

### DIFF
--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -52,6 +52,20 @@ def test_process_map():
             skip(str(err))
 
 
+def test_map_unsized_iterables():
+    """Test map functions accept iterables with no length hint (fixes #1801)"""
+    gen = (i for i in range(9))
+    assert thread_map(incr, gen, disable=True) == [i + 1 for i in range(9)]
+    try:
+        assert process_map(incr, (i for i in range(9)), max_workers=2,
+                           disable=True) == [i + 1 for i in range(9)]
+    except ImportError as err:
+        skip(str(err))
+    # mixed sized and unsized: the sized one still sets total/warns correctly
+    assert thread_map(lambda x, y: x, (i for i in range(9)), range(9),
+                      disable=True) == list(range(9))
+
+
 def check_lock(args):
     """Check that another interpreter cannot acquire a held tqdm lock"""
     from os.path import exists

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -100,8 +100,8 @@ def _get_interpreter_init(tqdm_class, lock_queue_id):
 
 
 def _min_map_len(iterables):
-    """min(map(length_hint, iterables))"""
-    return min(n for it in iterables if (n := length_hint(it, -1)) >= 0)
+    """min(map(length_hint, iterables)), or -1 if all iterables are unsized"""
+    return min((n for it in iterables if (n := length_hint(it, -1)) >= 0), default=-1)
 
 
 def _executor_map(
@@ -124,7 +124,9 @@ def _executor_map(
     """
     kwargs = tqdm_kwargs.copy()
     if 'total' not in kwargs:
-        kwargs['total'] = _min_map_len(iterables)
+        shortest_len = _min_map_len(iterables)
+        # -1 => all iterables unsized (e.g. generators): leave total unknown
+        kwargs['total'] = None if shortest_len < 0 else shortest_len
     map_kwargs = {}
     if 'buffersize' in kwargs:
         map_kwargs['buffersize'] = kwargs.pop('buffersize')


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

Fixes #1801.

## Problem

Passing **only** iterables without a length hint (e.g. generators) to
`process_map`/`thread_map` raises:

```
ValueError: min() iterable argument is empty
    in tqdm/contrib/concurrent.py, line 104, in _min_map_len
```

Since #1473, `_min_map_len` filters out unsized iterables before taking
the `min()`:

```python
return min(n for it in iterables if (n := length_hint(it, -1)) >= 0)
```

When *every* iterable is unsized (a very common case: `process_map(f,
(x for x in ...))`) the filtered generator is empty and `min()` raises.
The same crash also blocks `thread_map` and (on Python ≥3.14)
`interpreter_map`, which share `_executor_map`.

## Fix

- `_min_map_len` now uses `default=-1`: no sized iterable at all → `-1`.
- `_executor_map` maps `-1` to `total=None` (unknown length), so the bar
  simply runs in indeterminate mode instead of crashing — or worse,
  silently claiming `total=0`.
- Sized-but-empty iterables keep their existing `total=0` behaviour
  (`length_hint(()) == 0` still participates in the `min()`).
- The `process_map` chunksize warning logic (`shortest_iterable_len >
  1000`) is unchanged: an all-generators call yields `total=None`,
  which never warns, matching pre-#1473 semantics for unknown lengths.

## Tests

New `test_map_unsized_iterables` covers:
- `thread_map` / `process_map` with a single generator argument
  (previously raised `ValueError`)
- mixed sized + unsized arguments (total still taken from the sized one)

Full suite: `149 passed, 12 skipped`
(Python 3.11.16, Windows; skips are the pre-existing
Python≥3.14/optional-dependency ones).

Environment:
```python
import tqdm, sys
print(tqdm.__version__, sys.version, sys.platform)
```
```
4.70.0 3.11.16 (main, ...) win32
```

Less important but also useful:

- [x] I have visited the [source website], and in particular
  read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and
  environment, where applicable:
  ```python
  import tqdm, sys
  print(tqdm.__version__, sys.version, sys.platform)
  ```

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=
