### PR TITLE
CI: make Benchmark (Full) converge (red on all 59 retained weekly runs; gh-pages frozen since 2023-08-20)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,15 +45,22 @@ jobs:
         git checkout master && git checkout -
         asv machine --machine github-actions --yes
     - name: Restore previous results
-      uses: actions/cache@v6
+      uses: actions/cache/restore@v6
       with:
         path: .asv
-        key: asv-${{ runner.os }}
+        key: asv-${{ runner.os }}-${{ github.run_id }}
         restore-keys: |
+          asv-${{ runner.os }}-
           asv-
     - name: Benchmark
       run: |
-        asv run -j 8 --interleave-processes --skip-existing v3.2.0..HEAD
+        asv run -j 8 --interleave-processes --skip-existing v4.20.0..HEAD
+    - name: Save results
+      if: always()
+      uses: actions/cache/save@v6
+      with:
+        path: .asv
+        key: asv-${{ runner.os }}-${{ github.run_id }}
     - name: Build pages
       run: |
         git config --global user.email "$GIT_AUTHOR_EMAIL"


### PR DESCRIPTION
- [x] I have marked all applicable categories: none of the four apply (CI workflow only)
- [x] If applicable, I have mentioned the relevant/related issue(s): no existing issue covers this job

`Benchmark (Full)` (the `asvfull` job in `check.yml`) has failed on every scheduled run GitHub still retains, 59 of 59 from 2025-07-20 to 2026-08-30, and on all 13 retained release-tag runs (v4.67.2 through v4.70.0), so `Build pages` never runs and https://tqdm.github.io/tqdm was last generated 2023-08-20 (gh-pages f0a0ab3c08). [CONTRIBUTING.md:329-330](https://github.com/tqdm/tqdm/blob/96f2e60e4584cdab57a23602e27043d0465254ad/CONTRIBUTING.md#L329-L330) still describes the job as "Benchmark: automatically updates the [gh-pages project]". Cause: the 143 commits from v4.0.0 through v4.20.0 fail on Python 3.14 inside that era's own `tqdm/_tqdm.py`, which makes `asv run` exit 2; and because the `.asv` results store is a single `actions/cache` step, which only saves when the job succeeds, `--skip-existing` never receives the results that would let it skip them. Every Sunday re-runs and re-fails the same commits.

Both halves in two commands (asv 0.6.6, Python 3.14; 5d9e820a is v4.20.0):

```
pip install asv virtualenv && asv machine --yes
asv run --skip-existing '5d9e820a^!'   # exit 2: ValueError: max() iterable argument is empty, AttributeError: 'tqdm' object has no attribute 'pos'
asv run --skip-existing '5d9e820a^!'   # exit 0 in 0.4 s: the failed result is on disk, nothing runs
```

This PR starts the range after v4.20.0 (everything from v4.21.0 on passes, 159 commits) and splits the cache step into `actions/cache/restore` + `actions/cache/save` with `if: always()` and a per-run key, the pattern actions/cache documents for updating a cache. A cold run then passes in about 26 minutes and seeds the store; every run after that restores it, benchmarks only new commits, and finishes in under a minute.

---

**Mechanism** (identical in all 13 runs with logs still retained, 2026-06-07 to 2026-08-30, e.g. [33286512695](https://github.com/tqdm/tqdm/actions/runs/33286512695)):

- `asv run -j 8 --interleave-processes --skip-existing v3.2.0..HEAD` ([check.yml:56](https://github.com/tqdm/tqdm/blob/96f2e60e4584cdab57a23602e27043d0465254ad/.github/workflows/check.yml#L56)) covers 342 first-parent commits. The 143 from 35270518 (v4.0.0) through 5d9e820a (v4.20.0) fail: 98 with the `_get_free_pos` / `pos` errors above, 40 on `sys.setcheckinterval` (removed in Python 3.9) and a missing `disable` attribute, 3 on missing `docopt`, 1 `TypeError`, and bfb660a9 fails to build. d700e195 (v4.21.0) onward pass. Any failure makes asv return 2 ([run.py:606-607](https://github.com/airspeed-velocity/asv/blob/v0.6.6/asv/commands/run.py#L606-L607)).
- The results store is one `actions/cache@v6` step with the fixed key `asv-Linux` ([check.yml:47-53](https://github.com/tqdm/tqdm/blob/96f2e60e4584cdab57a23602e27043d0465254ad/.github/workflows/check.yml#L47-L53)). That action's post step is gated `post-if: success()` ([action.yml:44](https://github.com/actions/cache/blob/v6/action.yml#L44)), so a failing job never saves: all 13 retained logs contain `Cache not found for input keys: asv-Linux, asv-` and no `Cache saved`. `--skip-existing` skips failed results as well as successful ones ([run.py:182-187](https://github.com/airspeed-velocity/asv/blob/v0.6.6/asv/commands/run.py#L182-L187), [233-234](https://github.com/airspeed-velocity/asv/blob/v0.6.6/asv/commands/run.py#L233-L234)), so persisted results are all it needs. The two `asv-Linux` caches that do exist were saved by `Benchmark (Branch)` on a PR merge ref and a feature branch, which a scheduled run on master cannot restore.
- c682c7b7 (`benchmarks: fix asv`, v4.68.0) got asv running again: before it the job died about 5 minutes in (e.g. [26701042097](https://github.com/tqdm/tqdm/actions/runs/26701042097), 2026-05-31); since then it runs the full range for 45 to 50 minutes and fails on the band above.

**Runs**: 59 scheduled, every one with `Benchmark (Full)` = failure: oldest [16395116486](https://github.com/tqdm/tqdm/actions/runs/16395116486) (2025-07-20), midpoint [21790790426](https://github.com/tqdm/tqdm/actions/runs/21790790426) (2026-02-08), latest [33286512695](https://github.com/tqdm/tqdm/actions/runs/33286512695) (2026-08-30); [31290150244](https://github.com/tqdm/tqdm/actions/runs/31290150244) (2026-08-09) is the one cancelled run, and its `Benchmark (Full)` had already failed. Tags: 13 runs, e.g. v4.70.0 [30261832920](https://github.com/tqdm/tqdm/actions/runs/30261832920), all failing only in this job.

**Fork runs** at 96f2e60e (the repro branches differ from master only by a `workflow_dispatch` trigger):

- A1 [33556632766](https://github.com/glaziermag/tqdm/actions/runs/33556632766), stock config: 343 commits, the same 143 fail, exit 2, `Cache not found`, nothing saved. A2 [33565499409](https://github.com/glaziermag/tqdm/actions/runs/33565499409), run again: identical, so the failure is self-perpetuating.
- B1 [33565558387](https://github.com/glaziermag/tqdm/actions/runs/33565558387), cache split only: still fails once (seeding) but `Save results` stores a 9.7 MB cache. B2 [33569627368](https://github.com/glaziermag/tqdm/actions/runs/33569627368), next run: restores it, benchmarks nothing, exits 0, `Build pages` pushes gh-pages, 35 s.
- C1 [33569976505](https://github.com/glaziermag/tqdm/actions/runs/33569976505), this PR from a cold cache: 160 commits (159 plus the repro commit), all pass, exit 0 in 26 minutes, cache saved, gh-pages pushed. C2 [33572364081](https://github.com/glaziermag/tqdm/actions/runs/33572364081), next run: restores, benchmarks nothing, 25 s.

Why both changes: caches not accessed for 7 days are evicted, and an incremental run finishes well under a minute, so with a weekly cron the previous Sunday's entry is right at the 7-day mark at the next restore (this schedule has drifted up to 7 minutes late). With the range narrowed an evicted cache, a Python minor bump under `python-version: '3.x'`, or an edit to `benchmarks.py` only costs one slow run instead of a red one.

The other way to resolve this is the cache split alone, keeping `v3.2.0..HEAD` (B1 and B2 above): it works, but every eviction or Python bump then produces one red seeding run before the job goes green again. I would take the version in this PR.

Disclosure: I ran the fork runs and the two-command reproduction above, re-read the 13 retained logs, and checked asv's `--skip-existing` and exit-code semantics against its source; the audit that surfaced the red job and this write-up were done with Claude (AI assistant) under my review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
