### PR TITLE
fix: allow custom unit_scale in contrib.itertools.batched

### DIFF
--- a/tests/tests_itertools.py
+++ b/tests/tests_itertools.py
@@ -109,3 +109,11 @@ def test_batched(caperr):
 
     assert list(tit.batched(no_len(a), 3, total=12)) == list(it.batched(no_len(a), 3))
     assert "12/12" in caperr()
+
+
+@mark.skipif(not hasattr(it, 'batched'), reason="NotFound: itertools.batched")
+@mark.parametrize("unit_scale, expected", [(False, "4/4"), (2, "8/8")])
+def test_batched_unit_scale(caperr, unit_scale, expected):
+    a = range(10)
+    assert list(tit.batched(a, 3, unit_scale=unit_scale)) == list(it.batched(a, 3))
+    assert expected in caperr()

--- a/tqdm/contrib/itertools.py
+++ b/tqdm/contrib/itertools.py
@@ -87,6 +87,7 @@ def batched(iterable, n, total=None, tqdm_class=tqdm_auto, **kwargs):
             total = len(iterable)
         except (TypeError, AttributeError):
             pass
-    return tqdm_class(itertools.batched(iterable, n), unit_scale=n,
+    kwargs.setdefault('unit_scale', n)
+    return tqdm_class(itertools.batched(iterable, n),
                       total=(total+n-1) // n if total is not None else None,
                       **kwargs)


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    - [x] exception-raising fix
    - [ ] visual output fix
    - [ ] documentation modification
    - [ ] new feature
- [x] I have searched through the issue tracker for duplicates.
- [x] AI-assisted commits are marked with an `Assisted-by` trailer.

`list(batched(range(10), 3, unit_scale=False))` raises `TypeError` because `batched()` passes `unit_scale=n` alongside the caller's `unit_scale` keyword.

Set the default in `kwargs` so callers can override it. Add regression cases for `unit_scale=False` and `unit_scale=2`, checking both the batches and displayed totals. The existing tests cover the default scaling.

Validation on Windows / Python 3.12.3: both regression cases fail on upstream base `9cf5a12` and pass after the fix; itertools and concurrent tests: 21 passed, 3 skipped (Python 3.14 interpreter-pool cases). Flake8 and `git diff --check` pass. The full test suite was not run.

AI assistance: used OpenAI Codex with `gpt-5.6-sol` to inspect the implementation, prepare the fix and regression tests, and run the checks. The commit includes `Assisted-by: OpenAI gpt-5.6-sol <noreply@openai.com>` as required by the PR template.
