### PR TITLE
Fix ZeroDivisionError in tqdm.pandas on empty DataFrame

### DIFF
--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -881,7 +881,7 @@ class tqdm(Comparable):
                         elif axis == 'columns':
                             axis = 1
                         # when axis=0, total is shape[axis1]
-                        total = df.size // df.shape[axis]
+                        total = df.size // df.shape[axis] if df.shape[axis] else 0
 
                 # Init bar
                 if deprecated_t[0] is not None:


### PR DESCRIPTION
Fixes #1810 (first bug).

`df.progress_apply(...)` on an empty DataFrame crashed with `ZeroDivisionError` because the total was computed as `df.size // df.shape[axis]`, which divides by zero when the DataFrame has no rows (`axis=0`) or no columns (`axis=1`).

The fix guards the divisor:

```python
total = df.size // df.shape[axis] if df.shape[axis] else 0
```

Verified with the issue's repro (empty DataFrame, both `axis=0` and `axis=1`), confirmed the normal non-empty case still works, and the existing `tests/tests_pandas.py` suite passes (8 passed).