### PR TITLE
fix: restore concurrent map locks after exceptions

### DIFF
--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -1,14 +1,57 @@
 import sys
+from contextlib import nullcontext
+from threading import RLock
 
-from pytest import mark, skip, warns
+from pytest import mark, raises, skip, warns
 
-from tqdm import TqdmWarning
+from tqdm import TqdmWarning, tqdm
 from tqdm.contrib import concurrent
-from tqdm.contrib.concurrent import interpreter_map, process_map, thread_map
+from tqdm.contrib.concurrent import ensure_lock, interpreter_map, process_map, thread_map
 
 
 def dummy_func(x):
     return x + 1
+
+
+def failing_func(x):
+    raise ValueError("worker failed")
+
+
+@mark.parametrize("error", [None, ValueError, KeyboardInterrupt])
+def test_ensure_lock_restore(error, monkeypatch):
+    original_lock, temporary_lock = RLock(), RLock()
+    monkeypatch.setattr(tqdm, '_lock', original_lock, raising=False)
+    with raises(error, match="test failure") if error else nullcontext():
+        with ensure_lock(tqdm, lock=temporary_lock) as lock:
+            assert lock is temporary_lock
+            assert tqdm.get_lock() is temporary_lock
+            if error:
+                raise error("test failure")
+    assert tqdm.get_lock() is original_lock
+
+
+@mark.parametrize("error", [None, ValueError, KeyboardInterrupt])
+def test_ensure_lock_remove(error, monkeypatch):
+    monkeypatch.setattr(tqdm, '_lock', None, raising=False)
+    monkeypatch.delattr(tqdm, '_lock')
+    with raises(error, match="test failure") if error else nullcontext():
+        with ensure_lock(tqdm) as lock:
+            assert tqdm.get_lock() is lock
+            if error:
+                raise error("test failure")
+    assert not hasattr(tqdm, '_lock')
+
+
+def test_ensure_lock_nested_exception(monkeypatch):
+    original_lock, outer_lock, inner_lock = RLock(), RLock(), RLock()
+    monkeypatch.setattr(tqdm, '_lock', original_lock, raising=False)
+    with ensure_lock(tqdm, lock=outer_lock):
+        with raises(ValueError, match="inner failure"):
+            with ensure_lock(tqdm, lock=inner_lock):
+                assert tqdm.get_lock() is inner_lock
+                raise ValueError("inner failure")
+        assert tqdm.get_lock() is outer_lock
+    assert tqdm.get_lock() is original_lock
 
 
 @mark.parametrize("mapper", [interpreter_map, process_map, thread_map])
@@ -21,6 +64,23 @@ def test_concurrent_map(mapper, caperr):
         skip(str(err))
     err = caperr()
     assert '0/9' in err
+
+
+@mark.parametrize("mapper,lock_name", [(interpreter_map, ''), (process_map, 'mp_lock'),
+                                       (thread_map, 'th_lock')])
+@mark.parametrize("worker_error", [False, True])
+def test_concurrent_map_exception(mapper, lock_name, worker_error, monkeypatch):
+    original_lock = tqdm.get_lock()
+    monkeypatch.setattr(tqdm, '_lock', original_lock)
+    fn = failing_func if worker_error else dummy_func
+    max_workers = 1 if worker_error else 0
+    with raises(ValueError, match="worker failed" if worker_error else "max_workers"):
+        try:
+            mapper(fn, [0], max_workers=max_workers, lock_name=lock_name,
+                   tqdm_class=tqdm, disable=True)
+        except ImportError as err:
+            skip(str(err))
+    assert tqdm.get_lock() is original_lock
 
 
 def check_lock(args):

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -76,11 +76,13 @@ def ensure_lock(tqdm_class, lock_name="", lock=None):
         lock = old_lock or tqdm_class.get_lock()  # maybe create a new lock
     lock = getattr(lock, lock_name, lock)  # maybe subtype
     tqdm_class.set_lock(lock)
-    yield lock
-    if old_lock is None:
-        del tqdm_class._lock
-    else:
-        tqdm_class.set_lock(old_lock)
+    try:
+        yield lock
+    finally:
+        if old_lock is None:
+            del tqdm_class._lock
+        else:
+            tqdm_class.set_lock(old_lock)
 
 
 def _get_interpreter_init(tqdm_class, lock_queue_id):


### PR DESCRIPTION
## Summary

Restore the original tqdm write lock when a concurrent map exits with an exception.

`ensure_lock()` currently restores the lock only after a normal return from `yield`. A worker exception or an executor-construction error leaves the temporary lock installed on the tqdm class. For example, a failed `process_map()` retains the `mp_lock` member in place of the original composite lock, and a failed `interpreter_map()` retains its cross-interpreter lock.

Put the existing restoration/removal logic in a `finally` block. This also restores an outer lock after a nested context fails and removes a newly created class lock when there was none before entry. Exceptions still propagate unchanged; there is no public API or dependency change.

## Regression tests

The 13 new cases cover:

- Normal exit, `ValueError`, and `KeyboardInterrupt` with an explicit temporary lock.
- The same exits when the class initially has no lock.
- A nested context whose inner exception is caught inside the outer context.
- Real thread, process, and interpreter maps when a worker raises or `max_workers=0` makes executor construction fail.

Before the production change, `tests/tests_concurrent.py` reports **11 failed, 14 passed**. After the fix it reports **25 passed**, including all three executor types on Python 3.14.

## Validation

Windows 11 x64; Conda Python 3.14.7; upstream base `8d6ff8de5a9066de77d0a9df3e80a022a3dcf146`.
The tested development version is `4.70.1.dev7+g8d6ff8de5.d20260906`.

- `python -m pytest --cov=tqdm --cov-report=term-missing -k "not perf"`: **185 passed, 3 skipped, 7 deselected**. The skips are the optional Keras integration and the existing Windows man-page/completion cases.
- `python -m pytest -k perf`: **7 passed**.
- flake8 7.3.0 with the repository's configured plugins, and isort 9.0.0b1 `--check-only --diff`: passed for all 68 tracked Python files.
- `python -m build --no-isolation`, `python -m twine check dist/*`, and `python -m pymake -h`: passed. The wheel is **80,740 bytes**, below the CI limit of 102,400 bytes.
- `python -m pip check` and `git diff --check`: passed.

The separate notebook execution suite, TensorFlow/Keras, and other Python/OS combinations were not run locally; a complete tox run is not claimed. No tests or project configuration were changed to hide failures.

## Checklist

- [x] I have marked all applicable categories:
    + [x] exception-raising fix (exception-path cleanup; exceptions remain visible)
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s) — no matching issue found.
- [x] Any AI-assisted commits are clearly marked (`Assisted-by: OpenAI Codex`).
- [x] I have visited the [source website](https://github.com/tqdm/tqdm/) and read the [known issues](https://github.com/tqdm/tqdm/#faq-and-known-issues).
- [x] I have searched the issue and PR trackers for duplicates.
- [x] I have mentioned the version numbers, operating system, and environment.

AI assistance: Codex helped locate the bug, implement the patch, and write the tests. The validation results above are from actual local runs.

