### PR TITLE
Fix tqdm.pandas() losing total across calls and crashing on empty frames

### DIFF
--- a/tests/tests_pandas.py
+++ b/tests/tests_pandas.py
@@ -221,3 +221,35 @@ def test_pandas_deprecation():
         # Check deprecation message
         assert "TqdmDeprecationWarning" in our_file.getvalue()
         assert "instead of `tqdm_pandas(tqdm, ...)`" in our_file.getvalue()
+
+
+def test_pandas_empty_dataframe():
+    """Test tqdm.pandas() on an empty DataFrame doesn't divide by zero"""
+    with closing(StringIO()) as our_file:
+        tqdm.pandas(file=our_file, leave=True, ascii=True)
+        df = pd.DataFrame(columns=["a", "b"])
+        res = df.progress_apply(lambda column: column)
+        assert res.shape == (0, 2)
+
+        df = pd.DataFrame(index=[0, 1])
+        res = df.progress_apply(lambda row: row, axis=1)
+        assert res.shape == (2, 0)
+
+
+def test_pandas_total_kept_across_calls():
+    """`total=` passed to tqdm.pandas() should apply to every subsequent call,
+    not just the first one"""
+    with closing(StringIO()) as our_file:
+        tqdm.pandas(file=our_file, ascii=True, leave=True, total=123,
+                    mininterval=0, miniters=1)
+
+        pd.Series([10, 20, 30]).progress_apply(lambda value: value + 1)
+        first = our_file.getvalue().replace('\r', '\n').strip().split('\n')[-1]
+        our_file.seek(0)
+        our_file.truncate(0)
+
+        pd.Series([10, 20, 30, 40]).progress_apply(lambda value: value + 1)
+        second = our_file.getvalue().replace('\r', '\n').strip().split('\n')[-1]
+
+        assert '/123' in first
+        assert '/123' in second

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -865,8 +865,11 @@ class tqdm(Comparable):
                     Transmitted to `df.apply()`.
                 """
 
-                # Precompute total iterations
-                total = tqdm_kwargs.pop("total", getattr(df, 'ngroups', None))
+                # Copy so `total` (and anything else) survives for the next call
+                # instead of being permanently removed from the shared kwargs the
+                # first time it is used.
+                call_kwargs = tqdm_kwargs.copy()
+                total = call_kwargs.pop("total", getattr(df, 'ngroups', None))
                 if total is None:  # not grouped
                     if df_function == 'applymap':
                         total = df.size
@@ -880,15 +883,16 @@ class tqdm(Comparable):
                             axis = 0
                         elif axis == 'columns':
                             axis = 1
-                        # when axis=0, total is shape[axis1]
-                        total = df.size // df.shape[axis]
+                        # when axis=0, total is shape[axis1]; an empty axis means
+                        # there is nothing to iterate, so avoid dividing by zero
+                        total = df.size // df.shape[axis] if df.shape[axis] else 0
 
                 # Init bar
                 if deprecated_t[0] is not None:
                     t = deprecated_t[0]
                     deprecated_t[0] = None
                 else:
-                    t = cls(total=total, **tqdm_kwargs)
+                    t = cls(total=total, **call_kwargs)
 
                 if len(args) > 0:
                     # *args intentionally not supported (see #244, #299)


### PR DESCRIPTION
Fixes the two bugs from #1810.

tqdm.pandas() registers a single shared kwargs dict when it's called, and the inner wrapper used to pop "total" straight out of that dict the first time progress_apply/progress_map ran. Every call after the first lost the configured total, since the key was already gone, and fell back to guessing it from the data instead of respecting what was passed in. Copying the kwargs per call keeps total (and anything else in tqdm_kwargs) intact for every subsequent call.

Separately, the fallback that computes a total for an ungrouped DataFrame divides df.size by df.shape[axis], which raises a plain ZeroDivisionError as soon as a frame has zero rows (axis=0) or zero columns (axis=1). There's nothing to iterate over in that case, so the total is just 0.

Added two regression tests to tests/tests_pandas.py, one per bug. Confirmed both fail against the current code and pass with this change (checked by stashing the tqdm/std.py change and re-running just these two tests). Full tests_pandas.py suite still passes (10/10).