### PR TITLE
Don't register progress_map on GroupBy classes

### DIFF
--- a/tests/tests_pandas.py
+++ b/tests/tests_pandas.py
@@ -92,6 +92,19 @@ def test_pandas_data_frame(caperr):
 
 
 @mark.filterwarnings("ignore:DataFrameGroupBy.apply operated on the grouping columns")
+def test_pandas_groupby_no_progress_map():
+    """Test (DataFrame|Series)GroupBy has no progress_map"""
+    tqdm.pandas(leave=False, ascii=True)
+
+    df = pd.DataFrame({'a': randint(0, 2, (10,)), 'b': rand(10)})
+    # pandas has no GroupBy.map for progress_map to wrap, so registering it
+    # would only produce an AttributeError at call time
+    assert not hasattr(df.groupby('a'), 'map')
+    assert not hasattr(df.groupby('a')['b'], 'map')
+    assert not hasattr(df.groupby('a'), 'progress_map')
+    assert not hasattr(df.groupby('a')['b'], 'progress_map')
+
+
 def test_pandas_groupby_apply(caperr):
     """Test pandas.DataFrame.groupby(...).progress_apply"""
     tqdm.pandas(leave=False, ascii=True)

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -928,16 +928,17 @@ class tqdm(Comparable):
 
         # Monkeypatch pandas to provide easy methods
         # Enable custom tqdm progress in pandas!
+        # NOTE: `progress_map` is deliberately not registered on the GroupBy
+        # classes: pandas has no `SeriesGroupBy.map`/`DataFrameGroupBy.map` for
+        # it to wrap, so it could only ever raise AttributeError when called.
         Series.progress_apply = inner_generator()
         SeriesGroupBy.progress_apply = inner_generator()
         Series.progress_map = inner_generator('map')
-        SeriesGroupBy.progress_map = inner_generator('map')
 
         DataFrame.progress_apply = inner_generator()
         DataFrameGroupBy.progress_apply = inner_generator()
         DataFrame.progress_applymap = inner_generator('applymap')
         DataFrame.progress_map = inner_generator('map')
-        DataFrameGroupBy.progress_map = inner_generator('map')
 
         if Panel is not None:
             Panel.progress_apply = inner_generator()


### PR DESCRIPTION
`tqdm.pandas()` registered `progress_map` on both `SeriesGroupBy` and `DataFrameGroupBy`, but pandas has no `map()` on either class. The wrapper resolves the underlying method lazily via `getattr(df, df_function)`, so these attributes existed but raised as soon as they were called:

    >>> df.groupby('g').progress_map(lambda x: x)
    AttributeError: 'DataFrameGroupBy' object has no attribute 'map'

The message points at `map` rather than `progress_map`, which reads as if pandas itself is broken instead of tqdm having registered a method that could never work.

Neither registration can be made functional -- there is no GroupBy.map to wrap -- so both are removed. `df.groupby(...).progress_map` now raises the ordinary AttributeError for a method that does not exist, consistent with any other typo, and a comment records why it must not be re-added.

`Series.progress_map`, `DataFrame.progress_map`, `DataFrame.progress_applymap` and `progress_apply` on all four classes are unaffected.

The existing suite covered `progress_apply` on groupby but never `progress_map`, which is how this went unnoticed; a test is added to cover the gap.

Closes #1803