### PR TITLE
report the original error when bot message creation fails

### DIFF
--- a/tests/tests_contrib.py
+++ b/tests/tests_contrib.py
@@ -1,6 +1,8 @@
 """
 Tests for `tqdm.contrib`.
 """
+from importlib import import_module
+
 import pytest
 
 from tqdm import tqdm
@@ -59,3 +61,23 @@ def test_map(tqdm_kwargs):
         gen = tmap(lambda x: x + 1, a, file=our_file, **tqdm_kwargs)
         assert gen != b
         assert list(gen) == b
+
+
+@pytest.mark.parametrize("name,cls_name,args", [
+    ("discord", "DiscordIO", ("TOKEN", "CHANNEL")), ("telegram", "TelegramIO", ("TOKEN", "CHAT"))])
+def test_bot_io_request_error(capsys, monkeypatch, name, cls_name, args):
+    """Test contrib bots report the original request error"""
+    importorskip("requests")
+    mod = import_module(f"tqdm.contrib.{name}")
+
+    class BrokenSession:
+        def __init__(self, *_, **__):
+            pass
+
+        def post(self, *_, **__):
+            raise ConnectionError("connection refused")
+
+    monkeypatch.setattr(mod, "Session", BrokenSession)
+    assert getattr(mod, cls_name)(*args).message_id is None
+    out, _ = capsys.readouterr()
+    assert "connection refused" in out

--- a/tqdm/contrib/discord.py
+++ b/tqdm/contrib/discord.py
@@ -41,6 +41,7 @@ class DiscordIO(MonoWorker):
     def message_id(self):
         if hasattr(self, '_message_id'):
             return self._message_id  # pylint: disable=access-member-before-definition
+        req = None
         try:
             req = self.session.post(
                 f'{self.API}/channels/{self.channel_id}/messages',
@@ -49,7 +50,7 @@ class DiscordIO(MonoWorker):
             res = req.json()
             req.raise_for_status()
         except Exception as e:
-            if req.status_code == 429:
+            if req is not None and req.status_code == 429:
                 warn("Creation rate limit: try increasing `mininterval`.",
                      TqdmWarning, stacklevel=2)
             else:

--- a/tqdm/contrib/telegram.py
+++ b/tqdm/contrib/telegram.py
@@ -38,6 +38,7 @@ class TelegramIO(MonoWorker):
     def message_id(self):
         if hasattr(self, '_message_id'):
             return self._message_id  # pylint: disable=access-member-before-definition
+        req = None
         try:
             req = self.session.post(
                 f'{self.API}{self.token}/sendMessage',
@@ -46,7 +47,7 @@ class TelegramIO(MonoWorker):
             res = req.json()
             req.raise_for_status()
         except Exception as e:
-            if req.status_code == 429:
+            if req is not None and req.status_code == 429:
                 warn("Creation rate limit: try increasing `mininterval`.",
                      TqdmWarning, stacklevel=2)
             else:


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s) — closes #1812

## Problem

`DiscordIO.message_id` and `TelegramIO.message_id` inspect `req.status_code` inside the
exception handler, but `req` is only assigned by the `session.post()` call itself. When
that call raises — an unreachable host, DNS failure, proxy error — `req` is unbound and
the handler dies with `UnboundLocalError`, discarding the real error:

```python
from tqdm.contrib import discord as discord_module
from tqdm.contrib.discord import DiscordIO

class BrokenSession:
    def __init__(self, *a, **k): pass
    def post(self, *a, **k): raise ConnectionError("connection refused")

discord_module.Session = BrokenSession
DiscordIO("TOKEN", "CHANNEL")
# UnboundLocalError: cannot access local variable 'req' where it is not associated with a value
```

`tqdm/contrib/telegram.py` has the same shape and fails the same way. `slack.py` does not
use `requests`, so it is unaffected.

## Fix

Initialise `req = None` before the request and guard the rate-limit branch with
`req is not None`. A response that arrives and then fails (`raise_for_status`, bad JSON)
still takes the existing 429 path; a request that never produced a response now reports
its own exception through `tqdm_auto.write`, which is what the `else` branch was always
meant to do.

## Test

`tests/tests_contrib.py::test_bot_io_request_error` — parametrised over the Discord and
Telegram IO classes, with `Session` swapped for one whose `post()` raises. On master both
cases fail with `UnboundLocalError`; with the fix `message_id` is `None` and the original
`connection refused` text reaches the output. `requests` is `importorskip`ed so the test
skips where the optional dependency is absent.

## Verification

Ran locally against 96f2e60, Python 3.14.3, darwin:

- `pytest tests/ -m "not slow"` → `142 passed, 6 skipped` (skips are numpy / rich / tkinter not installed)
- `flake8 --max-line-length=99` clean on the three touched files

## AI disclosure

Written with Claude Code (Claude Opus 5) and credited in the commit trailer. The
reproduction above, the new test and the suite results were run locally, not asserted
from the model.
