### PR TITLE
Accept iterables without len() in tqdm.asyncio.as_completed

### DIFF
--- a/tests/tests_asyncio.py
+++ b/tests/tests_asyncio.py
@@ -166,3 +166,15 @@ async def test_async_iterable(caperr):
     assert result == list(range(9))
     err = caperr()
     assert '9it' in err
+
+
+@mark.asyncio
+async def test_as_completed_generator(capsys):
+    """Test asyncio as_completed with a generator (no len(), GitHub issue #1811)"""
+    tasks = (asyncio.create_task(asyncio.sleep(0, result=i)) for i in range(3))
+    result = [await i for i in as_completed(tasks)]
+    assert sorted(result) == [0, 1, 2]
+    _, err = capsys.readouterr()
+    # total is unknown for a generator, so the bar counts up (3it), not 3/3
+    assert '3it' in err
+    assert '3/3' not in err

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -64,7 +64,12 @@ class tqdm_asyncio(std_tqdm):
         Wrapper for `asyncio.as_completed`.
         """
         if total is None:
-            total = len(fs)
+            try:
+                total = len(fs)
+            except TypeError:
+                # `fs` may be a generator (accepted by `asyncio.as_completed`
+                # since Python 3.12); let the bar infer the total instead.
+                total = None
         kwargs = {}
         if version_info[:2] < (3, 10):
             kwargs['loop'] = loop


### PR DESCRIPTION
## Summary

Fixes #1811.

`asyncio.as_completed` has accepted generators of awaitables since Python 3.12, but the tqdm wrapper calls `len(fs)` unconditionally when `total` is omitted, raising `TypeError` for any input without a length:

```
TypeError: object of type 'generator' has no len()
```

This falls back to `total=None` for inputs without `len()`, so the bar simply infers progress (counting up) instead of crashing. Sized inputs (lists/tuples) keep the exact `n/n` total as before.

## Changes

- `tqdm/asyncio.py`: `as_completed()` — wrap the `len(fs)` in `try/except TypeError`, fall back to `total=None`
- `tests/tests_asyncio.py`: regression test feeding a generator (asserts counting behavior and results)

## Validation

- [x] Reproduced the issue's snippet on `main` — `TypeError: object of type 'generator' has no len()`
- [x] After the fix: generator input completes with `[0, 1, 2]`; list input still shows the exact `3/3` total
- [x] `python -m pytest tests/tests_asyncio.py -q` — 10 passed (9 existing + 1 new)

## Notes

Behavior change is limited to inputs that previously raised `TypeError` — no existing working call path changes output.