### PR TITLE
fix(logging): don't add tqdm handler when logger has no console handler (#1501)

### DIFF
--- a/tests/tests_contrib_logging.py
+++ b/tests/tests_contrib_logging.py
@@ -90,10 +90,24 @@ class TestGetFirstFoundConsoleLoggingHandler:
 class TestRedirectLoggingToTqdm:
     def test_should_add_and_remove_tqdm_handler(self):
         logger = logging.Logger('test')
+        console_handler = logging.StreamHandler(sys.stderr)
+        logger.addHandler(console_handler)
         with logging_redirect_tqdm(loggers=[logger]):
             assert len(logger.handlers) == 1
             assert isinstance(logger.handlers[0], TqdmLoggingHandler)
-        assert not logger.handlers
+        assert logger.handlers == [console_handler]
+
+    def test_should_not_add_tqdm_handler_when_logger_has_no_console_handler(self):
+        # regression test for tqdm/tqdm#1501: a logger with no console handler
+        # has nothing to redirect, so logging_redirect_tqdm must not fabricate
+        # a new console handler (which would introduce output that never existed)
+        logger = logging.Logger('test')
+        logger.handlers = []
+        logger.propagate = False
+        with logging_redirect_tqdm(loggers=[logger]):
+            assert logger.handlers == []
+            logger.info('test')  # must neither raise nor emit anywhere
+        assert logger.handlers == []
 
     def test_should_remove_and_restore_console_handlers(self):
         logger = logging.Logger('test')
@@ -134,29 +148,35 @@ class TestRedirectLoggingToTqdm:
         stream_handler = logging.StreamHandler(StringIO())
         logger.addHandler(stream_handler)
         with logging_redirect_tqdm(loggers=[logger]):
-            assert len(logger.handlers) == 2
-            assert logger.handlers[0] == stream_handler
-            assert isinstance(logger.handlers[1], TqdmLoggingHandler)
+            # a non-console (in-memory) StreamHandler is not redirected, and
+            # no tqdm handler is added because there is no console handler
+            assert logger.handlers == [stream_handler]
         assert logger.handlers == [stream_handler]
 
 
 class TestTqdmWithLoggingRedirect:
     def test_should_add_and_remove_handler_from_root_logger_by_default(self):
         original_handlers = list(logging.root.handlers)
-        with tqdm_logging_redirect(total=1) as pbar:
-            assert isinstance(logging.root.handlers[-1], TqdmLoggingHandler)
-            LOGGER.info('test')
-            pbar.update(1)
-        assert logging.root.handlers == original_handlers
+        console_handler = logging.StreamHandler(sys.stderr)
+        logging.root.addHandler(console_handler)
+        try:
+            with tqdm_logging_redirect(total=1) as pbar:
+                assert isinstance(logging.root.handlers[-1], TqdmLoggingHandler)
+                LOGGER.info('test')
+                pbar.update(1)
+        finally:
+            logging.root.handlers = original_handlers
 
     def test_should_add_and_remove_handler_from_custom_logger(self):
         logger = logging.Logger('test')
+        console_handler = logging.StreamHandler(sys.stderr)
+        logger.addHandler(console_handler)
         with tqdm_logging_redirect(total=1, loggers=[logger]) as pbar:
             assert len(logger.handlers) == 1
             assert isinstance(logger.handlers[0], TqdmLoggingHandler)
             logger.info('test')
             pbar.update(1)
-        assert not logger.handlers
+        assert logger.handlers == [console_handler]
 
     def test_should_not_fail_with_logger_without_console_handler(self):
         logger = logging.Logger('test')
@@ -178,9 +198,15 @@ class TestTqdmWithLoggingRedirect:
         assert CustomTqdm.messages == ['prefix:test']
 
     def test_use_root_logger_by_default_and_write_to_custom_tqdm(self):
-        logger = logging.root
-        CustomTqdm.messages = []
-        with tqdm_logging_redirect(total=1, tqdm_class=CustomTqdm) as pbar:
-            assert isinstance(pbar, CustomTqdm)
-            logger.info('test')
-            assert CustomTqdm.messages == ['test']
+        original_handlers = list(logging.root.handlers)
+        console_handler = logging.StreamHandler(sys.stderr)
+        logging.root.addHandler(console_handler)
+        try:
+            logger = logging.root
+            CustomTqdm.messages = []
+            with tqdm_logging_redirect(total=1, tqdm_class=CustomTqdm) as pbar:
+                assert isinstance(pbar, CustomTqdm)
+                logger.info('test')
+                assert CustomTqdm.messages == ['test']
+        finally:
+            logging.root.handlers = original_handlers

--- a/tqdm/contrib/logging.py
+++ b/tqdm/contrib/logging.py
@@ -82,16 +82,16 @@ def logging_redirect_tqdm(
     original_handlers_list = [logger.handlers for logger in loggers]
     try:
         for logger in loggers:
-            tqdm_handler = _TqdmLoggingHandler(tqdm_class)
             orig_handler = _get_first_found_console_logging_handler(logger.handlers)
             if orig_handler is not None:
+                tqdm_handler = _TqdmLoggingHandler(tqdm_class)
                 tqdm_handler.setFormatter(orig_handler.formatter)
                 tqdm_handler.stream = orig_handler.stream
                 for log_filter in orig_handler.filters:
                     tqdm_handler.addFilter(log_filter)
-            logger.handlers = [
-                handler for handler in logger.handlers
-                if not _is_console_logging_handler(handler)] + [tqdm_handler]
+                logger.handlers = [
+                    handler for handler in logger.handlers
+                    if not _is_console_logging_handler(handler)] + [tqdm_handler]
         yield
     finally:
         for logger, original_handlers in zip(loggers, original_handlers_list):


### PR DESCRIPTION
## Summary
`logging_redirect_tqdm` is documented to redirect **console** logging to `tqdm.write` while leaving other handlers (e.g. log files) untouched. However, when a target logger originally had **no** console handler, the old code still appended a `_TqdmLoggingHandler`, so the logger began emitting to the console where it previously produced no console output at all.

Fixes tqdm/tqdm#1501.

## Root cause
In `tqdm/contrib/logging.py`, the line
```python
logger.handlers = [h for h in logger.handlers if not _is_console_logging_handler(h)] + [tqdm_handler]
```
was executed **unconditionally** — even when `orig_handler is None` (no console handler found). So a logger with only a non-console handler (e.g. an in-memory/stream buffer) gained a brand-new console handler that introduced output that never existed before.

## Fix
Move the handler-replacement under the existing `if orig_handler is not None:` guard so the tqdm handler is only added when there is actually a console handler to redirect. Non-console handlers are left entirely untouched.

## Verification
- New regression test `test_should_not_add_tqdm_handler_when_logger_has_no_console_handler` **fails on pristine `master`** (RED — a `_TqdmLoggingHandler` is wrongly added) and **passes with the fix** (GREEN).
- Confirmed end-to-end: a logger with only a buffer `StreamHandler` emits nothing to stderr inside the context manager and is left untouched; a logger with a real console handler is still correctly redirected to `tqdm.write`.
- Full `tests/tests_contrib_logging.py` (20 tests) and `tests/tests_contrib.py` pass. `git diff --check` clean.

## Note on assistance
This change was prepared with AI assistance (Codex); I reproduced the bug, identified the root cause, and verified the fix and the RED→GREEN regression test locally on Windows. Happy to adjust the approach if maintainers prefer a different teardown scheme.

Closes #1501