### PR TITLE
Fix ValueError in thread_map/process_map with no-length iterables

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr.md
@@ -9,7 +9,7 @@ about: Use this template for proposing change(s)
     + [ ] documentation modification
     + [ ] new feature
 - [ ] If applicable, I have mentioned the relevant/related issue(s)
-- [ ] Any AI-assisted commits are clearly marked ([author], [Co-authored-by] or [Assisted-by])
+- [ ] Any AI-assisted commits are clearly marked ([author], [Co-authored-by] or [Assisted-by]) using the syntax `Provider Model <email>`, e.g. `Co-authored-by: Claude Opus 5 <noreply@anthropic.com>`
 
 Less important but also useful:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
   - id: pyupgrade
     args: [--py38-plus]
 - repo: https://github.com/PyCQA/isort
-  rev: 9.0.0b1
+  rev: 9.0.1
   hooks:
   - id: isort
 - repo: https://github.com/kynan/nbstripout

--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -11,6 +11,13 @@ def dummy_func(x):
     return x + 1
 
 
+def test_min_map_len():
+    """GH #1828: must not raise when every iterable has an unknown length (or there are none)"""
+    assert concurrent._min_map_len([]) == 0
+    assert concurrent._min_map_len([(i for i in range(9))]) == 0
+    assert concurrent._min_map_len([(i for i in range(9)), range(5)]) == 5
+
+
 @mark.parametrize("mapper", [interpreter_map, process_map, thread_map])
 def test_concurrent_map(mapper, caperr):
     a = range(9)
@@ -21,6 +28,18 @@ def test_concurrent_map(mapper, caperr):
         skip(str(err))
     err = caperr()
     assert '0/9' in err
+
+
+@mark.parametrize("mapper", [interpreter_map, process_map, thread_map])
+def test_concurrent_map_no_length_hint(mapper, caperr):
+    """GH #1828: iterables with no length hint (e.g. generators) shouldn't raise `ValueError`"""
+    b = [i + 1 for i in range(9)]
+    try:
+        assert mapper(dummy_func, (i for i in range(9))) == b
+    except ImportError as err:
+        skip(str(err))
+    err = caperr()
+    assert '9it [' in err
 
 
 def check_lock(args):

--- a/tests/tests_concurrent.py
+++ b/tests/tests_concurrent.py
@@ -12,7 +12,6 @@ def dummy_func(x):
 
 
 def test_min_map_len():
-    """GH #1828: must not raise when every iterable has an unknown length (or there are none)"""
     assert concurrent._min_map_len([]) == 0
     assert concurrent._min_map_len([(i for i in range(9))]) == 0
     assert concurrent._min_map_len([(i for i in range(9)), range(5)]) == 5
@@ -31,8 +30,7 @@ def test_concurrent_map(mapper, caperr):
 
 
 @mark.parametrize("mapper", [interpreter_map, process_map, thread_map])
-def test_concurrent_map_no_length_hint(mapper, caperr):
-    """GH #1828: iterables with no length hint (e.g. generators) shouldn't raise `ValueError`"""
+def test_concurrent_map_unknown_len(mapper, caperr):
     b = [i + 1 for i in range(9)]
     try:
         assert mapper(dummy_func, (i for i in range(9))) == b

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -100,8 +100,8 @@ def _get_interpreter_init(tqdm_class, lock_queue_id):
 
 
 def _min_map_len(iterables):
-    """min(map(length_hint, iterables))"""
-    return min(n for it in iterables if (n := length_hint(it, -1)) >= 0)
+    """min(map(length_hint, iterables)), ignoring unknown lengths [default: 0]"""
+    return min((n for it in iterables if (n := length_hint(it, -1)) >= 0), default=0)
 
 
 def _executor_map(

--- a/tqdm/contrib/concurrent.py
+++ b/tqdm/contrib/concurrent.py
@@ -100,7 +100,7 @@ def _get_interpreter_init(tqdm_class, lock_queue_id):
 
 
 def _min_map_len(iterables):
-    """min(map(length_hint, iterables)), ignoring unknown lengths [default: 0]"""
+    """min(map(length_hint, iterables), default=0)"""
     return min((n for it in iterables if (n := length_hint(it, -1)) >= 0), default=0)
 
 


### PR DESCRIPTION
Fixes #1828: `thread_map`/`process_map`/`interpreter_map` raised
`ValueError: min() iterable argument is empty` when every input iterable had
no known length (e.g. a bare generator), because `_min_map_len()` called
`min()` on a filtered-empty generator expression. Restored the pre-2023
fallback behavior (`total=0`, i.e. "unknown total") for the all-unknown case
by adding `default=0` to that `min()` call.

- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [x] Any AI-assisted commits are clearly marked