### PR TITLE
Add Fira Code progress bar glyphs support

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -326,6 +326,11 @@ of a neat one-line progress bar.
 
   * Environments which report that they support unicode will have solid smooth
     progress bars. The fallback is an ``ascii``-only bar.
+  * Fira Code and compatible fonts can use their dedicated progress bar
+    glyphs. Set ``UNICODE_PROGRESS_BAR=true`` as described in the
+    `Fira Code specification
+    <https://github.com/tonsky/FiraCode#whats-in-the-box>`__.
+    An explicit ``ascii`` value overrides this environment variable.
   * Windows consoles often only partially support unicode and thus
     `often require explicit ascii=True <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__
     (also `here <https://github.com/tqdm/tqdm/issues/499>`__). This is due to

--- a/README.rst
+++ b/README.rst
@@ -326,6 +326,11 @@ of a neat one-line progress bar.
 
   * Environments which report that they support unicode will have solid smooth
     progress bars. The fallback is an ``ascii``-only bar.
+  * Fira Code and compatible fonts can use their dedicated progress bar
+    glyphs. Set ``UNICODE_PROGRESS_BAR=true`` as described in the
+    `Fira Code specification
+    <https://github.com/tonsky/FiraCode#whats-in-the-box>`__.
+    An explicit ``ascii`` value overrides this environment variable.
   * Windows consoles often only partially support unicode and thus
     `often require explicit ascii=True <https://github.com/tqdm/tqdm/issues/454#issuecomment-335416815>`__
     (also `here <https://github.com/tqdm/tqdm/issues/499>`__). This is due to
@@ -425,6 +430,8 @@ Parameters
 * ascii  : bool or str, optional  
     If unspecified or False, use unicode (smooth blocks) to fill
     the meter. The fallback is to use ASCII characters " 123456789#".
+    Set ``UNICODE_PROGRESS_BAR=true`` to use Fira Code bar glyphs.
+    An explicit value overrides the environment variable.
 * disable  : bool, optional  
     Whether to disable the entire progress bar wrapper
     [default: False]. If set to None, disable on non-TTY.

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -17,7 +17,7 @@ class Comparison:
     def run(self, cls):
         pbar = cls(self.iterable)
         t0 = self.time()
-        all(pbar)  # pylint: disable=pointless-statement
+        _ = all(pbar)
         t1 = self.time()
         return t1 - t0
 

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -76,6 +76,17 @@ def test_main_log(capsysbinary, caplog, monkeypatch, level, logged):
         assert bool(caplog.record_tuples) is logged
 
 
+def test_main_fira(capsysbinary, monkeypatch):
+    lines = [b"one\n", b"two\n"]
+    monkeypatch.setattr(sys, 'stdin', lines)
+    monkeypatch.setenv("UNICODE_PROGRESS_BAR", "true")
+    main(sys.stderr, ['--total', '2', '--mininterval', '0', '--miniters', '1'])
+    out, err = capsysbinary.readouterr()
+    assert out == b''.join(lines)
+    for glyph in range(0xee00, 0xee06):
+        assert chr(glyph).encode() in err
+
+
 def test_main_misc_options(capsysbinary, monkeypatch):
     N = 123
     monkeypatch.setattr(sys, 'stdin', [(str(i) + '\n').encode() for i in range(N)])

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -747,6 +747,28 @@ def test_unicode_bar():
     assert "20%|\u2588\u2588" in res[3]
 
 
+@mark.parametrize("n,left,body,right", [
+    (0, "\uee00", "\uee01" * 10, "\uee02"),
+    (5, "\uee03", "\uee04" * 5 + "\uee01" * 5, "\uee02"),
+    (10, "\uee03", "\uee04" * 10, "\uee05"),
+])
+def test_fira_bar(n, left, body, right):
+    meter = tqdm.format_meter(n, 10, 1, ascii=Bar.FIRA)
+    assert left + body + right in meter
+
+
+def test_fira_bar_env(monkeypatch):
+    monkeypatch.setenv("UNICODE_PROGRESS_BAR", "true")
+    with UnicodeIO() as tmp_file:
+        with tqdm(total=1, file=tmp_file) as t:
+            assert t.ascii == Bar.FIRA
+        with tqdm(total=1, file=tmp_file, ascii=False) as t:
+            assert t.ascii is False
+        monkeypatch.setenv("UNICODE_PROGRESS_BAR", "1")
+        with tqdm(total=1, file=tmp_file) as t:
+            assert t.ascii is False
+
+
 @mark.parametrize("bars", [" .oO0", " #"])
 def test_custom_bar(tmp_file, bars):
     for _ in tqdm(range(len(bars) - 1), file=tmp_file, miniters=1,

--- a/tests/tests_tqdm.py
+++ b/tests/tests_tqdm.py
@@ -1220,7 +1220,6 @@ def test_refresh(caperr):
 
 def test_disabled_repr(capsys):
     with tqdm(total=10, disable=True) as t:
-        str(t)
         t.update()
         print(t)
     out, err = capsys.readouterr()

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -12,6 +12,7 @@ from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from numbers import Number
+from os import environ
 from time import time
 from warnings import warn
 from weakref import WeakSet
@@ -141,6 +142,11 @@ class Bar:
     """
     ASCII = " 123456789#"
     UTF = " " + ''.join(map(chr, range(0x258F, 0x2587, -1)))
+    FIRA = "\uee01\uee04"
+    FIRA_LEFT_EMPTY = "\uee00"
+    FIRA_RIGHT_EMPTY = "\uee02"
+    FIRA_LEFT = "\uee03"
+    FIRA_RIGHT_FULL = "\uee05"
     BLANK = "  "
     COLOUR_RESET = '\x1b[0m'
     COLOUR_RGB = '\x1b[38;2;%d;%d;%dm'
@@ -292,6 +298,8 @@ class tqdm(Comparable):
     ascii  : bool or str, optional
         If unspecified or False, use unicode (smooth blocks) to fill
         the meter. The fallback is to use ASCII characters " 123456789#".
+        Set `UNICODE_PROGRESS_BAR=true` to use Fira Code bar glyphs.
+        An explicit value overrides the environment variable.
     disable  : bool, optional
         Whether to disable the entire progress bar wrapper
         [default: False]. If set to None, disable on non-TTY.
@@ -612,12 +620,17 @@ class tqdm(Comparable):
             frac = n / total
             percentage = frac * 100
 
-            l_bar += f'{percentage:3.0f}%|'
+            if ascii == Bar.FIRA:
+                l_bar += (f'{percentage:3.0f}%'
+                          f'{Bar.FIRA_LEFT_EMPTY if frac <= 0 else Bar.FIRA_LEFT}')
+                r_bar = (Bar.FIRA_RIGHT_FULL if frac >= 1 else Bar.FIRA_RIGHT_EMPTY) + r_bar[1:]
+            else:
+                l_bar += f'{percentage:3.0f}%|'
 
             if ncols == 0:
                 return l_bar[:-1] + r_bar[1:]
 
-            format_dict.update(l_bar=l_bar)
+            format_dict.update(l_bar=l_bar, r_bar=r_bar)
             if bar_format:
                 format_dict.update(percentage=percentage)
 
@@ -1041,7 +1054,8 @@ class tqdm(Comparable):
             maxinterval = 0
 
         if ascii is None:
-            ascii = not _supports_unicode(file)
+            ascii = (Bar.FIRA if environ.get("UNICODE_PROGRESS_BAR") == "true"
+                     else not _supports_unicode(file))
 
         if bar_format and ascii is not True and not _is_ascii(ascii):
             # Convert bar format into unicode since terminal uses unicode

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -91,6 +91,8 @@ skipping items, etc) you should set miniters=1.
 bool or str, optional.
 If unspecified or False, use unicode (smooth blocks) to fill the meter.
 The fallback is to use ASCII characters \(rq 123456789#\(lq.
+Set \f[CR]UNICODE_PROGRESS_BAR=true\f[R] to use Fira Code bar glyphs.
+An explicit value overrides the environment variable.
 .TP
 \-\-disable
 bool, optional.


### PR DESCRIPTION
Add opt-in support for the dedicated progress bar glyphs provided by [Fira Code](https://github.com/tonsky/FiraCode).

<img src="https://raw.githubusercontent.com/tonsky/FiraCode/727682c24c33fb0bbc7ab0ed9b7a8d0d9745a198/extras/progress.png" width="754">

<img src="https://raw.githubusercontent.com/tonsky/FiraCode/refs/heads/master/extras/progress.gif" width="560">

Related implementations:

- [cheggaaa/pb#236](https://github.com/cheggaaa/pb/pull/236)
- [a8m/pb#125](https://github.com/a8m/pb/pull/125)

Set `UNICODE_PROGRESS_BAR=true` to enable the Fira Code glyph set:

```sh
UNICODE_PROGRESS_BAR=true python -m tqdm --total 100
```

The active terminal font must support the Fira Code progress bar glyphs.
The existing Unicode or ASCII bar remains the default.

## Changes

- Add the Fira Code empty and filled bar glyphs.
- Render distinct borders for empty, active, and completed bars.
- Support the glyphs in both the Python API and command-line interface.
- Enable the feature only when UNICODE_PROGRESS_BAR is exactly true.
- Preserve explicit ascii=True, ascii=False, and custom character sets.
- Keep existing output unchanged when the environment variable is absent.
- Add rendering, compatibility, and CLI tests.
- Update the README and generated manual page.

The core change uses only the Python standard library. It does not change any
function signature and adds only one environment lookup during bar
initialization.
