### PR TITLE
docs: clarify miniters defaults and dynamic adjustment

### DIFF
--- a/.meta/.readme.rst
+++ b/.meta/.readme.rst
@@ -1159,11 +1159,13 @@ Monitoring thread, intervals and miniters
   but it will display only every ``mininterval``.
 - Reduce number of calls to check system clock/time.
 - ``mininterval`` is more intuitive to configure than ``miniters``.
-  A clever adjustment system ``dynamic_miniters`` will automatically adjust
-  ``miniters`` to the amount of iterations that fit into time ``mininterval``.
+  Leaving ``miniters=None`` (the default) enables ``dynamic_miniters``,
+  an internal flag rather than a constructor argument. This automatically
+  adjusts ``miniters`` to the amount of iterations that fit into time
+  ``mininterval``.
   Essentially, ``tqdm`` will check if it's time to print without actually
-  checking time. This behaviour can be still be bypassed by manually setting
-  ``miniters``.
+  checking time. Setting ``miniters`` to a number disables this automatic
+  adjustment; ``miniters=0`` checks ``mininterval`` on every iteration.
 
 However, consider a case with a combination of fast and slow iterations.
 After a few fast iterations, ``dynamic_miniters`` will set ``miniters`` to a

--- a/README.rst
+++ b/README.rst
@@ -412,12 +412,14 @@ Parameters
 * maxinterval  : float, optional  
     Maximum progress display update interval [default: 10] seconds.
     Automatically adjusts ``miniters`` to correspond to ``mininterval``
-    after long display update lag. Only works if ``dynamic_miniters``
-    or monitor thread is enabled.
+    after long display update lag. Only works with automatic
+    ``miniters`` adjustment or the monitor thread enabled.
 * miniters  : int or float, optional  
-    Minimum progress display update interval, in iterations.
-    If 0 and ``dynamic_miniters``, will automatically adjust to equal
+    Minimum progress display update interval, in iterations
+    [default: None]. If None, automatically adjusts to match
     ``mininterval`` (more CPU efficient, good for tight loops).
+    This sets the internal ``dynamic_miniters`` flag, which is not a
+    constructor argument. If 0, checks ``mininterval`` every iteration.
     If > 0, will skip display of specified number of iterations.
     Tweak this and ``mininterval`` to get very efficient loops.
     If your progress is erratic with both fast and slow iterations
@@ -1376,11 +1378,13 @@ Monitoring thread, intervals and miniters
   but it will display only every ``mininterval``.
 - Reduce number of calls to check system clock/time.
 - ``mininterval`` is more intuitive to configure than ``miniters``.
-  A clever adjustment system ``dynamic_miniters`` will automatically adjust
-  ``miniters`` to the amount of iterations that fit into time ``mininterval``.
+  Leaving ``miniters=None`` (the default) enables ``dynamic_miniters``,
+  an internal flag rather than a constructor argument. This automatically
+  adjusts ``miniters`` to the amount of iterations that fit into time
+  ``mininterval``.
   Essentially, ``tqdm`` will check if it's time to print without actually
-  checking time. This behaviour can be still be bypassed by manually setting
-  ``miniters``.
+  checking time. Setting ``miniters`` to a number disables this automatic
+  adjustment; ``miniters=0`` checks ``mininterval`` on every iteration.
 
 However, consider a case with a combination of fast and slow iterations.
 After a few fast iterations, ``dynamic_miniters`` will set ``miniters`` to a

--- a/tqdm/std.py
+++ b/tqdm/std.py
@@ -279,12 +279,14 @@ class tqdm(Comparable):
     maxinterval  : float, optional
         Maximum progress display update interval [default: 10] seconds.
         Automatically adjusts `miniters` to correspond to `mininterval`
-        after long display update lag. Only works if `dynamic_miniters`
-        or monitor thread is enabled.
+        after long display update lag. Only works with automatic
+        `miniters` adjustment or the monitor thread enabled.
     miniters  : int or float, optional
-        Minimum progress display update interval, in iterations.
-        If 0 and `dynamic_miniters`, will automatically adjust to equal
+        Minimum progress display update interval, in iterations
+        [default: None]. If None, automatically adjusts to match
         `mininterval` (more CPU efficient, good for tight loops).
+        This sets the internal `dynamic_miniters` flag, which is not a
+        constructor argument. If 0, checks `mininterval` every iteration.
         If > 0, will skip display of specified number of iterations.
         Tweak this and `mininterval` to get very efficient loops.
         If your progress is erratic with both fast and slow iterations

--- a/tqdm/tqdm.1
+++ b/tqdm/tqdm.1
@@ -75,13 +75,17 @@ float, optional.
 Maximum progress display update interval [default: 10] seconds.
 Automatically adjusts \f[CR]miniters\f[R] to correspond to
 \f[CR]mininterval\f[R] after long display update lag.
-Only works if \f[CR]dynamic_miniters\f[R] or monitor thread is enabled.
+Only works with automatic \f[CR]miniters\f[R] adjustment or the monitor
+thread enabled.
 .TP
 \-\-miniters=\f[I]miniters\f[R]
 int or float, optional.
-Minimum progress display update interval, in iterations.
-If 0 and \f[CR]dynamic_miniters\f[R], will automatically adjust to equal
-\f[CR]mininterval\f[R] (more CPU efficient, good for tight loops).
+Minimum progress display update interval, in iterations [default: None].
+If None, automatically adjusts to match \f[CR]mininterval\f[R] (more CPU
+efficient, good for tight loops).
+This sets the internal \f[CR]dynamic_miniters\f[R] flag, which is not a
+constructor argument.
+If 0, checks \f[CR]mininterval\f[R] every iteration.
 If > 0, will skip display of specified number of iterations.
 Tweak this and \f[CR]mininterval\f[R] to get very efficient loops.
 If your progress is erratic with both fast and slow iterations (network,


### PR DESCRIPTION
The parameter documentation mentions `dynamic_miniters` without explaining how it is enabled, which makes it look like a constructor argument. It also leaves the difference between the default `miniters=None` and an explicit `miniters=0` unclear.

Document that `None` enables automatic adjustment, `0` checks `mininterval` on each iteration, and `dynamic_miniters` is an internal flag. Keep the class docstring, README source, generated README and manual-page options consistent.

Fixes #1556. Fixes #1327.

Validation:

- `python -m pytest tests/tests_tqdm.py`: 85 passed, 1 skipped (NumPy is not installed).
- A deterministic-clock check confirmed the `None`, `0`, `1`, and `3` modes and verified that passing `dynamic_miniters` to the constructor raises `TqdmKeyError`.
- Generated the README and updated manual-page sections with `.meta/mkdocs.py`; preserved existing formatting outside the changed manual-page sections.
- `git diff --check` passes.

Environment: Windows, Python 3.12.14 for tests, Python 3.14 for documentation generation; upstream commit `9cf5a12b1f955468a17f0ba3c59092b23e4258ac`.

AI assistance: OpenAI GPT-6 (Codex) assisted with this change and validation. The contribution commit is marked with `Assisted-by: OpenAI GPT-6 <noreply@openai.com>`.

- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] visual output fix
    + [x] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [x] Any AI-assisted commits are clearly marked ([author], [Co-authored-by] or [Assisted-by]) using the syntax `Provider Model <email>`

Less important but also useful:

- [x] I have visited the [source website], and in particular read the [known issues]
- [x] I have searched through the [issue tracker] for duplicates
- [x] I have mentioned version numbers, operating system and environment, where applicable

[source website]: https://github.com/tqdm/tqdm/
[known issues]: https://github.com/tqdm/tqdm/#faq-and-known-issues
[issue tracker]: https://github.com/tqdm/tqdm/issues?q=
[author]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---authorauthor
[Co-authored-by]: https://docs.github.com/en/pull-requests/how-tos/commit-changes/creating-a-commit-with-multiple-authors
[Assisted-by]: https://allthingsopen.org/articles/open-source-ai-contributions-assisted-by-git-trailer-standard

CI note: the online README/manual generation and quick pytest hooks pass. The flake8 hook reports B018 in the unchanged `benchmarks/benchmarks.py:20` and `tests/tests_tqdm.py:1201`; both statements are also present in the upstream parent commit. See the [pre-commit run](https://results.pre-commit.ci/run/github/36804486/1789196017.jfXEgTQPRE-bXHsVJOc3SQ).