### PR TITLE
Fix notebook progress bars with CSS widths

### DIFF
--- a/tests/tests_notebook.py
+++ b/tests/tests_notebook.py
@@ -1,3 +1,5 @@
+from pytest import importorskip, mark
+
 from tqdm.notebook import tqdm as tqdm_notebook
 
 
@@ -5,3 +7,39 @@ def test_notebook_disabled_description():
     """Test that set_description works for disabled tqdm_notebook"""
     with tqdm_notebook(1, disable=True) as t:
         t.set_description("description")
+
+
+@mark.parametrize("ncols", ["100%", "480px"])
+@mark.parametrize("bar_format", [None, "{l_bar}{bar:20}{r_bar}"])
+def test_notebook_css_width(ncols, bar_format):
+    """CSS widths must not be used as character counts in text representations."""
+    importorskip("ipywidgets")
+    pretty = importorskip("IPython.lib.pretty").pretty
+    with tqdm_notebook(total=4, ncols=ncols, bar_format=bar_format, display=False) as t:
+        assert "0/4" in repr(t.container)
+        t.update(2)
+        t.refresh()
+        assert "2/4" in str(t)
+        assert "2/4" in repr(t.container)
+        assert "2/4" in pretty(t.container)
+        if hasattr(t.container, "_repr_mimebundle_"):
+            assert "2/4" in t.container._repr_mimebundle_()["text/plain"]
+        assert t.container.children[1].value == 2
+        assert t.ncols == ncols
+        assert t.container.layout.width == ncols
+    assert t.container.layout.width == ncols
+
+
+@mark.parametrize("ncols", [None, 0, 80])
+def test_notebook_numeric_width(ncols):
+    """Keep existing text formatting for numeric and unspecified widths."""
+    importorskip("ipywidgets")
+    with tqdm_notebook(total=4, ncols=ncols, display=False) as t:
+        assert t.format_dict["ncols"] == ncols
+        text = repr(t.container)
+        assert "0/4" in text
+        if ncols:
+            assert len(text) == ncols
+            assert t.container.layout.width == f"{ncols}px"
+        elif ncols == 0:
+            assert "|" not in text

--- a/tqdm/notebook.py
+++ b/tqdm/notebook.py
@@ -192,6 +192,14 @@ class tqdm_notebook(std_tqdm):
             self.displayed = True
 
     @property
+    def format_dict(self):
+        d = super().format_dict
+        # CSS widths apply to the widget layout, not text character counts.
+        if isinstance(d['ncols'], str):
+            d['ncols'] = None
+        return d
+
+    @property
     def colour(self):
         if hasattr(self, 'container'):
             return self.container.children[-2].style.bar_color


### PR DESCRIPTION
Fixes #1533.

The documented notebook widths `ncols='100%'` and `ncols='480px'` reach `format_meter` as strings. On current master, even constructing the bar with `display=False` raises `TypeError` when the initial display tries to trim text using that width. Widget representations and custom bar formats also use the same text formatter.

Override the notebook's `format_dict` to use the default text width for CSS string values. The original `ncols` and widget `layout.width` are preserved; numeric widths and `None` retain their existing behavior.

Regression tests cover both documented CSS widths, default and custom bar formats, construction, updates, `str`, widget `repr`, IPython pretty output, the MIME text fallback where available, and numeric/unspecified widths.

Minimal reproduction on master:

```python
from tqdm.notebook import tqdm

with tqdm(total=4, ncols="100%", display=False) as bar:
    bar.update(2)
    print(repr(bar.container))
    assert bar.container.layout.width == "100%"
```

Validation on macOS arm64, Python 3.12.14, ipywidgets 8.1.9, IPython 9.17.1, based on master `8d6ff8de`:

- `pytest -k 'not perf' --cov=tqdm`: 179 passed, 3 skipped, 7 deselected. Skips are two Python 3.14-only tests and the unavailable Keras integration; the 7 deselected cases are performance tests.
- Existing `tests_notebook.ipynb` with the project's nbval command: 19 passed.
- `pre-commit run --files tqdm/notebook.py tests/tests_notebook.py`: passed.
- `python -m build`, `python -m twine check dist/*`, and `git diff --check`: passed.

- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [x] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [x] Any AI-assisted commits are clearly marked (the commit includes `Assisted-by: OpenAI Codex`)
- [x] I have visited the source website and read the known issues
- [x] I have searched through the issue tracker for duplicates
- [x] I have mentioned version numbers, operating system and environment

AI assistance: this patch and its regression tests were prepared with OpenAI Codex and checked locally as described above.
