### PR TITLE
support unsized iterables in `asyncio.as_completed`

### DIFF
--- a/tests/tests_asyncio.py
+++ b/tests/tests_asyncio.py
@@ -120,6 +120,15 @@ async def test_as_completed(capsys, tol):
                 raise
 
 
+@mark.asyncio
+async def test_as_completed_unsized(capsys):
+    """Test asyncio as_completed with an unsized iterable"""
+    res = [await i for i in as_completed(asyncio.sleep(0, result=i) for i in range(3))]
+    _, err = capsys.readouterr()
+    assert sorted(res) == [0, 1, 2]
+    assert '3/3' in err
+
+
 async def double(i):
     return i * 2
 

--- a/tqdm/asyncio.py
+++ b/tqdm/asyncio.py
@@ -64,7 +64,11 @@ class tqdm_asyncio(std_tqdm):
         Wrapper for `asyncio.as_completed`.
         """
         if total is None:
-            total = len(fs)
+            try:
+                total = len(fs)
+            except TypeError:  # e.g. generator: `asyncio` consumes it eagerly anyway
+                fs = list(fs)
+                total = len(fs)
         kwargs = {}
         if version_info[:2] < (3, 10):
             kwargs['loop'] = loop


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s) — closes #1811

## Problem

`tqdm_asyncio.as_completed()` calls `len(fs)` whenever `total` is omitted, so an unsized
iterable of awaitables fails, even though `asyncio.as_completed()` accepts it:

```python
import asyncio
from tqdm.asyncio import tqdm_asyncio

async def main():
    tasks = (asyncio.create_task(asyncio.sleep(0, result=v)) for v in range(3))
    return [await f for f in tqdm_asyncio.as_completed(tasks)]

asyncio.run(main())
# TypeError: object of type 'generator' has no len()
```

Passing the same generator straight to `asyncio.as_completed` returns `[0, 1, 2]`.

## Fix

Fall back to materialising the iterable when it has no `__len__`. That costs nothing in
laziness: `asyncio` already consumes the awaitables eagerly when the iterator is
constructed — `_AsCompletedIterator.__init__` does
`todo = {ensure_future(aw, loop=loop) for aw in set(aws)}` — so a generator was never
iterated lazily by asyncio either. The sized path is untouched, and an explicit
`total=` still short-circuits the check.

## Test

`tests/tests_asyncio.py::test_as_completed_unsized` — on master it fails with the
`TypeError` above; with the fix it passes and the bar reaches `3/3`.

## Verification

Ran locally against 96f2e60, Python 3.14.3, darwin:

- `pytest tests/ -m "not slow"` → `142 passed, 6 skipped` (skips are numpy / rich / tkinter not installed)
- `flake8 --max-line-length=99` clean on both touched files

## AI disclosure

Written with Claude Code (Claude Opus 5) and credited in the commit trailer. The
reproduction above, the new test and the suite results were run locally, not asserted
from the model.
