### PR TITLE
Fix CLI error handling for invalid log levels

### DIFF
--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -64,16 +64,57 @@ def test_main_bytes(capsysbinary, monkeypatch):
     assert str(len(IN_DATA)) + "B" in err.decode('U8')
 
 
+@mark.parametrize("equals", [False, True])
 @mark.parametrize("level,logged", [("INFO", False), ("DEBUG", True)])
-def test_main_log(capsysbinary, caplog, monkeypatch, level, logged):
+def test_main_log(capsysbinary, caplog, monkeypatch, level, logged, equals):
     N = 123
     lines = [(str(i) + '\n').encode() for i in range(N)]
     monkeypatch.setattr(sys, 'stdin', lines)
     with caplog.at_level(getattr(logging, level)):
-        main(sys.stderr, ['--log', level])
+        main(sys.stderr, [f'--log={level}'] if equals else ['--log', level])
         out, err = capsysbinary.readouterr()
         assert norm(out) == b''.join(lines) and b"123/123" in err
         assert bool(caplog.record_tuples) is logged
+
+
+@mark.parametrize("args", [
+    ['--log'], ['--log='], ['--log', '--bytes'],
+    ['--log', 'NOTALEVEL'], ['--log=NOTALEVEL'],
+    ['--log', 'basicConfig'], ['--log=BASIC_FORMAT'],
+])
+def test_main_invalid_log(capsys, monkeypatch, args):
+    lines = ['first line\n', 'second line without a newline']
+    monkeypatch.setattr(sys, 'stdin', lines)
+    with raises(TqdmTypeError, match='log level'):
+        main(sys.stderr, args)
+    out, err = capsys.readouterr()
+    assert out == ''.join(lines)
+    assert 'Error:' in err and 'Usage:' in err
+
+
+@mark.parametrize("level", [
+    'CRITICAL', 'FATAL', 'ERROR', 'WARN', 'WARNING', 'INFO', 'DEBUG', 'NOTSET',
+])
+def test_main_log_level(level):
+    data = b'first line\nlast line'
+    result = subprocess.run(  # nosec
+        [sys.executable, '-m', 'tqdm', '--log', level], input=data,
+        capture_output=True)
+    assert result.returncode == 0
+    assert norm(result.stdout) == data
+    assert b'Error:' not in result.stderr
+
+
+@mark.parametrize("args", [['--log'], ['--log=NOTALEVEL']])
+def test_pipes_invalid_log(args):
+    data = b'first line\nlast line'
+    result = subprocess.run(  # nosec
+        [sys.executable, '-m', 'tqdm', *args], input=data,
+        capture_output=True)
+    assert result.returncode != 0
+    assert norm(result.stdout) == data
+    assert b'TqdmTypeError:' in result.stderr
+    assert b'Usage:' in result.stderr
 
 
 def test_main_misc_options(capsysbinary, monkeypatch):

--- a/tqdm/cli.py
+++ b/tqdm/cli.py
@@ -162,22 +162,6 @@ def main(fp=sys.stderr, argv=None):
     """
     if argv is None:
         argv = sys.argv[1:]
-    try:
-        log_idx = argv.index('--log')
-    except ValueError:
-        for i in argv:
-            if i.startswith('--log='):
-                logLevel = i[len('--log='):]
-                break
-        else:
-            logLevel = 'INFO'
-    else:
-        # argv.pop(log_idx)
-        # logLevel = argv.pop(log_idx)
-        logLevel = argv[log_idx + 1]
-    logging.basicConfig(level=getattr(logging, logLevel),
-                        format="%(levelname)s:%(module)s:%(lineno)d:%(message)s")
-
     # py<3.13 doesn't dedent docstrings
     d = (tqdm.__doc__ if sys.version_info < (3, 13)
          else indent(tqdm.__doc__, "    ")) + CLI_EXTRA_DOC
@@ -187,8 +171,6 @@ def main(fp=sys.stderr, argv=None):
 
     for o in UNSUPPORTED_OPTS:
         opt_types.pop(o)
-
-    log.debug(sorted(opt_types.items()))
 
     # d = RE_OPTS.sub(r'  --\1=<\1>  : \2', d)
     split = RE_OPTS.split(d)
@@ -218,11 +200,17 @@ Options:
     argv = RE_SHLEX.split(' '.join(["tqdm"] + argv))
     opts = dict(zip(argv[1::3], argv[3::3]))
 
-    log.debug(opts)
-    opts.pop('log', True)
-
     tqdm_args = {'file': fp}
     try:
+        log_level = opts.pop('log', 'INFO')
+        level = logging.getLevelName(log_level)
+        if not isinstance(level, int):
+            raise TqdmTypeError(f'{log_level!r} : log level')
+        logging.basicConfig(level=level,
+                            format="%(levelname)s:%(module)s:%(lineno)d:%(message)s")
+        log.debug(sorted(opt_types.items()))
+        log.debug(opts)
+
         for (o, v) in opts.items():
             o = o.replace('-', '_')
             try:


### PR DESCRIPTION
Fixes #1827.

`--log` with a missing or invalid value currently raises before the CLI's argument-error handler, so usage is not displayed and piped input is lost. Parse it with the existing option parser and validate the level before configuring logging. Invalid values now raise `TqdmTypeError` through the same recovery path as other invalid CLI options, preserving stdin on stdout.

Tests cover both `--log LEVEL` and `--log=LEVEL`, missing values, unknown names, non-level attributes of `logging`, all standard levels and aliases, and real subprocess pipelines with a final line without a newline. The seven invalid-input regression cases fail on the base commit and pass with this change.

Validation on macOS / Python 3.12.9:

- CLI suite: 28 passed.
- `pytest -k 'not slow' --cov=tqdm --cov-fail-under=70`: 180 passed, 3 skipped (Python 3.14 interpreter support), 22 deselected; 72.73% coverage.
- Flake8 with the configured plugins, Isort, Pyupgrade, and `git diff --check` passed.

- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] visual output fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [x] Any AI-assisted commits are clearly marked using `Provider Model <email>` (`Assisted-by: OpenAI GPT-6 <noreply@openai.com>`).
- [x] I have visited the source website and read the known issues.
- [x] I have searched through the issue tracker for duplicates.
- [x] I have mentioned version numbers, operating system and environment where applicable.
