### PR TITLE
fix: catch ValueError in Bar.colour setter for invalid hex strings

### DIFF
--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1552,6 +1552,14 @@ def test_colour_unknown():
             t.update()
 
 
+def test_colour_invalid_hex():
+    # gh-1826: a well-formed #rrggbb string with a non-hex digit raised
+    # ValueError from int(i, 16) instead of emitting TqdmWarning.
+    with warns(TqdmWarning, match="Unknown colour"):
+        with tqdm(total=1, colour="#00ff0g") as t:
+            t.update()
+
+
 def test_closed_file(tmp_file):
     for i in trange(9, file=tmp_file, miniters=1, mininterval=0):
         if i == 5:

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -175,7 +175,7 @@ class Bar:
                     int(i, 16) for i in (value[1:3], value[3:5], value[5:7]))
             else:
                 raise KeyError
-        except (KeyError, AttributeError):
+        except (KeyError, AttributeError, ValueError):
             warn(f"Unknown colour ({value}); valid choices:"
                  f" [hex (#00ff00), {', '.join(self.COLOURS)}]", TqdmWarning, stacklevel=2)
             self._colour = None


### PR DESCRIPTION
## What this fixes

Closes #1826.

Setting `colour='#00ff0g'` (a `#rrggbb` string with a non-hex digit) raised an unhandled `ValueError` instead of the expected `TqdmWarning`:

```python
from tqdm import tqdm
list(tqdm(range(3), colour="#00ff0g"))
# ValueError: invalid literal for int() with base 16: '0g'
```

## Root cause

In `tqdm/std.py`, the `Bar.colour` setter parses `#rrggbb` strings with:

```python
int(i, 16) for i in (value[1:3], value[3:5], value[5:7])
```

When a hex component contains a non-hex character, `int(i, 16)` raises `ValueError`. The `except` clause only caught `(KeyError, AttributeError)`, so `ValueError` propagated uncaught instead of falling through to the `TqdmWarning` branch that handles all other unknown/invalid colour values.

## Fix

Add `ValueError` to the except tuple in `tqdm/std.py` line 178:

```python
# before
except (KeyError, AttributeError):
# after
except (KeyError, AttributeError, ValueError):
```

## Tests

Added `test_colour_invalid_hex` alongside the existing `test_colour_unknown` test. All 4 colour tests pass.
